### PR TITLE
Document installing CSET into its own environment

### DIFF
--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -4,8 +4,10 @@ Installation
 .. Tutorial saying how to install CSET. For edge cases should link elsewhere.
 
 The recommended way to install CSET is via conda. It is packaged on
-`conda-forge`_ and can be installed with a simple ``conda install -c conda-forge
-cset``.
+`conda-forge`_ and can be installed with a simple ``conda create --name=cset
+--channel=conda-forge cset``. This will install CSET into its own conda
+environment, which is the recommended way to use it, but it is also possible to
+install it into an existing environment.
 
 If you instead want to run a development version that has yet to be released,
 the easiest way is via an editable install. You can learn how to do this in the


### PR DESCRIPTION
This is faster, less likely to have package conflicts, and avoids issues with read-only base environments.

[Rendered documentation](https://tmpweb.net/BS8eBVp1ioXl/getting-started/installation)

Fixes #197
Also fixes https://github.com/MetOffice/CSET-workflow/issues/111