### PR TITLE
Fix globbing for lock file hashing

### DIFF
--- a/.github/workflows/conda-lock.yml
+++ b/.github/workflows/conda-lock.yml
@@ -48,7 +48,7 @@ jobs:
             exit 0
           fi
           # Update lock_file_hashes so pushed branch name is unique.
-          sha256sum requirements/* > ${{ runner.temp }}/lock_file_hashes
+          sha256sum requirements/locks/*.txt > ${{ runner.temp }}/lock_file_hashes
           git add requirements/locks/*.txt
           git commit -m "[CI] Update conda lock files"
           git push --set-upstream origin "conda-lock-files:conda-lock-$(sha256sum ${{ runner.temp }}/lock_file_hashes | head -c 8)"


### PR DESCRIPTION
It was trying to hash a folder, which doesn't work, and causes the workflow run to fail.