### PR TITLE
Update installation instructions to use conda and add missing operators to documentation

### DIFF
--- a/docs/source/operators.rst
+++ b/docs/source/operators.rst
@@ -3,7 +3,7 @@ CSET Operators
 
 This page details the operators contained within CSET. It is automatically
 generated from the code and its docstrings. Operators should be used via
-:doc:`operator-recipes`.
+:doc:`usage/operator-recipes`.
 
 CSET.operators.constraints
 --------------------------

--- a/docs/source/operators.rst
+++ b/docs/source/operators.rst
@@ -2,7 +2,33 @@ CSET Operators
 ==============
 
 This page details the operators contained within CSET. It is automatically
-generated from the code and its docstrings.
+generated from the code and its docstrings. Operators should be used via
+:doc:`operator-recipes`.
+
+CSET.operators.constraints
+--------------------------
+
+.. automodule:: CSET.operators.constraints
+   :members:
+
+CSET.operators.filters
+----------------------
+
+.. automodule:: CSET.operators.filters
+   :members:
+
+
+CSET.operators.misc
+-------------------
+
+.. automodule:: CSET.operators.misc
+   :members:
+
+CSET.operators.plot
+--------------------------
+
+.. automodule:: CSET.operators.plot
+   :members:
 
 CSET.operators.read
 -------------------
@@ -14,16 +40,4 @@ CSET.operators.write
 --------------------
 
 .. automodule:: CSET.operators.write
-   :members:
-
-CSET.operators.filters
-----------------------
-
-.. automodule:: CSET.operators.filters
-   :members:
-
-CSET.operators.constraints
---------------------------
-
-.. automodule:: CSET.operators.constraints
    :members:

--- a/docs/source/usage/index.rst
+++ b/docs/source/usage/index.rst
@@ -13,18 +13,22 @@ Usage Guide
 Installation
 ------------
 
-Currently CSET is not packaged. The way to use it is thus via an editable
-install.
+CSET is packaged on `conda-forge`_, so the easiest way to use it is via a simple
+``conda install cset``.
 
-First make sure you have installed and activated the conda environment.
+If you want to run a development version that has yet to be released the easiest
+way is via an editable install. First make sure you have installed and activated
+the conda environment.
 
 .. code-block::
 
     conda create -n cset-dev --file requirements/locks/py310-lock-linux-64.txt
     conda activate cset-dev
 
-Then, from the root of the repository, CSET can be installed with :code:`pip install
--e .`
+Then, from the root of the repository, CSET can be installed with :code:`pip
+install -e .`
+
+.. _conda-forge: https://anaconda.org/conda-forge/cset
 
 Usage
 -----

--- a/docs/source/usage/operator-recipes.rst
+++ b/docs/source/usage/operator-recipes.rst
@@ -20,8 +20,8 @@ Recipe format
 -------------
 
 The recipes are text files written in `TOML`_, a configuration language that is
-very similar to INI. They are saved with the ``.toml`` extension. Below is a
-commented example recipe:
+similar to INI, but better defined. They are saved with the ``.toml`` extension.
+Below is a commented example recipe:
 
 .. code-block:: toml
 


### PR DESCRIPTION
Documentation update to add installation instructions for using conda. Also adds missing operators to operators page, and improves some wording on the recipes page.