### PR TITLE
Graceful error when graphing without xdg-open

### DIFF
--- a/src/CSET/graph.py
+++ b/src/CSET/graph.py
@@ -93,7 +93,7 @@ def save_graph(
     graph.draw(save_path, format="svg", prog="dot")
     print(f"Graph rendered to {save_path}")
 
-    if auto_open:  # pragma: no cover (xdg-open breaks in CI)
+    if auto_open:
         try:
             # Stderr is redirected here to suppress gvfs-open deprecation warning.
             # See https://bugs.python.org/issue30219 for an example.

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -14,6 +14,8 @@
 
 """Graph tests."""
 
+import os
+import stat
 from pathlib import Path
 
 import pytest
@@ -40,3 +42,27 @@ def test_save_graph_no_operators_exception():
     with pytest.raises(ValueError):
         # Inline YAML form used.
         graph.save_graph('{"steps": [{"argument": "no_operators"}]}')
+
+
+def test_save_graph_auto_open_xdg_open(tmp_path: Path, monkeypatch):
+    """Test the auto-opening of the graph with (a mocked) xdg-open."""
+    xdg_open = tmp_path / "xdg-open"
+    with open(xdg_open, "wt", encoding="UTF-8") as fp:
+        fp.write("#!/bin/bash\ntrue")
+    xdg_open.chmod(stat.S_IRUSR | stat.S_IXUSR)
+    monkeypatch.setenv("PATH", str(tmp_path), prepend=os.pathsep)
+    graph.save_graph(Path("tests/test_data/plot_instant_air_temp.yaml"), auto_open=True)
+
+
+def test_save_graph_auto_open_no_xdg_open(tmp_path: Path, monkeypatch):
+    """Test the auto-opening of the graph errors without xdg-open.
+
+    Strictly speaking this tests xdg-open failing, but it is equivalent to it
+    missing.
+    """
+    xdg_open = tmp_path / "xdg-open"
+    with open(xdg_open, "wt", encoding="UTF-8") as fp:
+        fp.write("#!/bin/bash\nfalse")
+    xdg_open.chmod(stat.S_IRUSR | stat.S_IXUSR)
+    monkeypatch.setenv("PATH", str(tmp_path), prepend=os.pathsep)
+    graph.save_graph(Path("tests/test_data/plot_instant_air_temp.yaml"), auto_open=True)


### PR DESCRIPTION
On non-desktop systems, such as HPCs, xdg-open doesn't exist. The created file can still be viewed manually, and the new error helps users discover the -o option to set the output.

Fixes https://github.com/MetOffice/CSET/issues/393

The new output if xdg-open fails is thus:

```
❯ cset graph -r recipe.yaml 
Graph rendered to /var/tmp/054629bb-a7b6-4eb8-87e1-e653015337fa.svg
Cannot automatically display graph. Specify an output with -o instead.
```

To do:

- [x] Add tests.