### PR TITLE
Pin version of tox used in environment

### DIFF
--- a/development.yaml
+++ b/development.yaml
@@ -1,0 +1,9 @@
+name: cset-dev
+channels:
+  - conda-forge
+dependencies:
+  # Just the dependencies needed during development. Others are pulled in by
+  # tox.
+  - pre-commit
+  - black
+  - tox-conda

--- a/docs/source/working-practices/index.rst
+++ b/docs/source/working-practices/index.rst
@@ -54,7 +54,7 @@ environment for you to use.
 .. code-block:: bash
 
     # Creates a conda environment. This command can be slow.
-    conda env create --file requirements/environment.yml
+    conda env create --file requirements/development.yaml
     # Activates the conda environment.
     conda activate cset-dev
     # Adds extra checks when you commit something with git.

--- a/requirements/environment.yml
+++ b/requirements/environment.yml
@@ -22,7 +22,7 @@ dependencies:
   - black
 
   # Testing dependencies
-  - tox >= 4.0
+  - tox < 4.0
   - tox-conda
   - pytest >= 7.0
   - pytest-cov

--- a/requirements/environment.yml
+++ b/requirements/environment.yml
@@ -1,4 +1,4 @@
-name: cset-dev
+name: cset-run
 channels:
   - conda-forge
 dependencies:


### PR DESCRIPTION
tox-conda does not currently support Tox version 4 (https://github.com/tox-dev/tox-conda/issues/156), so this PR pins tox to less than version 4.

It also adds a minimal environment for development, as tox pulls in the requirements to actually run CSET.