### PR TITLE
Add initial operator runner script

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ conda_channels = conda-forge
 conda_deps =
     pytest
     iris
+    mo_pack  # For PP file handling
 commands = pytest
 
 [testenv:docs]

--- a/src/CSET/run-operators.py
+++ b/src/CSET/run-operators.py
@@ -13,7 +13,7 @@ from CSET.operators import read, write, filters
 input_file = sys.argv[1]
 output_file = sys.argv[2]
 
-# Hardcoded task chain
+# Hardcoded task chain to extract instantaneous air temperature.
 cubes = read.read_cubes(input_file)
-cube = filters.filter_cubes(cubes, "stash_code")
+cube = filters.filter_cubes(cubes, "m01s03i236", ())
 write.write_cube_to_nc(cube, output_file)


### PR DESCRIPTION
Resolves #6 

The operators it runs will need to be updated when they are implemented. It will also have to be made much more complicated so it works off a config file instead of being hardcoded.

It will also have to be changed to reflect what the operators actually end up looking like, but that will have to wait for them to be implemented.

Depends on #15.