### PR TITLE
Add note on updating a cloned repository

### DIFF
--- a/docs/source/contributing/getting-started.rst
+++ b/docs/source/contributing/getting-started.rst
@@ -27,6 +27,11 @@ This will download a copy of the repository (where the code is stored), and all
 of its history onto your computer. From there we need to setup a few things
 before we can develop.
 
+.. note::
+
+    If you have previously cloned the repository you can update it with the
+    latest changes. Ensure all changes are committed, then run ``git pull``.
+
 Setting up tooling
 ------------------
 


### PR DESCRIPTION
Fixes #187

Adds the following note to the contributing getting started page.
![Screenshot from 2023-08-29 15-24-12](https://github.com/MetOffice/CSET/assets/113985160/a54df111-a89c-423a-adab-b11bc284020b)