### PR TITLE
Use GitHub App for making conda-lock update PRs

### DIFF
--- a/.github/workflows/conda-lock.yml
+++ b/.github/workflows/conda-lock.yml
@@ -59,8 +59,6 @@ jobs:
           private-key: ${{ secrets.AUTH_APP_PRIVATE_KEY }}
 
       - name: Create pull requests
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           shopt -s globstar
           git diff --name-status
@@ -72,6 +70,14 @@ jobs:
           sha256sum **/locks/*.txt > ${{ runner.temp }}/lock_file_hashes
           git add **/locks/*.txt
           git commit -m "[CI] Update conda lock files"
-          git push --set-upstream origin "conda-lock-files:conda-lock-$(sha256sum ${{ runner.temp }}/lock_file_hashes | head -c 8)"
-          # Create PR on GitHub using GitHub CLI.
-          gh pr create --base main --title "[CI] Update conda lock files" --body "Created automatically by GitHub Actions."
+          remote_branch_name="conda-lock-$(sha256sum ${{ runner.temp }}/lock_file_hashes | head -c 8)"
+          git push --set-upstream origin "conda-lock-files:${remote_branch_name}"
+          # Create PR on GitHub using GitHub REST API.
+          request_body='{"title":"[CI] Update conda lock files","body":"Created automatically by GitHub Actions.","base":"main","head":"'"${remote_branch_name}"'"}'
+          curl -LsS --fail-with-body \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ steps.app-token.outputs.token }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/${{ github.repository }}/pulls \
+            -d "$request_body"

--- a/.github/workflows/conda-lock.yml
+++ b/.github/workflows/conda-lock.yml
@@ -33,8 +33,8 @@ jobs:
 
       - name: Switch branch
         run: |
-          git config --local user.name "$GITHUB_ACTOR"
-          git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git switch -c conda-lock-files
 
       - name: Update CSET lock files
@@ -51,9 +51,16 @@ jobs:
           done
           wait
 
+      - name: Generate GitHub App Token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.AUTH_APP_ID }}
+          private-key: ${{ secrets.AUTH_APP_PRIVATE_KEY }}
+
       - name: Create pull requests
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           shopt -s globstar
           git diff --name-status

--- a/.github/workflows/conda-lock.yml
+++ b/.github/workflows/conda-lock.yml
@@ -2,7 +2,7 @@ name: "Update conda lock files"
 
 on:
   schedule:
-    - cron: "37 5 1 * *"
+    - cron: "37 5 * * 1"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/pre-commit-update.yml
+++ b/.github/workflows/pre-commit-update.yml
@@ -27,14 +27,21 @@ jobs:
 
       - name: Update pre-commit config
         run: |
-          git config --local user.name "$GITHUB_ACTOR"
-          git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git switch -c "pre-commit-update"
           pre-commit autoupdate --freeze
 
+      - name: Generate GitHub App Token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.AUTH_APP_ID }}
+          private-key: ${{ secrets.AUTH_APP_PRIVATE_KEY }}
+
       - name: Create pull requests
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           if $(sha256sum --status -c ${{ runner.temp }}/config_file_hashes); then
             echo "Config file unchanged. Skipping pull request..."

--- a/.github/workflows/pre-commit-update.yml
+++ b/.github/workflows/pre-commit-update.yml
@@ -40,8 +40,6 @@ jobs:
           private-key: ${{ secrets.AUTH_APP_PRIVATE_KEY }}
 
       - name: Create pull requests
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           if $(sha256sum --status -c ${{ runner.temp }}/config_file_hashes); then
             echo "Config file unchanged. Skipping pull request..."
@@ -49,7 +47,14 @@ jobs:
           fi
           git add .pre-commit-config.yaml
           git commit -m "[CI] Update .pre-commit-config.yaml"
-          git push --set-upstream origin "pre-commit-update:pre-commit-$(sha256sum .pre-commit-config.yaml | head -c 8)"
-          # Create PR on GitHub using GitHub CLI.
-          gh pr create --base main --title "[CI] Update .pre-commit-config.yaml" \
-          --body "Created automatically by GitHub Actions."
+          remote_branch_name="pre-commit-$(sha256sum .pre-commit-config.yaml | head -c 8)"
+          git push --set-upstream origin "pre-commit-update:${remote_branch_name}"
+          # Create PR on GitHub using GitHub REST API.
+          request_body='{"title":"[CI] Update pre-commit hooks","body":"Created automatically by GitHub Actions.","base":"main","head":"'"${remote_branch_name}"'"}'
+          curl -LsS --fail-with-body \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ steps.app-token.outputs.token }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/${{ github.repository }}/pulls \
+            -d "$request_body"

--- a/.github/workflows/pre-commit-update.yml
+++ b/.github/workflows/pre-commit-update.yml
@@ -2,7 +2,7 @@ name: "Update pre-commit config"
 
 on:
   schedule:
-    - cron: "48 3 1 * *"
+    - cron: "48 3 * * 1"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This means that the CI can run automatically after these changes, ensuring they don't break anything unknowingly.