### PR TITLE
Run PR checks on push to main

### DIFF
--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -2,6 +2,9 @@ name: Pull request checks
 
 on:
   pull_request:
+  push:
+    branches:
+      - "main"
 
 jobs:
   tests:
@@ -26,6 +29,7 @@ jobs:
           retention-days: 1
 
   coverage-report:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     needs: tests
     permissions:


### PR DESCRIPTION
This should catch things like the dependency updates breaking things. An if check is also added so the coverage report is only generated on pull requests.