### PR TITLE
CAPE ratio rose edit tweak

### DIFF
--- a/cset-workflow/meta/rose-meta.conf
+++ b/cset-workflow/meta/rose-meta.conf
@@ -270,7 +270,8 @@ sort-key=diag-060
 
 [template variables=DETERMINISTIC_PLOT_CAPE_RATIO]
 ns=Diagnostics
-description=Extracts data required for, and calculates the CAPE ratio diagnostic, plotting on a map. Required STASH m01s20i114, m01s20i112, m01s20i113.
+description=Extracts data required for, and calculates the CAPE ratio diagnostic, plotting on a map.
+            Required STASH m01s20i114, m01s20i112, m01s20i113.
 help=See includes/deterministic_plot_cape_ratio.cylc
 type=python_boolean
 compulsory=true

--- a/src/CSET/operators/convection.py
+++ b/src/CSET/operators/convection.py
@@ -29,15 +29,15 @@ def cape_ratio(SBCAPE, MUCAPE, MUCIN, MUCIN_thresh=-75.0):
 
     Parameters
     ----------
-    SBCAPE: cube
+    SBCAPE: Cube
         Surface-based convective available potential energy as calculated by the
         model.
         Stash: m01s20i114
-    MUCAPE: cube
+    MUCAPE: Cube
         Most-unstable convective available potential energy as calculated by the
         model.
         Stash: m01s20i112
-    MUCIN: cube
+    MUCIN: Cube
         Most-unstable convective inhibition associated with the most-unstable
         ascent as calculated by the model.
         Stash: m01s20i113
@@ -46,7 +46,7 @@ def cape_ratio(SBCAPE, MUCAPE, MUCIN, MUCIN_thresh=-75.0):
 
     Returns
     -------
-    cube
+    Cube
 
     Notes
     -----


### PR DESCRIPTION
fix the CAPE ratio description so that it is on two lines on the GUI, and minor formatting tweaks on CAPE ratio documentation.