### PR TITLE
Lock pre-commit config to specific SHA

### DIFF
--- a/.github/workflows/pre-commit-update.yml
+++ b/.github/workflows/pre-commit-update.yml
@@ -30,7 +30,7 @@ jobs:
           git config --local user.name "$GITHUB_ACTOR"
           git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
           git switch -c "pre-commit-$(sha256sum ${{ runner.temp }}/config_file_hashes | head -c 8)"
-          pre-commit autoupdate
+          pre-commit autoupdate --freeze
 
       - name: Create pull requests
         env:


### PR DESCRIPTION
Security improvement suggested on Yammer. We where already pinning the versions, this just makes it more robust against malicious packages.

Fixes #117