### PR TITLE
Fix tox not building documentation.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ requires = tox-conda
 isolated_build = True
 envlist =
     py310-linux-tests
-    py10-linux-docs
+    py310-linux-docs
 
 [testenv:py{38,39,310,311}-lock]
 allowlist_externals = cp


### PR DESCRIPTION
A single character typo was preventing tox from using the correct environment to build the documentation, and thus it wasn't doing anything.