### PR TITLE
Add documentation on rational

### DIFF
--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -52,7 +52,6 @@ jobs:
           report_url="$(curl --data-binary @coverage-report.tar.gz https://tmpweb.net)"
           badge_options="$(coverage json --fail-under=0 -qo - | jq -r .totals.percent_covered_display)%25-blue?style=for-the-badge"
           echo "[![Coverage](https://img.shields.io/badge/coverage-${badge_options})](${report_url})" >> ${{ runner.temp }}/cov-report.md
-          echo "[Code coverage report](${report_url})" >> ${{ runner.temp }}/cov-report.md
           # Edit last comment if it exists, else create new one.
           if ! gh pr comment --edit-last ${{ github.head_ref }} --body-file ${{ runner.temp }}/cov-report.md ; then
             gh pr comment ${{ github.head_ref }} --body-file ${{ runner.temp }}/cov-report.md

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,11 +10,6 @@ CSET Documentation
    genindex
    GitHub <https://github.com/MetOffice/CSET>
 
-.. note::
-
-   This is where we should write a high level introduction to CSET and have
-   some useful links to other related resources.
-
 CSET is a tool to aid in evaluating regional model configurations. It aims to
 replace the collection of bespoke scripts littering people's home directories,
 reducing effort wasted on duplicating already existing code. This centralisation
@@ -33,12 +28,12 @@ questions that need investigations.
 
 CSET aids in this by providing a quick way to interrogate model data, using
 diagnostics that can be quickly created by the combination of :doc:`operators`
-in an :doc:`usage/operator-recipe`.
+in an :doc:`usage/operator-recipes`.
 
-CSET also is a centralised place for custom diagnostics to live, with well
-defined :doc:`working-practices/index` to ensure that they stay maintained. By
-constributing diagnostics to CSET you ensure that they outlive the paper they
-were written for, and benifit the entire modelling community.
+CSET is a centralised place for custom diagnostics to live, with well defined
+:doc:`working-practices/index` to ensure that they stay maintained. By
+contributing diagnostics to CSET you ensure that they outlive the paper they
+were written for, and benefit the entire modelling community.
 
 .. _CSET repository on GitHub: https://github.com/MetOffice/CSET
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,10 +10,10 @@ CSET Documentation
    genindex
    GitHub <https://github.com/MetOffice/CSET>
 
-CSET is a tool to aid in evaluating regional model configurations. It aims to
-replace the collection of bespoke scripts littering people's home directories,
+CSET is a tool to aid in verifying and evaluating convective-scale and turbulence-scale (regional and increasingly global) model configurations. It aims to
+replace the RMED RES and Toolbox and the collection of bespoke scripts littering people's home directories,
 reducing effort wasted on duplicating already existing code. This centralisation
-of diagnostics should also make evaluations more consistent and comparable.
+of diagnostics should also make evaluations more consistent, reproduceable and comparable.
 Development takes place in the `CSET repository on GitHub`_.
 
 Use the side bar to the left to access other pages of the documentation.
@@ -21,12 +21,11 @@ Use the side bar to the left to access other pages of the documentation.
 Why use CSET?
 -------------
 
-When evaluating weather models you are trying to figure out what processes are
-happening inside the model, and how that compares to other models and reality.
-This is a very iterative process, and each step of evaluation unveils more
+When evaluating weather models you are trying to understand the processes that lead to biases in our model configurations, and how that compares to other models and observations.
+This can be a very iterative process, and each step of evaluation unveils more
 questions that need investigations.
 
-CSET aids in this by providing a quick way to interrogate model data, using
+CSET aids in this by providing a flexible way to interrogate model data, using
 diagnostics that can be quickly created by the combination of :doc:`operators`
 in an :doc:`usage/operator-recipes`.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,20 +10,23 @@ CSET Documentation
    genindex
    GitHub <https://github.com/MetOffice/CSET>
 
-CSET is a tool to aid in verifying and evaluating convective-scale and turbulence-scale (regional and increasingly global) model configurations. It aims to
-replace the RMED RES and Toolbox and the collection of bespoke scripts littering people's home directories,
-reducing effort wasted on duplicating already existing code. This centralisation
-of diagnostics should also make evaluations more consistent, reproduceable and comparable.
-Development takes place in the `CSET repository on GitHub`_.
+CSET is a tool to aid in verifying and evaluating convective-scale and
+turbulence-scale (regional and increasingly global) model configurations. It
+aims to replace the RMED RES and Toolbox and the collection of bespoke scripts
+littering people's home directories, reducing effort wasted on duplicating
+already existing code. This centralisation of diagnostics should also make
+evaluations more consistent, reproducible and comparable. Development takes
+place in the `CSET repository on GitHub`_.
 
 Use the side bar to the left to access other pages of the documentation.
 
 Why use CSET?
 -------------
 
-When evaluating weather models you are trying to understand the processes that lead to biases in our model configurations, and how that compares to other models and observations.
-This can be a very iterative process, and each step of evaluation unveils more
-questions that need investigations.
+When evaluating weather models you are trying to understand the processes that
+lead to biases in our model configurations, and how that compares to other
+models and observations. This can be a very iterative process, and each step of
+evaluation unveils more questions that need investigations.
 
 CSET aids in this by providing a flexible way to interrogate model data, using
 diagnostics that can be quickly created by the combination of :doc:`operators`

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -23,6 +23,23 @@ Development takes place in the `CSET repository on GitHub`_.
 
 Use the side bar to the left to access other pages of the documentation.
 
+Why use CSET?
+-------------
+
+When evaluating weather models you are trying to figure out what processes are
+happening inside the model, and how that compares to other models and reality.
+This is a very iterative process, and each step of evaluation unveils more
+questions that need investigations.
+
+CSET aids in this by providing a quick way to interrogate model data, using
+diagnostics that can be quickly created by the combination of :doc:`operators`
+in an :doc:`usage/operator-recipe`.
+
+CSET also is a centralised place for custom diagnostics to live, with well
+defined :doc:`working-practices/index` to ensure that they stay maintained. By
+constributing diagnostics to CSET you ensure that they outlive the paper they
+were written for, and benifit the entire modelling community.
+
 .. _CSET repository on GitHub: https://github.com/MetOffice/CSET
 
 Licence

--- a/requirements/environment.yml
+++ b/requirements/environment.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   # Runtime dependencies
   - numpy
-  - iris
+  - iris >= 3.5
   - mo_pack # For handling pp files.
   # Unfortunately selectors are not supported by conda currently, so unused
   # dependencies are included. See https://github.com/conda/conda/issues/8089
@@ -21,11 +21,11 @@ dependencies:
   - black
 
   # Testing dependencies
-  - tox
+  - tox >= 4.0
   - tox-conda
-  - pytest
+  - pytest >= 7.0
   - pytest-cov
 
   # Documentation dependencies
-  - sphinx
+  - sphinx >= 7.0
   - furo


### PR DESCRIPTION
This adds some reasons why one would use CSET. This is partly to help promote it, but also helps to clarify the aims of the project for the developers.