### PR TITLE
Refactor tests to use PyTest helpers

### DIFF
--- a/tests/operators/test_filters.py
+++ b/tests/operators/test_filters.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
+
 from CSET.operators import read, filters, constraints
 
 
@@ -28,9 +30,5 @@ def test_filters_operator():
     assert repr(cube) == expected_cube
     # Test for exception when multiple cubes returned.
     constraint = constraints.generate_stash_constraint("m01s03i236")
-    try:
+    with pytest.raises(ValueError):
         cube = filters.filter_cubes(cubes, constraint)
-    except ValueError:
-        assert True
-    else:
-        assert False

--- a/tests/operators/test_plots.py
+++ b/tests/operators/test_plots.py
@@ -14,7 +14,6 @@
 
 from pathlib import Path
 from uuid import uuid4
-import tempfile
 
 import iris.cube
 import pytest
@@ -22,11 +21,11 @@ import pytest
 import CSET.operators
 
 
-def test_spatial_plot():
+def test_spatial_plot(tmp_path: Path):
     """Plot spatial contour plot of instant air temp."""
 
     input_file = Path("tests/test_data/air_temp.nc")
-    output_file = Path(f"{tempfile.gettempdir()}/{uuid4()}")
+    output_file = tmp_path / f"{uuid4()}"
     recipe_file = Path("tests/test_data/plot_instant_air_temp.yaml")
     CSET.operators.execute_recipe(recipe_file, input_file, output_file)
     actual_output_file = output_file.with_suffix(".svg")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,7 +21,6 @@ from uuid import uuid4
 import os
 import subprocess
 import shutil
-import tempfile
 
 
 def test_command_line_help():
@@ -71,7 +70,7 @@ def test_environ_var_recipe():
     )
 
 
-def test_graph_creation():
+def test_graph_creation(tmp_path: Path):
     """Generates a graph with the command line interface."""
 
     # We can't easily test running without the output specified from the CLI, as
@@ -79,7 +78,7 @@ def test_graph_creation():
     # environment.
 
     # Run with output path specified
