### PR TITLE
Use regular install for CI tests

### DIFF
--- a/.github/workflows/pull_request_checks.yml
+++ b/.github/workflows/pull_request_checks.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           # Install package and run pytest.
           echo '::group::Installing local package'
-          python3 -m pip install -e .
+          python3 -m pip install .
           echo '::endgroup::'
           pytest --verbose --cov --cov-append --cov-config=pyproject.toml
           mv .coverage ".coverage.${{ matrix.py-ver }}"


### PR DESCRIPTION
The CI tests are now installed with a regular pip install, rather than being installed editabally. This ensures they are more realistic, as it slightly changes how data files are included into the package.

- [x] Investigate why the coverage has dropped because of this. (It seems the CLI tests are being missed.)