### PR TITLE
Reenable testing on python 3.11

### DIFF
--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -18,7 +18,7 @@ jobs:
           key: tox|tests|${{ runner.os }}-${{ runner.arch}}|${{ hashFiles('requirements/locks/*') }}
           path: .tox
       - name: Run tests
-        run: tox -e py38-linux-tests,py39-linux-tests,py310-linux-tests
+        run: tox -e py38-linux-tests,py39-linux-tests,py310-linux-tests,py311-linux-tests
 
   pre-commit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Installing Iris on python 3.11 was broken for a time. (https://github.com/SciTools/iris/issues/5016) Iris now has a temporary fix in place, and is working on a more permanent one.