### PR TITLE
Rename steps and post steps to parallel and collate

### DIFF
--- a/cset-workflow/app/run_cset_recipe/bin/run-cset-recipe.py
+++ b/cset-workflow/app/run_cset_recipe/bin/run-cset-recipe.py
@@ -170,7 +170,7 @@ def parallel():
 def collate():
     """Collate processed data together and produce output plot.
 
-    If intermediate directory doesn't exists then we are running a simple
+    If the intermediate directory doesn't exist then we are running a simple
     non-parallelised recipe, and we need to run cset bake to process the data
     and produce any plots. So we actually get some usage out of it, we are using
     the non-restricted form of bake, so it runs both the processing and

--- a/cset-workflow/app/run_cset_recipe/bin/run-cset-recipe.py
+++ b/cset-workflow/app/run_cset_recipe/bin/run-cset-recipe.py
@@ -145,8 +145,8 @@ def add_to_diagnostic_index(output_directory, recipe_id):
     append_to_index({category: {recipe_id: title}})
 
 
-def process():
-    """Process raw data."""
+def parallel():
+    """Process raw data in parallel."""
     logging.info("Pre-processing data into intermediate form.")
     try:
         subprocess.run(
@@ -157,7 +157,7 @@ def process():
                 f"--recipe={recipe_file()}",
                 f"--input-dir={data_directory()}",
                 f"--output-dir={output_directory()}",
-                "--pre-only",
+                "--parallel-only",
             ),
             check=True,
             env=subprocess_env(),
@@ -168,41 +168,28 @@ def process():
 
 
 def collate():
-    """Collate processed data together and produce output plot."""
-    # If intermediate directory doesn't exists then we are running a simple
-    # non-parallelised recipe, and we need to run cset bake to process the data
-    # and produce any plots. So we actually get some usage out of it, we are
-    # using the non-restricted form of bake, so it runs both the processing and
-    # collation steps.
+    """Collate processed data together and produce output plot.
+
+    If intermediate directory doesn't exists then we are running a simple
+    non-parallelised recipe, and we need to run cset bake to process the data
+    and produce any plots. So we actually get some usage out of it, we are using
+    the non-restricted form of bake, so it runs both the processing and
+    collation steps.
+    """
     try:
-        if not Path(output_directory(), "intermediate").exists():
-            logging.info("Pre-processing data and saving output.")
-            subprocess.run(
-                (
-                    "cset",
-                    "-v",
-                    "bake",
-                    f"--recipe={recipe_file()}",
-                    f"--input-dir={data_directory()}",
-                    f"--output-dir={output_directory()}",
-                ),
-                check=True,
-                env=subprocess_env(),
-            )
-        else:
-            logging.info("Collating intermediate data and saving output.")
-            subprocess.run(
-                (
-                    "cset",
-                    "-v",
-                    "bake",
-                    f"--recipe={recipe_file()}",
-                    f"--output-dir={output_directory()}",
-                    "--post-only",
-                ),
-                check=True,
-                env=subprocess_env(),
-            )
+        logging.info("Collating intermediate data and saving output.")
+        subprocess.run(
+            (
+                "cset",
+                "-v",
+                "bake",
+                f"--recipe={recipe_file()}",
+                f"--output-dir={output_directory()}",
+                "--collate-only",
+            ),
+            check=True,
+            env=subprocess_env(),
+        )
     except subprocess.CalledProcessError:
         logging.error("cset bake exited non-zero while collating.")
         sys.exit(1)
@@ -211,9 +198,9 @@ def collate():
 
 
 if __name__ == "__main__":
-    # Check if we are running in process or collate mode.
+    # Check if we are running in parallel or collate mode.
     bake_mode = os.getenv("CSET_BAKE_MODE")
-    if bake_mode == "process":
-        process()
+    if bake_mode == "parallel":
+        parallel()
     elif bake_mode == "collate":
         collate()

--- a/cset-workflow/flow.cylc
+++ b/cset-workflow/flow.cylc
@@ -22,14 +22,14 @@ URL = https://metoffice.github.io/CSET
 
     # Only runs on the final cycle.
     R1/$ = """
-    process_finish => COLLATE_PROCESSED_DATA:succeed-all =>
+    process_finish => COLLATE:succeed-all =>
     finish_website => send_email => housekeeping_full
     """
 
     # Runs every cycle to process the data in parallel.
     {{CSET_CYCLE_PERIOD}} = """
     install_website_skeleton[^] & install_local_cset[^] =>
-    FETCH_DATA:succeed-all => PROCESS_DATA:succeed-all =>
+    FETCH_DATA:succeed-all => PARALLEL:succeed-all =>
     process_finish => housekeeping_raw
 
     # Intercycle dependence with this task ensures the collate step waits for
@@ -40,8 +40,8 @@ URL = https://metoffice.github.io/CSET
     {% if CSET_INCREMENTAL_OUTPUT %}
     # Runs every so often to update output plots during runtime.
     {{CSET_INCREMENTAL_OUTPUT_PERIOD}} = """
-    COLLATE_PROCESSED_DATA[-{{CSET_INCREMENTAL_OUTPUT_PERIOD}}]:finish-all &
-    process_finish => COLLATE_PROCESSED_DATA
+    COLLATE[-{{CSET_INCREMENTAL_OUTPUT_PERIOD}}]:finish-all &
+    process_finish => COLLATE
     """
     {% endif %}
 
@@ -74,12 +74,12 @@ URL = https://metoffice.github.io/CSET
         LOGLEVEL = {{LOGLEVEL}}
         WEB_DIR = {{WEB_DIR}}
 
