### PR TITLE
Update copyright year to 2023 in visible places.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Show your appreciation to those who have contributed to the project. -->
 
 ## Licence
 
-Copyright 2022 Met Office and contributors.
+Copyright © 2022-2023 Met Office and contributors.
 
 Licensed under the [Apache License, Version 2.0](LICENCE) (the "License"); You
 may obtain a copy of the License at

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -7,7 +7,7 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = "CSET"
-copyright = "2022, Met Office and contributors."
+copyright = "2022-2023, Met Office and contributors."
 author = "Met Office and Partners"
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -28,7 +28,7 @@ Use the side bar to the left to access other pages of the documentation.
 Licence
 -------
 
-Copyright 2022 Met Office and contributors. CSET is distributed under the
+Copyright © 2022-2023 Met Office and contributors. CSET is distributed under the
 `Apache 2.0 License`_, in the hope that it will be useful.
 
 .. _Apache 2.0 License: https://www.apache.org/licenses/LICENSE-2.0


### PR DESCRIPTION
Happy new year! :tada:

This change only adds the new year in "title" pages, as individual code files should be updated when they are actually changed.