### PR TITLE
Add command to create recipes on disk

### DIFF
--- a/docs/source/usage/index.rst
+++ b/docs/source/usage/index.rst
@@ -45,6 +45,23 @@ contain the YAML text that you want executed.
     options:
     -h, --help   show this help message and exit
 
+cset cookbook
+~~~~~~~~~~~~~
+
+Saves the included recipe files to a local directory. This allows access to
+pre-created recipes for many common tasks. See [LINK TO DOCUMENTATION PAGE ON
+RECIPES] for descriptions of available recipes.
+
+.. code-block:: text
+
+    usage: cset cookbook [-h] [recipe_dir]
+
+    positional arguments:
+    recipe_dir  directory to save recipes. If omitted uses $PWD/recipes
+
+    options:
+    -h, --help  show this help message and exit
+
 cset graph
 ~~~~~~~~~~
 

--- a/src/CSET/__init__.py
+++ b/src/CSET/__init__.py
@@ -81,7 +81,7 @@ def main():
         "recipe_dir",
         type=Path,
         nargs="?",
-        help='directory to save recipes. If omitted creates "recipes" directory in $PWD',
+        help="directory to save recipes. If omitted creates directory in $PWD",
         default=None,
     )
     parser_unpack.set_defaults(func=_unpack_recipes)

--- a/src/CSET/__init__.py
+++ b/src/CSET/__init__.py
@@ -81,7 +81,7 @@ def main():
         "recipe_dir",
         type=Path,
         nargs="?",
-        help="directory to save recipes. If omitted creates directory in $PWD",
+        help="directory to save recipes. If omitted uses $PWD/recipes",
         default=Path.cwd().joinpath("recipes"),
     )
     parser_cookbook.set_defaults(func=_cookbook_command)

--- a/src/CSET/__init__.py
+++ b/src/CSET/__init__.py
@@ -82,7 +82,7 @@ def main():
         type=Path,
         nargs="?",
         help="directory to save recipes. If omitted uses $PWD/recipes",
-        default=Path.cwd().joinpath("recipes"),
+        default=None,
     )
     parser_cookbook.set_defaults(func=_cookbook_command)
 
@@ -119,5 +119,8 @@ def _graph_command(args):
 
 def _cookbook_command(args):
     from CSET.recipes import unpack_recipes
+
+    if not args.recipe_dir:
+        args.recipe_dir = Path.cwd().joinpath("recipes")
 
     unpack_recipes(args.recipe_dir)

--- a/src/CSET/__init__.py
+++ b/src/CSET/__init__.py
@@ -72,19 +72,19 @@ def main():
         action="store_true",
         help="include operator arguments in output",
     )
-    parser_graph.set_defaults(func=_render_graph)
+    parser_graph.set_defaults(func=_graph_command)
 