-    [[PROCESS_DATA]]
+    [[PARALLEL]]
     script = rose task-run -v --app-key=run_cset_recipe
     [[[environment]]]
         CSET_BAKE_MODE = parallel
 
-    [[COLLATE_PROCESSED_DATA]]
+    [[COLLATE]]
     script = rose task-run -v --app-key=run_cset_recipe
     [[[environment]]]
         CSET_BAKE_MODE = collate

--- a/cset-workflow/flow.cylc
+++ b/cset-workflow/flow.cylc
@@ -26,7 +26,7 @@ URL = https://metoffice.github.io/CSET
     finish_website => send_email => housekeeping_full
     """
 
-    # Runs every cycle to process the data.
+    # Runs every cycle to process the data in parallel.
     {{CSET_CYCLE_PERIOD}} = """
     install_website_skeleton[^] & install_local_cset[^] =>
     FETCH_DATA:succeed-all => PROCESS_DATA:succeed-all =>
@@ -77,7 +77,7 @@ URL = https://metoffice.github.io/CSET
     [[PROCESS_DATA]]
     script = rose task-run -v --app-key=run_cset_recipe
     [[[environment]]]
-        CSET_BAKE_MODE = process
+        CSET_BAKE_MODE = parallel
 
     [[COLLATE_PROCESSED_DATA]]
     script = rose task-run -v --app-key=run_cset_recipe

--- a/cset-workflow/includes/deterministic_domain_mean_surface_time_series.cylc
+++ b/cset-workflow/includes/deterministic_domain_mean_surface_time_series.cylc
@@ -2,13 +2,13 @@
 {% for model_field in SURFACE_MODEL_FIELDS %}
 [runtime]
     [[pre_process_domain_mean_surface_time_series_{{model_field}}]]
-    inherit = PROCESS_DATA
+    inherit = PARALLEL
         [[[environment]]]
         CSET_RECIPE_NAME = "generic_surface_domain_mean_time_series.yaml"
         CSET_ADDOPTS = "--VARNAME={{model_field}}"
 
     [[collate_domain_mean_surface_time_series_{{model_field}}]]
-    inherit = COLLATE_PROCESSED_DATA
+    inherit = COLLATE
         [[[environment]]]
         CSET_RECIPE_NAME = "generic_surface_domain_mean_time_series.yaml"
         CSET_ADDOPTS = "--VARNAME={{model_field}}"

--- a/cset-workflow/includes/domain_mean_time_series_stash.cylc
+++ b/cset-workflow/includes/domain_mean_time_series_stash.cylc
@@ -2,13 +2,13 @@
 {% for stash in STASH_CODES %}
 [runtime]
     [[pre_process_stash_surface_domain_mean_time_series_{{stash}}]]
-    inherit = PROCESS_DATA
+    inherit = PARALLEL
         [[[environment]]]
         CSET_RECIPE_NAME = "stash_surface_domain_mean_time_series.yaml"
         CSET_ADDOPTS = "--STASH={{stash}}"
 
     [[collate_stash_surface_domain_mean_time_series_{{stash}}]]
-    inherit = COLLATE_PROCESSED_DATA
+    inherit = COLLATE
         [[[environment]]]
         CSET_RECIPE_NAME = "stash_surface_domain_mean_time_series.yaml"
         CSET_ADDOPTS = "--STASH={{stash}}"

--- a/cset-workflow/includes/lfric_deterministic_domain_mean_surface_time_series.cylc
+++ b/cset-workflow/includes/lfric_deterministic_domain_mean_surface_time_series.cylc
@@ -2,13 +2,13 @@
 {% for model_field in SURFACE_MODEL_FIELDS %}
 [runtime]
     [[pre_process_lfric_domain_mean_surface_time_series_{{model_field}}]]
-    inherit = PROCESS_DATA
+    inherit = PARALLEL
         [[[environment]]]
         CSET_RECIPE_NAME = "lfric_generic_surface_domain_mean_time_series.yaml"
         CSET_ADDOPTS = "--VARNAME={{model_field}}"
 
     [[collate_lfric_domain_mean_surface_time_series_{{model_field}}]]
-    inherit = COLLATE_PROCESSED_DATA
+    inherit = COLLATE
         [[[environment]]]
         CSET_RECIPE_NAME = "lfric_generic_surface_domain_mean_time_series.yaml"
         CSET_ADDOPTS = "--VARNAME={{model_field}}"

--- a/cset-workflow/includes/lfric_plot_spatial_surface_model_field.cylc
+++ b/cset-workflow/includes/lfric_plot_spatial_surface_model_field.cylc
@@ -2,13 +2,13 @@
 {% for model_field in SURFACE_MODEL_FIELDS %}
 [runtime]
     [[lfric_generic_spatial_plot_time_series_{{model_field}}]]
-    inherit = PROCESS_DATA
+    inherit = PARALLEL
         [[[environment]]]
         CSET_RECIPE_NAME = "lfric_generic_surface_spatial_plot_sequence.yaml"
         CSET_ADDOPTS = "--VARNAME={{model_field}}"
 
     [[lfric_generic_spatial_plot_time_series_collation_{{model_field}}]]
-    inherit = COLLATE_PROCESSED_DATA
+    inherit = COLLATE
         [[[environment]]]
         CSET_RECIPE_NAME = "lfric_generic_surface_spatial_plot_sequence.yaml"
         CSET_ADDOPTS = "--VARNAME={{model_field}}"

