### PR TITLE
Fix crash when running recipe from env var

### DIFF
--- a/cset-workflow/app/run_cset_recipe/bin/run-cset-recipe.py
+++ b/cset-workflow/app/run_cset_recipe/bin/run-cset-recipe.py
@@ -69,7 +69,7 @@ if cset_recipe:
     subprocess.run(("cset", "-v", "cookbook", cset_recipe), check=True)
 else:
     cset_recipe = Path("recipe.yaml")
-    cset_recipe.write_bytes(os.getenvb("CSET_RECIPE"))
+    cset_recipe.write_bytes(os.getenvb(b"CSET_RECIPE"))
 
 subprocess.run(
     (


### PR DESCRIPTION
os.getenvb requires the key to be bytes. A nice 1 character fix.

Fixes #383