### PR TITLE
Fix install instructions in docs

### DIFF
--- a/docs/source/contributing/getting-started.rst
+++ b/docs/source/contributing/getting-started.rst
@@ -37,8 +37,8 @@ environment for you to use.
 
 .. code-block:: bash
 
-    # Creates a conda environment. This command can be slow.
-    conda env create --file requirements/development.yaml
+    # Creates a conda environment named "cset-dev".
+    conda create -n cset-dev --file requirements/locks/py311-lock-linux-64.txt
     # Activates the conda environment.
     conda activate cset-dev
     # Adds extra checks when you commit something with git.


### PR DESCRIPTION
The conda environment creation is now done from a lock file.

Fixes #167.