--- a/cset-workflow/includes/plot_spatial_plevel_model_field.cylc
+++ b/cset-workflow/includes/plot_spatial_plevel_model_field.cylc
@@ -3,13 +3,13 @@
 {% for model_field in PRESSURE_LEVEL_MODEL_FIELDS %}
 {% for plevel in PRESSURE_LEVELS %}
     [[process_generic_plevel_spatial_plot_sequence_{{model_field}}_{{plevel}}]]
-    inherit = PROCESS_DATA
+    inherit = PARALLEL
         [[[environment]]]
         CSET_RECIPE_NAME = "generic_plevel_spatial_plot_sequence.yaml"
         CSET_ADDOPTS = "--VARNAME={{model_field}} --PLEVEL={{plevel}}"
 
     [[collate_generic_plevel_spatial_plot_sequence_{{model_field}}_{{plevel}}]]
-    inherit = COLLATE_PROCESSED_DATA
+    inherit = COLLATE
         [[[environment]]]
         CSET_RECIPE_NAME = "generic_plevel_spatial_plot_sequence.yaml"
         CSET_ADDOPTS = "--VARNAME={{model_field}} --PLEVEL={{plevel}}"

--- a/cset-workflow/includes/plot_spatial_stash_field.cylc
+++ b/cset-workflow/includes/plot_spatial_stash_field.cylc
@@ -11,7 +11,7 @@
 
 [runtime]
     [[stash_surface_spatial_plot_sequence_{{stash}}]]
-    inherit = COLLATE_PROCESSED_DATA
+    inherit = COLLATE
         [[[environment]]]
         CSET_RECIPE_NAME = "stash_surface_spatial_plot_sequence.yaml"
         CSET_ADDOPTS = "--STASH={{stash}}"

--- a/cset-workflow/includes/plot_spatial_surface_model_field.cylc
+++ b/cset-workflow/includes/plot_spatial_surface_model_field.cylc
@@ -2,13 +2,13 @@
 {% for model_field in SURFACE_MODEL_FIELDS %}
 [runtime]
     [[generic_spatial_plot_time_series_{{model_field}}]]
-    inherit = PROCESS_DATA
+    inherit = PARALLEL
         [[[environment]]]
         CSET_RECIPE_NAME = "generic_surface_spatial_plot_sequence.yaml"
         CSET_ADDOPTS = "--VARNAME={{model_field}}"
 
     [[generic_spatial_plot_time_series_collation_{{model_field}}]]
-    inherit = COLLATE_PROCESSED_DATA
+    inherit = COLLATE
         [[[environment]]]
         CSET_RECIPE_NAME = "generic_surface_spatial_plot_sequence.yaml"
         CSET_ADDOPTS = "--VARNAME={{model_field}}"

--- a/docs/source/getting-started/create-first-recipe.rst
+++ b/docs/source/getting-started/create-first-recipe.rst
@@ -75,9 +75,11 @@ Recipe Steps
 ------------
 
 Just as in baking you would follow a recipe step-by-step, so does CSET. The
-steps of the recipe are all under the ``steps`` key. Each block prefixed with a
-``-`` (which makes a list in YAML) is a step, and they are run in order from top
-to bottom.
+steps of the recipe are contained within one of two keys. The ``parallel`` key
+for independent tasks that process the raw data, and the ``collate`` key for
+sequential tasks that bring together the processed data into the final output.
+Each block prefixed with a ``-`` (which makes a list in YAML) is an individual
+step, and they are run in order from top to bottom.
 
 Each step has an ``operator`` key, which specifies which operator to use. A
 `complete list of operators is in the documentation`_, but for this tutorial we
@@ -91,7 +93,7 @@ to the input data as its implicit input.
 
 .. code-block:: yaml
 
-    steps:
+    parallel:
       - operator: read.read_cubes
 
 Once we have read the data, we need to filter them down to the data we require
@@ -155,7 +157,7 @@ After following this far your recipe should look like this:
       Extracts and plots the 1.5m air temperature from a file. The temperature
       is averaged across the time coordinate.
 
-    steps:
+    parallel:
       - operator: read.read_cubes
 
       - operator: filters.filter_cubes

--- a/docs/source/getting-started/create-first-recipe.rst
+++ b/docs/source/getting-started/create-first-recipe.rst
@@ -74,12 +74,12 @@ provided they are all indented with at least two spaces.
 Recipe Steps
 ------------
 
-Just as in baking you would follow a recipe step-by-step, so does CSET. The
-steps of the recipe are contained within one of two keys. The ``parallel`` key
-for independent tasks that process the raw data, and the ``collate`` key for
-sequential tasks that bring together the processed data into the final output.
-Each block prefixed with a ``-`` (which makes a list in YAML) is an individual
-step, and they are run in order from top to bottom.
+When baking you follow a recipe step-by-step, CSET does the same with its
+recipes. The steps of the recipe are contained within one of two keys. The
+``parallel`` key for independent tasks that process the raw data, and the
+``collate`` key for sequential tasks that bring together the processed data into
+the final output. Each block prefixed with a ``-`` (which makes a list in YAML)
+is an individual step, and they are run in order from top to bottom.
 
 Each step has an ``operator`` key, which specifies which operator to use. A
 `complete list of operators is in the documentation`_, but for this tutorial we

--- a/docs/source/reference/cli.rst
+++ b/docs/source/reference/cli.rst
@@ -16,15 +16,15 @@ page.
     usage: cset bake [-h] [-i INPUT_DIR] -o OUTPUT_DIR -r RECIPE [--pre-only | --post-only]
 
     options:
-    -h, --help            show this help message and exit
+    -h, --help              show this help message and exit
     -i INPUT_DIR, --input-dir INPUT_DIR
                             directory containing input data
     -o OUTPUT_DIR, --output-dir OUTPUT_DIR
                             directory to write output into
     -r RECIPE, --recipe RECIPE
                             recipe file to read
