### PR TITLE
Skip build-docs on push to main

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           name: html-docs
           path: docs/build/html/
-          retention-days: 10
+          retention-days: 1
           if-no-files-found: error
 
   pages-deploy:

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -83,6 +83,7 @@ jobs:
         run: pre-commit run --show-diff-on-failure --color=always --all-files
 
   build-docs:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
The docs will already be built as part of the documentation deploy process, so this was redundant.