### PR TITLE
Centralise scheduling into flow.cylc

### DIFF
--- a/cset-workflow/flow.cylc
+++ b/cset-workflow/flow.cylc
@@ -26,6 +26,17 @@ URL = https://metoffice.github.io/CSET
     finish_website => send_email => housekeeping_full
     """
 
+    # Runs every cycle to process the data.
+    {{CSET_CYCLE_PERIOD}} = """
+    install_website_skeleton[^] & install_local_cset[^] =>
+    FETCH_DATA:succeed-all => PROCESS_DATA:succeed-all =>
+    process_finish => housekeeping_raw
+
+    # Intercycle dependence with this task ensures the collate step waits for
+    # the required data.
+    process_finish[-{{CSET_CYCLE_PERIOD}}] => process_finish
+    """
+
     {% if CSET_INCREMENTAL_OUTPUT %}
     # Runs every so often to update output plots during runtime.
     {{CSET_OUTPUT_UPDATE_PERIOD}} = """

--- a/cset-workflow/includes/deterministic_domain_mean_surface_time_series.cylc
+++ b/cset-workflow/includes/deterministic_domain_mean_surface_time_series.cylc
@@ -1,13 +1,4 @@
 {% for model_field in SURFACE_MODEL_FIELDS %}
-[scheduling]
-    [[graph]]
-    PT1H = """
-    install_website_skeleton[^] & install_local_cset[^] => FETCH_DATA:succeed-all =>
-    pre_process_domain_mean_surface_time_series_{{model_field}} =>
-    housekeeping_raw => process_finish
-    process_finish[-PT1H] => process_finish
-    """
-
 [runtime]
     [[pre_process_domain_mean_surface_time_series_{{model_field}}]]
     inherit = PROCESS_DATA

--- a/cset-workflow/includes/domain_mean_time_series_stash.cylc
+++ b/cset-workflow/includes/domain_mean_time_series_stash.cylc
@@ -1,13 +1,4 @@
 {% for stash in STASH_CODES %}
-[scheduling]
-    [[graph]]
-    PT1H = """
-    install_website_skeleton[^] & install_local_cset[^] => FETCH_DATA:succeed-all =>
-    pre_process_stash_surface_domain_mean_time_series_{{stash}} =>
-    housekeeping_raw => process_finish
-    process_finish[-PT1H] => process_finish
-    """
-
 [runtime]
     [[pre_process_stash_surface_domain_mean_time_series_{{stash}}]]
     inherit = PROCESS_DATA

--- a/cset-workflow/includes/plot_spatial_surface_model_field.cylc
+++ b/cset-workflow/includes/plot_spatial_surface_model_field.cylc
@@ -1,13 +1,4 @@
 {% for model_field in SURFACE_MODEL_FIELDS %}
-[scheduling]
-    [[graph]]
-    PT1H = """
-    install_website_skeleton[^] & install_local_cset[^] => FETCH_DATA:succeed-all =>
-    generic_spatial_plot_time_series_{{model_field}} =>
-    housekeeping_raw => process_finish
-    process_finish[-PT1H] => process_finish
-    """
-
 [runtime]
     [[generic_spatial_plot_time_series_{{model_field}}]]
     inherit = PROCESS_DATA


### PR DESCRIPTION
This means the include files only need to contain the runtime sections for the recipes. In future we might even be able to avoid that.