-    parser_unpack = subparsers.add_parser(
-        "unpack-recipes", help="unpack default recipe files to a folder"
+    parser_cookbook = subparsers.add_parser(
+        "cookbook", help="unpack included recipes to a folder"
     )
-    parser_unpack.add_argument(
+    parser_cookbook.add_argument(
         "recipe_dir",
         type=Path,
         nargs="?",
         help="directory to save recipes. If omitted creates directory in $PWD",
-        default=None,
+        default=Path.cwd().joinpath("recipes"),
     )
-    parser_unpack.set_defaults(func=_unpack_recipes)
+    parser_cookbook.set_defaults(func=_cookbook_command)
 
     args = parser.parse_args()
 
@@ -106,7 +106,7 @@ def _run_operators(args):
     execute_recipe(args.recipe_file, args.input_file, args.output_file)
 
 
-def _render_graph(args):
+def _graph_command(args):
     from CSET.graph import save_graph
 
     save_graph(
@@ -117,9 +117,7 @@ def _render_graph(args):
     )
 
 
-def _unpack_recipes(args):
-    from CSET.recipes import unpack
+def _cookbook_command(args):
+    from CSET.recipes import unpack_recipes
 
-    if not args.recipe_dir:
-        args.recipe_dir = Path.cwd().joinpath("recipes")
-    unpack(args.recipe_dir)
+    unpack_recipes(args.recipe_dir)

--- a/src/CSET/recipes/extract_instant_air_temp.yaml
+++ b/src/CSET/recipes/extract_instant_air_temp.yaml
@@ -12,8 +12,6 @@ steps:
       operator: constraints.generate_stash_constraint
       stash: m01s03i236
 
-  - operator: misc.noop
-
   - operator: filters.filter_cubes
     constraint:
       operator: constraints.combine_constraints

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from uuid import uuid4
 import os
 import subprocess
+import shutil
 import tempfile
 
 
@@ -99,9 +100,10 @@ def test_graph_details():
 
 def test_cookbook_cwd():
     """Unpacking the recipes into the current working directory."""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        subprocess.run(["cset", "cookbook"], cwd=tmpdir, check=True)
-        assert Path(tmpdir, "recipes/extract_instant_air_temp.yaml").exists()
+    # with tempfile.TemporaryDirectory() as tmpdir:
+    subprocess.run(["cset", "cookbook"], check=True)
+    assert Path.cwd().joinpath("recipes/extract_instant_air_temp.yaml").exists()
+    shutil.rmtree(Path.cwd().joinpath("recipes"))
 
 
 def test_cookbook_path():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -100,7 +100,6 @@ def test_graph_details():
 
 def test_cookbook_cwd():
     """Unpacking the recipes into the current working directory."""
-    # with tempfile.TemporaryDirectory() as tmpdir:
     subprocess.run(["cset", "cookbook"], check=True)
     assert Path.cwd().joinpath("recipes/extract_instant_air_temp.yaml").exists()
     shutil.rmtree(Path.cwd().joinpath("recipes"))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Tests for the command line interface. In many ways these are integration tests.
+"""
+
 from pathlib import Path
 from uuid import uuid4
 import os
@@ -91,3 +95,17 @@ def test_graph_details():
     )
     assert output_file.exists()
     output_file.unlink()
+
+
+def test_cookbook_cwd():
+    """Unpacking the recipes into the current working directory."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        subprocess.run(["cset", "cookbook"], cwd=tmpdir, check=True)
+        assert Path(tmpdir, "recipes/extract_instant_air_temp.yaml").exists()
+
+
+def test_cookbook_path():
+    """Unpacking the recipes into a specified directory."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        subprocess.run(["cset", "cookbook", tmpdir], check=True)
+        assert Path(tmpdir, "extract_instant_air_temp.yaml").exists()

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -25,6 +25,8 @@ def test_unpack():
     with tempfile.TemporaryDirectory() as tmpdir:
         CSET.recipes._unpack_recipes_from_dir(Path("tests"), Path(tmpdir))
         assert Path(tmpdir, "test_data/noop_recipe.yaml").exists()
+        # Run again to check that warnings are produced when files collide.
+        CSET.recipes._unpack_recipes_from_dir(Path("tests"), Path(tmpdir))
 
 
 def test_unpack_recipes_exception_collision():

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -1,0 +1,52 @@
+# Copyright 2023 Met Office and contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Recipe tests."""
+
+from pathlib import Path
+import tempfile
+
+import CSET.recipes
+
+
+def test_unpack():
+    """Unpack directory containing sub-directories."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        CSET.recipes._unpack_recipes_from_dir(Path("tests"), Path(tmpdir))
+        assert Path(tmpdir, "test_data/noop_recipe.yaml").exists()
+
+
+def test_unpack_recipes_exception_collision():
+    """Output path already exists and is not a directory."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        Path(tmpdir, "regular_file").touch()
+        try:
+            CSET.recipes.unpack_recipes(Path(tmpdir, "regular_file"))
+        except FileExistsError:
+            assert True
+        else:
+            assert False
+
+
+def test_unpack_recipes_exception_permission():
+    """
+    Insufficient permission to create output directory. Will always fail if
+    tests are run as root, but no one should be doing that, right?
+    """
+    try:
+        CSET.recipes.unpack_recipes(Path("/usr/bin/cset"))
+    except OSError:
+        assert True
+    else:
+        assert False


### PR DESCRIPTION
This PR moves the recipes out of the internals of the operators module, and removes any direct internal reference to them in favour of always using files, as discussed in #103.

As part of this a new command has been implemented to create the default recipe files on disk, though I haven't yet though up a name.

## Still to do

- [x] Tests
- [x] Documentation
- [x] Name command

Fixes #103