-    output_file = Path(tempfile.gettempdir(), f"{uuid4()}.svg")
+    output_file = tmp_path / f"{uuid4()}.svg"
     subprocess.run(
         ("cset", "graph", "-o", str(output_file), "tests/test_data/noop_recipe.yaml"),
         check=True,
@@ -88,7 +87,7 @@ def test_graph_creation():
     output_file.unlink()
 
 
-def test_graph_creation_env_var():
+def test_graph_creation_env_var(tmp_path: Path):
     """
     Generates a graph with the command line interface from an environment
     variable.
@@ -101,16 +100,16 @@ def test_graph_creation_env_var():
           - operator: misc.noop
         """
     # Run with output path specified
-    output_file = Path(tempfile.gettempdir(), f"{uuid4()}.svg")
+    output_file = tmp_path / f"{uuid4()}.svg"
     subprocess.run(("cset", "graph", "-o", str(output_file)), check=True)
     assert output_file.exists()
     output_file.unlink()
 
 
-def test_graph_details():
+def test_graph_details(tmp_path: Path):
     """Generate a graph with details with details."""
 
-    output_file = Path(tempfile.gettempdir(), f"{uuid4()}.svg")
+    output_file = tmp_path / f"{uuid4()}.svg"
     subprocess.run(
         (
             "cset",
@@ -134,9 +133,8 @@ def test_cookbook_cwd():
     shutil.rmtree(Path.cwd().joinpath("recipes"))
 
 
-def test_cookbook_path():
+def test_cookbook_path(tmp_path: Path):
     """Unpacking the recipes into a specified directory."""
 
-    with tempfile.TemporaryDirectory() as tmpdir:
-        subprocess.run(["cset", "cookbook", tmpdir], check=True)
-        assert Path(tmpdir, "extract_instant_air_temp.yaml").exists()
+    subprocess.run(["cset", "cookbook", tmp_path], check=True)
+    assert (tmp_path / "extract_instant_air_temp.yaml").exists()

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -16,6 +16,8 @@
 
 from pathlib import Path
 
+import pytest
+
 import CSET._common as common
 
 
@@ -52,69 +54,41 @@ def test_parse_recipe_path():
 
 def test_parse_recipe_exception_missing():
     """Test exception for non-existent file."""
-    try:
+    with pytest.raises(FileNotFoundError):
         common.parse_recipe(Path("/non-existent/path"))
-    except FileNotFoundError:
-        assert True
-    else:
-        assert False
 
 
 def test_parse_recipe_exception_type():
     """Test exception for incorrect type."""
-    try:
+    with pytest.raises(TypeError):
         common.parse_recipe(True)
-    except TypeError:
-        assert True
-    else:
-        assert False
 
 
 def test_parse_recipe_exception_invalid_yaml():
     """Test exception for invalid YAML."""
-    try:
+    with pytest.raises(ValueError):
         common.parse_recipe('"Inside quotes" outside of quotes')
-    except ValueError:
-        assert True
-    else:
-        assert False
 
 
 def test_parse_recipe_exception_invalid_recipe():
     """Test exception for valid YAML but invalid recipe."""
-    try:
+    with pytest.raises(ValueError):
         common.parse_recipe("a: 1")
-    except ValueError:
-        assert True
-    else:
-        assert False
 
 
 def test_parse_recipe_exception_blank():
     """Test exception for blank recipe."""
-    try:
+    with pytest.raises(ValueError):
         common.parse_recipe("")
-    except ValueError:
-        assert True
-    else:
-        assert False
 
 
 def test_parse_recipe_exception_no_steps():
     """Test exception for recipe without any steps."""
-    try:
+    with pytest.raises(ValueError):
         common.parse_recipe("steps: []")
-    except ValueError:
-        assert True
-    else:
-        assert False
 
 
 def test_parse_recipe_exception_non_dict():
     """Test exception for recipe that parses to a non-dict."""
-    try:
+    with pytest.raises(ValueError):
         common.parse_recipe("[]")
-    except ValueError:
-        assert True
-    else:
-        assert False

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -14,6 +14,8 @@
 
 from pathlib import Path
 
+import pytest
+
 import CSET.graph
 
 
@@ -23,14 +25,10 @@ def test_save_graph():
     CSET.graph.save_graph(Path("tests/test_data/plot_instant_air_temp.yaml"))
 
     # Test exception for recipe without an operator in a step.
-    try:
+    with pytest.raises(ValueError):
         CSET.graph.save_graph(
             """\
             steps:
                 - argument: no_operators
             """
         )
-    except ValueError:
-        assert True
-    else:
-        assert False

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -15,28 +15,26 @@
 """Recipe tests."""
 
 from pathlib import Path
-import tempfile
 
 import pytest
 
 import CSET.recipes
 
 
-def test_unpack():
+def test_unpack(tmp_path: Path):
     """Unpack directory containing sub-directories."""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        CSET.recipes._unpack_recipes_from_dir(Path("tests"), Path(tmpdir))
-        assert Path(tmpdir, "test_data/noop_recipe.yaml").exists()
-        # Run again to check that warnings are produced when files collide.
-        CSET.recipes._unpack_recipes_from_dir(Path("tests"), Path(tmpdir))
+    CSET.recipes._unpack_recipes_from_dir(Path("tests"), tmp_path)
+    assert Path(tmp_path, "test_data/noop_recipe.yaml").exists()
+    # Run again to check that warnings are produced when files collide.
+    CSET.recipes._unpack_recipes_from_dir(Path("tests"), tmp_path)
 
 
-def test_unpack_recipes_exception_collision():
+def test_unpack_recipes_exception_collision(tmp_path: Path):
     """Output path already exists and is not a directory."""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        Path(tmpdir, "regular_file").touch()
-        with pytest.raises(FileExistsError):
-            CSET.recipes.unpack_recipes(Path(tmpdir, "regular_file"))
+    file_path = tmp_path / "regular_file"
+    file_path.touch()
+    with pytest.raises(FileExistsError):
+        CSET.recipes.unpack_recipes(file_path)
 
 
 def test_unpack_recipes_exception_permission():

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -17,6 +17,8 @@
 from pathlib import Path
 import tempfile
 
+import pytest
+
 import CSET.recipes
 
 
@@ -33,12 +35,8 @@ def test_unpack_recipes_exception_collision():
     """Output path already exists and is not a directory."""
     with tempfile.TemporaryDirectory() as tmpdir:
         Path(tmpdir, "regular_file").touch()
-        try:
+        with pytest.raises(FileExistsError):
             CSET.recipes.unpack_recipes(Path(tmpdir, "regular_file"))
-        except FileExistsError:
-            assert True
-        else:
-            assert False
 
 
 def test_unpack_recipes_exception_permission():
@@ -46,9 +44,5 @@ def test_unpack_recipes_exception_permission():
     Insufficient permission to create output directory. Will always fail if
     tests are run as root, but no one should be doing that, right?
     """
-    try:
+    with pytest.raises(OSError):
         CSET.recipes.unpack_recipes(Path("/usr/bin/cset"))
-    except OSError:
-        assert True
-    else:
-        assert False

--- a/tests/test_run_recipes.py
+++ b/tests/test_run_recipes.py
@@ -18,6 +18,8 @@ from pathlib import Path
 import tempfile
 from uuid import uuid4
 
+import pytest
+
 import CSET.operators
 
 
@@ -29,32 +31,20 @@ def test_get_operator():
 
 def test_get_operator_exception_missing():
     """Test exception for non-existent operators."""
-    try:
+    with pytest.raises(ValueError):
         CSET.operators.get_operator("non-existent.operator")
-    except ValueError:
-        assert True
-    else:
-        assert False
 
 
 def test_get_operator_exception_type():
     """Test exception if wrong type provided."""
-    try:
+    with pytest.raises(ValueError):
         CSET.operators.get_operator(["Not", b"a", "string", 1])
-    except ValueError:
-        assert True
-    else:
-        assert False
 
 
 def test_get_operator_exception_not_callable():
     """Test exception if operator isn't a function."""
-    try:
+    with pytest.raises(ValueError):
         CSET.operators.get_operator("misc.__doc__")
-    except ValueError:
-        assert True
-    else:
-        assert False
 
 
 def test_execute_recipe():

--- a/tests/test_run_recipes.py
+++ b/tests/test_run_recipes.py
@@ -15,7 +15,6 @@
 """Tests for running CSET operator recipes."""
 
 from pathlib import Path
-import tempfile
 from uuid import uuid4
 
 import pytest
@@ -47,21 +46,21 @@ def test_get_operator_exception_not_callable():
         CSET.operators.get_operator("misc.__doc__")
 
 
-def test_execute_recipe():
+def test_execute_recipe(tmp_path: Path):
     """Execute recipe to test happy case (this is really an integration test)."""
     input_file = Path("tests/test_data/air_temp.nc")
-    output_file = Path(f"{tempfile.gettempdir()}/{uuid4()}.nc")
+    output_file = tmp_path / f"{uuid4()}.nc"
     recipe_file = Path("tests/test_data/plot_instant_air_temp.yaml")
     CSET.operators.execute_recipe(recipe_file, input_file, output_file)
     output_file.unlink()
 
 
-def test_execute_recipe_edge_cases():
+def test_execute_recipe_edge_cases(tmp_path: Path):
     """
     Test weird edge cases. Also tests data paths not being pathlib Paths.
     """
     input_file = "tests/test_data/air_temp.nc"
-    output_file = f"{tempfile.gettempdir()}/{uuid4()}.nc"
+    output_file = tmp_path / f"{uuid4()}.nc"
     recipe = Path("tests/test_data/noop_recipe.yaml")
     CSET.operators.execute_recipe(recipe, input_file, output_file)
     # The output_file doesn't actually get written, so doesn't need removing.


### PR DESCRIPTION
Uses the exception testing and tmp_path helpers to significantly clean up tests.

Fixes #165.