### PR TITLE
Add licence header to convection tests

### DIFF
--- a/tests/operators/test_convection.py
+++ b/tests/operators/test_convection.py
@@ -1,4 +1,16 @@
-#!/usr/bin/env python3
+# Copyright 2023 Met Office and contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """Tests for convection diagnostics."""
 


### PR DESCRIPTION
This was missed beforehand.