-    --pre-only            only run pre-processing steps
-    --post-only           only run post-processing steps
+    --parallel-only         only run parallel steps
+    --collate-only          only run collation steps
 
 .. _cset-cookbook-command:
 

--- a/docs/source/reference/recipe-format.rst
+++ b/docs/source/reference/recipe-format.rst
@@ -12,7 +12,7 @@ commented example recipe:
       Extended description that can
       go across multiple lines.
 
-    steps:
+    parallel:
       # Specify the operator to run in each step.
       - operator: read.read_cubes
 
@@ -46,15 +46,15 @@ The title and description keys provide a human readable description of what the
 recipe does. The title is also used to derive the ID of the running recipe, used
 when running the recipe in a workflow.
 
-The steps keys specifies a list of processing steps. The steps are run from top
-to bottom, with each step specifying an operator to run, and optionally any
-additional inputs to that operator. A step is denoted by a ``-`` under the
-``steps:`` key. The operators are specified on the operator key. Its value
-should be a string of the form ``module.function``. For additional inputs the key
-should be the name of the argument.
+The ``parallel`` and ``collate`` keys specify lists of processing steps. The
+steps are run from top to bottom, with each step specifying an operator to run,
+and optionally any additional inputs to that operator. A parallel step is
+denoted by a ``-`` under the ``parallel:`` key. The operators are specified on
+the operator key. Its value should be a string of the form ``module.function``.
+For additional inputs the key should be the name of the argument.
 
 The ``collate:`` key is used for collating together the output of the
-processing steps to produce the final output. This allows for the expensive
+parallel steps to produce the final output. This allows for the expensive
 processing to be parallelised over many compute nodes, with just the final
 visualisation of the data done in a single job to ensure it has all of the data.
 

--- a/docs/source/reference/recipe-format.rst
+++ b/docs/source/reference/recipe-format.rst
@@ -32,7 +32,7 @@ commented example recipe:
         # that needs collating.
 
     # Steps to collate processed data into output.
