### PR TITLE
Allow PR checks to be run manually

### DIFF
--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - "main"
+  workflow_dispatch:
 
 jobs:
   tests:


### PR DESCRIPTION
This allows running them on automatically created PRs, such as conda lock updates.