### PR TITLE
446 ifs in build conda

### DIFF
--- a/cset-workflow/app/build_conda/bin/build_conda_env.sh
+++ b/cset-workflow/app/build_conda/bin/build_conda_env.sh
@@ -53,7 +53,7 @@ if [[ $CSET_ENV_USE_MODULES == True ]]; then
       # a module to make conda available. This is to simplify the logic.
       module load "$build_module"
     done
-    IFS=$IFS_SAVE
+    IFS="$IFS_SAVE"
     echo "sourcing conda via modules:"
     module list
   fi

--- a/cset-workflow/app/build_conda/bin/build_conda_env.sh
+++ b/cset-workflow/app/build_conda/bin/build_conda_env.sh
@@ -43,6 +43,8 @@ fi
 # Source modules/paths required to build the environment.
 if [[ $CSET_ENV_USE_MODULES == True ]]; then
   if [[ $MODULES_LIST ]]; then
+    IFS_SAVE=$IFS
+    IFS=' '
     if [[ $MODULES_PURGE == True ]]; then
       module purge
     fi
@@ -51,6 +53,7 @@ if [[ $CSET_ENV_USE_MODULES == True ]]; then
       # a module to make conda available. This is to simplify the logic.
       module load "$build_module"
     done
+    IFS=$IFS_SAVE
     echo "sourcing conda via modules:"
     module list
   fi

--- a/cset-workflow/bin/app_env_wrapper
+++ b/cset-workflow/bin/app_env_wrapper
@@ -25,7 +25,7 @@ then
   for module in $MODULES_LIST; do
     module load "$module"
   done
-  IFS=$IFS_SAVE
+  IFS="$IFS_SAVE"
   module list
 fi
 

--- a/cset-workflow/bin/app_env_wrapper
+++ b/cset-workflow/bin/app_env_wrapper
@@ -17,12 +17,15 @@ fi
 # Load modules
 if [[ $CSET_ENV_USE_MODULES == True ]]
 then
+  IFS_SAVE=$IFS
+  IFS=' '
   if [[ "$MODULES_PURGE" ]]; then
     module purge
   fi
   for module in $MODULES_LIST; do
     module load "$module"
   done
+  IFS=$IFS_SAVE
   module list
 fi
 


### PR DESCRIPTION
All shell scripts that use `module load` modified to set `IFS` to a single space for the loop that loads the module, returning it after to its original value. 