-    post-steps:
+    collate:
       - operator: read.read_cube
         filename: intermediate/*.nc
 
@@ -53,7 +53,7 @@ additional inputs to that operator. A step is denoted by a ``-`` under the
 should be a string of the form ``module.function``. For additional inputs the key
 should be the name of the argument.
 
-The ``post-steps:`` key is used for collating together the output of the
+The ``collate:`` key is used for collating together the output of the
 processing steps to produce the final output. This allows for the expensive
 processing to be parallelised over many compute nodes, with just the final
 visualisation of the data done in a single job to ensure it has all of the data.

--- a/src/CSET/__init__.py
+++ b/src/CSET/__init__.py
@@ -67,10 +67,10 @@ def main():
     )
     bake_step_control = parser_bake.add_mutually_exclusive_group()
     bake_step_control.add_argument(
-        "--pre-only", action="store_true", help="only run pre-processing steps"
+        "--parallel-only", action="store_true", help="only run parallel steps"
     )
     bake_step_control.add_argument(
-        "--post-only", action="store_true", help="only run post-processing steps"
+        "--collate-only", action="store_true", help="only run collation steps"
     )
     parser_bake.set_defaults(func=_bake_command)
 
@@ -187,18 +187,18 @@ def calculate_loglevel(args) -> int:
 
 def _bake_command(args, unparsed_args):
     from CSET._common import parse_variable_options
-    from CSET.operators import execute_recipe_post_steps, execute_recipe_steps
+    from CSET.operators import execute_recipe_collate, execute_recipe_parallel
 
     recipe_variables = parse_variable_options(unparsed_args)
-    if not args.post_only:
-        # Input dir is needed for pre-steps, but not collate.
+    if not args.collate_only:
+        # Input dir is needed for parallel steps, but not collate steps.
         if not args.input_dir:
             raise ArgumentError("the following arguments are required: -i/--input-dir")
-        execute_recipe_steps(
+        execute_recipe_parallel(
             args.recipe, args.input_dir, args.output_dir, recipe_variables
         )
-    if not args.pre_only:
-        execute_recipe_post_steps(args.recipe, args.output_dir, recipe_variables)
+    if not args.parallel_only:
+        execute_recipe_collate(args.recipe, args.output_dir, recipe_variables)
 
 
 def _graph_command(args, unparsed_args):

--- a/src/CSET/__init__.py
+++ b/src/CSET/__init__.py
@@ -191,7 +191,7 @@ def _bake_command(args, unparsed_args):
 
     recipe_variables = parse_variable_options(unparsed_args)
     if not args.post_only:
-        # Input dir is needed for pre-steps, but not post-steps.
+        # Input dir is needed for pre-steps, but not collate.
         if not args.input_dir:
             raise ArgumentError("the following arguments are required: -i/--input-dir")
         execute_recipe_steps(

--- a/src/CSET/graph.py
+++ b/src/CSET/graph.py
@@ -85,7 +85,8 @@ def save_graph(
     prev_node = "START"
     graph.add_node(prev_node)
     try:
-        for step in recipe["steps"]:
+        # TODO: Expand to cover collate too.
+        for step in recipe["parallel"]:
             prev_node = step_parser(step, prev_node)
     except KeyError as err:
         raise ValueError("Invalid recipe") from err

--- a/src/CSET/operators/__init__.py
+++ b/src/CSET/operators/__init__.py
@@ -194,7 +194,7 @@ def execute_recipe_parallel(
     try:
         steps = recipe["parallel"]
     except KeyError:
-        if "post-steps" in recipe:
+        if "steps" in recipe:
             warnings.warn(
                 "'steps' recipe key is deprecated. Use 'parallel' instead.",
                 DeprecationWarning,

--- a/src/CSET/operators/__init__.py
+++ b/src/CSET/operators/__init__.py
@@ -86,7 +86,7 @@ def _write_metadata(recipe: dict):
     metadata = recipe.copy()
     # Remove steps, as not needed, and might contain non-serialisable types.
     metadata.pop("steps", None)
-    metadata.pop("post-steps", None)
+    metadata.pop("collate", None)
     with open("meta.json", "wt", encoding="UTF-8") as fp:
         json.dump(metadata, fp)
     os.sync()
@@ -216,8 +216,8 @@ def execute_recipe_post_steps(
         recipe_variables = {}
     output_directory = Path(output_directory).absolute()
     recipe = parse_recipe(recipe_yaml, recipe_variables)
-    # If post-steps doesn't exist treat it as having no steps.
-    steps = recipe.get("post-steps", tuple())
+    # If collate doesn't exist treat it as having no steps.
+    steps = recipe.get("collate", tuple())
     assert output_directory.is_dir()
     _run_steps(recipe, steps, output_directory, output_directory)
 

--- a/src/CSET/operators/__init__.py
+++ b/src/CSET/operators/__init__.py
@@ -18,6 +18,7 @@ import inspect
 import json
 import logging
 import os
+import warnings
 from pathlib import Path
 from typing import Union
 
@@ -83,10 +84,13 @@ def get_operator(name: str):
 
 def _write_metadata(recipe: dict):
     """Write a meta.json file in the CWD."""
+    # TODO: Investigate whether we might be better served by an SQLite database.
     metadata = recipe.copy()
     # Remove steps, as not needed, and might contain non-serialisable types.
+    metadata.pop("parallel", None)
     metadata.pop("steps", None)
     metadata.pop("collate", None)
+    metadata.pop("post-steps", None)
     with open("meta.json", "wt", encoding="UTF-8") as fp:
         json.dump(metadata, fp)
     os.sync()
@@ -143,13 +147,13 @@ def _run_steps(recipe, steps, step_input, output_directory: Path):
         os.chdir(original_working_directory)
 
 
-def execute_recipe_steps(
+def execute_recipe_parallel(
     recipe_yaml: Union[Path, str],
     input_directory: Path,
     output_directory: Path,
     recipe_variables: dict = None,
 ) -> None:
-    """Parse and executes the initial steps from a recipe file.
+    """Parse and executes the parallel steps from a recipe file.
 
     Parameters
     ----------
@@ -186,10 +190,21 @@ def execute_recipe_steps(
     except (FileExistsError, NotADirectoryError) as err:
         logging.error("Output directory is a file. %s", output_directory)
         raise err
-    _run_steps(recipe, recipe["steps"], step_input, output_directory)
+    # If parallel doesn't exist try steps.
+    try:
+        steps = recipe["parallel"]
+    except KeyError:
+        if "post-steps" in recipe:
+            warnings.warn(
+                "'steps' recipe key is deprecated. Use 'parallel' instead.",
+                DeprecationWarning,
+                stacklevel=1,
+            )
+        steps = recipe["steps"]
+    _run_steps(recipe, steps, step_input, output_directory)
 
 
-def execute_recipe_post_steps(
+def execute_recipe_collate(
     recipe_yaml: Union[Path, str], output_directory: Path, recipe_variables: dict = None
 ) -> None:
     """Parse and execute the collation steps from a recipe file.
@@ -214,11 +229,20 @@ def execute_recipe_post_steps(
     """
     if recipe_variables is None:
         recipe_variables = {}
-    output_directory = Path(output_directory).absolute()
-    recipe = parse_recipe(recipe_yaml, recipe_variables)
-    # If collate doesn't exist treat it as having no steps.
-    steps = recipe.get("collate", tuple())
+    output_directory = Path(output_directory).resolve()
     assert output_directory.is_dir()
+    recipe = parse_recipe(recipe_yaml, recipe_variables)
+    # If collate doesn't exist try post-steps, else treat it as having no steps.
+    try:
+        steps = recipe["collate"]
+    except KeyError:
+        if "post-steps" in recipe:
+            warnings.warn(
+                "'post-steps' recipe key is deprecated. Use 'collate' instead.",
+                DeprecationWarning,
+                stacklevel=1,
+            )
+        steps = recipe.get("post-steps", tuple())
     _run_steps(recipe, steps, output_directory, output_directory)
 
 
@@ -227,7 +251,8 @@ __all__ = [
     "collapse",
     "constraints",
     "convection",
-    "execute_recipe_steps",
+    "execute_recipe_parallel",
+    "execute_recipe_collate",
     "filters",
     "get_operator",
     "misc",

--- a/src/CSET/operators/read.py
+++ b/src/CSET/operators/read.py
@@ -107,7 +107,7 @@ def read_cubes(
     ---------
     loadpath: pathlike
         Path to where .pp/.nc files are located
-    constraint: iris.Constraint or iris.ConstraintCombination, optional
+    constraint: iris.Constraint | iris.ConstraintCombination, optional
         Constraints to filter data by
     filename_pattern: str, optional
         Unix shell-style pattern to match filenames to. Defaults to "*"

--- a/src/CSET/recipes/CAPE_ratio_plot.yaml
+++ b/src/CSET/recipes/CAPE_ratio_plot.yaml
@@ -2,7 +2,7 @@ title: CAPE ratio plot
 description: |
   Extracts data required for, and calculates the CAPE ratio diagnostic, plotting on a map.
 
-steps:
+parallel:
   - operator: read.read_cubes
 
   - operator: convection.cape_ratio

--- a/src/CSET/recipes/aggregate_precipitation.yaml
+++ b/src/CSET/recipes/aggregate_precipitation.yaml
@@ -4,7 +4,7 @@ description: |
   LARGE SCALE RAINFALL RATE (KG/M2/S) (stash m01s04i203) from a file
   and aggregates it up to new intervals and writes it to a new time coordinate.
 
-steps:
+parallel:
   - operator: read.read_cubes
 
   - operator: filters.filter_cubes

--- a/src/CSET/recipes/extract_instant_air_temp.yaml
+++ b/src/CSET/recipes/extract_instant_air_temp.yaml
@@ -6,7 +6,7 @@ section: Grid Stat
 major_cat: Major Category 1
 minor_cat: Minor Category 1
 
-steps:
+parallel:
   - operator: read.read_cubes
     constraint:
       operator: constraints.generate_stash_constraint

--- a/src/CSET/recipes/generic_plevel_spatial_plot_sequence.yaml
+++ b/src/CSET/recipes/generic_plevel_spatial_plot_sequence.yaml
@@ -25,7 +25,7 @@ steps:
   - operator: write.write_cube_to_nc
     filename: intermediate/pressure_level_field
 
-post-steps:
+collate:
   - operator: read.read_cube
     filename_pattern: intermediate/*.nc
 

--- a/src/CSET/recipes/generic_plevel_spatial_plot_sequence.yaml
+++ b/src/CSET/recipes/generic_plevel_spatial_plot_sequence.yaml
@@ -3,7 +3,7 @@ title: $VARNAME $PLEVEL Level Spatial Plot
 description: |
   Extracts ands plots the $PLEVELNAME from a file at pressure level $PLEVEL.
 
-steps:
+parallel:
   - operator: read.read_cubes
     constraint:
       operator: constraints.combine_constraints

--- a/src/CSET/recipes/generic_surface_domain_mean_time_series.yaml
+++ b/src/CSET/recipes/generic_surface_domain_mean_time_series.yaml
@@ -30,7 +30,7 @@ steps:
 
 # Collation steps.
 # Reads in intermediate cube and plots it.
-post-steps:
+collate:
   - operator: read.read_cube
     filename_pattern: intermediate/*.nc
 

--- a/src/CSET/recipes/generic_surface_domain_mean_time_series.yaml
+++ b/src/CSET/recipes/generic_surface_domain_mean_time_series.yaml
@@ -2,8 +2,8 @@ category: Quick Look
 title: Domain mean surface $VARNAME time series
 description: Plots a time series of the domain mean surface $VARNAME.
 
-# Pre-processing steps.
-steps:
+# Parallel steps.
+parallel:
   - operator: read.read_cube
     constraint:
       operator: constraints.combine_constraints

--- a/src/CSET/recipes/generic_surface_spatial_plot_sequence.yaml
+++ b/src/CSET/recipes/generic_surface_spatial_plot_sequence.yaml
@@ -2,7 +2,7 @@ category: Quick Look
 title: Surface $VARNAME
 description: Extracts and plots the surface $VARNAME from a file.
 
-steps:
+parallel:
   - operator: read.read_cube
     constraint:
       operator: constraints.combine_constraints

--- a/src/CSET/recipes/generic_surface_spatial_plot_sequence.yaml
+++ b/src/CSET/recipes/generic_surface_spatial_plot_sequence.yaml
@@ -22,7 +22,7 @@ steps:
   - operator: write.write_cube_to_nc
     filename: intermediate/surface_field
 
-post-steps:
+collate:
   - operator: read.read_cube
     filename_pattern: intermediate/*.nc
 

--- a/src/CSET/recipes/initial_time-step_surface_air_temperature_ensemble_postage_stamp_plot.yaml
+++ b/src/CSET/recipes/initial_time-step_surface_air_temperature_ensemble_postage_stamp_plot.yaml
@@ -3,7 +3,7 @@ description: |
   Plots the first time-step from a set of ensemble air temperature files with a
   filename containing the ensemble member in the form `\*_em\*.nc`.
 
-steps:
+parallel:
   - operator: read.read_cubes
     filename_pattern: "*_em*.nc"
     constraint:

--- a/src/CSET/recipes/lfric_generic_surface_domain_mean_time_series.yaml
+++ b/src/CSET/recipes/lfric_generic_surface_domain_mean_time_series.yaml
@@ -3,7 +3,7 @@ title: Domain mean surface $VARNAME time series
 description: Plots a time series of the domain mean surface $VARNAME.
 
 # Pre-processing steps.
-steps:
+parallel:
   - operator: read.read_cubes
     constraint:
       operator: constraints.combine_constraints
@@ -39,7 +39,7 @@ steps:
 
 # Collation steps.
 # Reads in intermediate cube and plots it.
-post-steps:
+collate:
   - operator: read.read_cube
     filename_pattern: intermediate/*.nc
 

--- a/src/CSET/recipes/lfric_generic_surface_spatial_plot_sequence.yaml
+++ b/src/CSET/recipes/lfric_generic_surface_spatial_plot_sequence.yaml
@@ -2,7 +2,7 @@ category: Quick Look
 title: Surface $VARNAME
 description: Extracts and plots the surface $VARNAME from a file.
 
-steps:
+parallel:
   - operator: read.read_cubes
     constraint:
       operator: constraints.combine_constraints
@@ -31,7 +31,7 @@ steps:
   - operator: write.write_cube_to_nc
     filename: intermediate/surface_field
 
-post-steps:
+collate:
   - operator: read.read_cube
     filename_pattern: intermediate/*.nc
 

--- a/src/CSET/recipes/mean_surface_air_temperature_spatial_plot.yaml
+++ b/src/CSET/recipes/mean_surface_air_temperature_spatial_plot.yaml
@@ -3,7 +3,7 @@ description: |
   Extracts and plots the 1.5m air temperature from a file. The temperature
   is averaged across the time coordinate.
 
-steps:
+parallel:
   - operator: read.read_cubes
     constraint:
       operator: constraints.generate_stash_constraint

--- a/src/CSET/recipes/meaned_model_level_air_temperature_spatial_plot.yaml
+++ b/src/CSET/recipes/meaned_model_level_air_temperature_spatial_plot.yaml
@@ -3,7 +3,7 @@ description: |
   Extracts out the instantaneous model level air temperature from a file and writes it
   to a new one.
 
-steps:
+parallel:
   - operator: read.read_cubes
     constraint:
       operator: constraints.generate_var_constraint

--- a/src/CSET/recipes/stash_surface_domain_mean_time_series.yaml
+++ b/src/CSET/recipes/stash_surface_domain_mean_time_series.yaml
@@ -27,7 +27,7 @@ steps:
 
 # Collation steps.
 # Reads in intermediate cube and plots it.
-post-steps:
+collate:
   - operator: read.read_cube
     filename_pattern: intermediate/*.nc
 

--- a/src/CSET/recipes/stash_surface_domain_mean_time_series.yaml
+++ b/src/CSET/recipes/stash_surface_domain_mean_time_series.yaml
@@ -2,8 +2,8 @@ category: Quick Look
 title: Domain mean time series of $STASH
 description: Plots a time series of the domain mean for STASH $STASH.
 
-# Pre-processing steps.
-steps:
+# Pre-processing parallel.
+parallel:
   - operator: read.read_cube
     constraint:
       operator: constraints.combine_constraints
@@ -25,7 +25,7 @@ steps:
   - operator: write.write_cube_to_nc
     filename: intermediate/domain_mean
 
-# Collation steps.
+# Collation parallel.
 # Reads in intermediate cube and plots it.
 collate:
   - operator: read.read_cube

--- a/src/CSET/recipes/stash_surface_spatial_plot_sequence.yaml
+++ b/src/CSET/recipes/stash_surface_spatial_plot_sequence.yaml
@@ -2,7 +2,7 @@ category: Quick Look
 title: Spatial plot of $STASH
 description: Extracts and plots STASH $STASH from a file.
 
-steps:
+parallel:
   - operator: read.read_cube
     constraint:
       operator: constraints.combine_constraints

--- a/src/CSET/recipes/surface_air_temperature_spatial_plot_time_sequence.yaml
+++ b/src/CSET/recipes/surface_air_temperature_spatial_plot_time_sequence.yaml
@@ -2,7 +2,7 @@ title: Surface Air Temperature Spatial Plot Time Sequence
 description: |
   Extracts and plots the 1.5m air temperature from a file.
 
-steps:
+parallel:
   - operator: read.read_cubes
     constraint:
       operator: constraints.generate_stash_constraint

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -52,8 +52,8 @@ def test_bake_recipe_execution(tmp_path):
     )
 
 
-def test_bake_pre_only(tmp_path):
-    """Run recipe pre-steps from the command line."""
+def test_bake_parallel_only(tmp_path):
+    """Run recipe parallel steps from the command line."""
     subprocess.run(
         [
             "cset",
@@ -61,21 +61,21 @@ def test_bake_pre_only(tmp_path):
             f"--input-dir={os.devnull}",
             f"--output-dir={tmp_path}",
             "--recipe=tests/test_data/noop_recipe.yaml",
-            "--pre-only",
+            "--parallel-only",
         ],
         check=True,
     )
 
 
 def test_bake_post_only(tmp_path):
-    """Run recipe collate from the command line."""
+    """Run recipe collate steps from the command line."""
     subprocess.run(
         [
             "cset",
             "bake",
             f"--output-dir={tmp_path}",
             "--recipe=tests/test_data/noop_recipe.yaml",
-            "--post-only",
+            "--collate-only",
         ],
         check=True,
     )
@@ -98,7 +98,7 @@ def test_bake_invalid_args():
 
 
 def test_bake_invalid_args_input_dir():
-    """Missing required input-dir argument for pre-steps."""
+    """Missing required input-dir argument for parallel."""
     with pytest.raises(subprocess.CalledProcessError):
         subprocess.run(
             ["cset", "bake", "--recipe=foo", "--output-dir=/tmp"], check=True

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -68,7 +68,7 @@ def test_bake_pre_only(tmp_path):
 
 
 def test_bake_post_only(tmp_path):
-    """Run recipe post-steps from the command line."""
+    """Run recipe collate from the command line."""
     subprocess.run(
         [
             "cset",

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -47,7 +47,7 @@ def test_parse_recipe_path():
                 "substep": {"operator": "constraints.combine_constraints"},
             }
         ],
-        "post-steps": [{"operator": "misc.noop"}],
+        "collate": [{"operator": "misc.noop"}],
     }
     assert parsed == expected
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -88,6 +88,12 @@ def test_parse_recipe_exception_no_parallel():
         common.parse_recipe("parallel: []")
 
 
+def test_parse_recipe_exception_parallel_not_sequence():
+    """Exception for recipe with parallel containing an atom."""
+    with pytest.raises(ValueError):
+        common.parse_recipe("parallel: 7")
+
+
 def test_parse_recipe_deprecated_steps():
     """Deprecation warning when falling back to steps key."""
     with pytest.warns(DeprecationWarning):

--- a/tests/test_data/ensemble_air_temp.yaml
+++ b/tests/test_data/ensemble_air_temp.yaml
@@ -1,4 +1,4 @@
-steps:
+parallel:
   - operator: read.read_cubes
     filename_pattern: "exeter_em*.nc"
     constraint:

--- a/tests/test_data/noop_recipe.yaml
+++ b/tests/test_data/noop_recipe.yaml
@@ -8,5 +8,5 @@ steps:
     substep:
       operator: constraints.combine_constraints
 
-post-steps:
+collate:
   - operator: misc.noop

--- a/tests/test_data/noop_recipe.yaml
+++ b/tests/test_data/noop_recipe.yaml
@@ -1,7 +1,7 @@
 title: Noop
 description: A recipe that does nothing. Only used for testing.
 
-steps:
+parallel:
   - operator: misc.noop
     test_argument: Banana
     dict_argument: {"key": "value"}

--- a/tests/test_data/plot_instant_air_temp.yaml
+++ b/tests/test_data/plot_instant_air_temp.yaml
@@ -3,7 +3,7 @@ description: |
   Extracts out the instantaneous 1.5m air temperature from a file and writes it
   to a new one.
 
-steps:
+parallel:
   - operator: read.read_cubes
     constraint:
       operator: constraints.generate_stash_constraint

--- a/tests/test_data/plot_instant_air_temp_collapse.yaml
+++ b/tests/test_data/plot_instant_air_temp_collapse.yaml
@@ -2,7 +2,7 @@ title: Plot average air temperature
 description: |
   Plots the mean 1.5m air temperature over an area.
 
-steps:
+parallel:
   - operator: read.read_cubes
     constraint:
       operator: constraints.generate_stash_constraint

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -41,7 +41,7 @@ def test_save_graph_no_operators_exception():
     """Exception raised from recipe with no operators."""
     with pytest.raises(ValueError):
         # Inline YAML form used.
-        graph.save_graph('{"steps": [{"argument": "no_operators"}]}')
+        graph.save_graph('{"parallel": [{"argument": "no_operators"}]}')
 
 
 def test_save_graph_auto_open_xdg_open(tmp_path: Path, monkeypatch):

--- a/tests/test_run_recipes.py
+++ b/tests/test_run_recipes.py
@@ -73,7 +73,7 @@ def test_execute_recipe_steps_invalid_output_dir(tmp_path: Path):
 
 
 def test_execute_recipe_post_steps(tmp_path):
-    """Execute post-steps from a recipe."""
+    """Execute collate from a recipe."""
     output_dir = tmp_path
     recipe_file = Path("tests/test_data/noop_recipe.yaml")
     CSET.operators.execute_recipe_post_steps(recipe_file, output_dir)

--- a/tests/test_run_recipes.py
+++ b/tests/test_run_recipes.py
@@ -46,34 +46,34 @@ def test_get_operator_exception_not_callable():
         CSET.operators.get_operator("misc.__doc__")
 
 
-def test_execute_recipe_steps(tmp_path: Path):
+def test_execute_recipe_parallel(tmp_path: Path):
     """Execute recipe to test happy case (this is really an integration test)."""
     input_file = Path("tests/test_data/air_temp.nc")
     output_dir = tmp_path / f"{uuid4()}"
     recipe_file = Path("tests/test_data/plot_instant_air_temp.yaml")
-    CSET.operators.execute_recipe_steps(recipe_file, input_file, output_dir)
+    CSET.operators.execute_recipe_parallel(recipe_file, input_file, output_dir)
 
 
-def test_execute_recipe_steps_edge_cases(tmp_path: Path):
+def test_execute_recipe_parallel_edge_cases(tmp_path: Path):
     """Test weird edge cases. Also tests data paths not being pathlib Paths."""
     input_file = "tests/test_data/air_temp.nc"
     output_dir = tmp_path / f"{uuid4()}"
     recipe = Path("tests/test_data/noop_recipe.yaml")
-    CSET.operators.execute_recipe_steps(recipe, input_file, output_dir)
+    CSET.operators.execute_recipe_parallel(recipe, input_file, output_dir)
 
 
-def test_execute_recipe_steps_invalid_output_dir(tmp_path: Path):
+def test_execute_recipe_parallel_invalid_output_dir(tmp_path: Path):
     """Exception raised if output directory can't be created."""
-    recipe = '{"steps":[{"operator": misc.noop}]}'
+    recipe = '{"parallel":[{"operator": misc.noop}]}'
     input_file = Path("tests/test_data/air_temp.nc")
     output_dir = tmp_path / "actually_a_file"
     output_dir.touch()
     with pytest.raises((FileExistsError, NotADirectoryError)):
-        CSET.operators.execute_recipe_steps(recipe, input_file, output_dir)
+        CSET.operators.execute_recipe_parallel(recipe, input_file, output_dir)
 
 
-def test_execute_recipe_post_steps(tmp_path):
+def test_execute_recipe_collate(tmp_path):
     """Execute collate from a recipe."""
     output_dir = tmp_path
     recipe_file = Path("tests/test_data/noop_recipe.yaml")
-    CSET.operators.execute_recipe_post_steps(recipe_file, output_dir)
+    CSET.operators.execute_recipe_collate(recipe_file, output_dir)


### PR DESCRIPTION
Fixes #479

Athough it looks like a lot of changes, most of it is just renaming. The substantive changes are contained within `src/CSET/_common.py` and `src/CSET/operators/__init__.py`, which involved cleaning up the recipe validator, and supporting a fall back to the old names, with a DeprecationWarning.