### PR TITLE
Fix regrid operator missing from __init__.py

### DIFF
--- a/src/CSET/operators/__init__.py
+++ b/src/CSET/operators/__init__.py
@@ -36,6 +36,7 @@ from CSET.operators import (
     misc,
     plot,
     read,
+    regrid,
     write,
 )
 
@@ -258,5 +259,6 @@ __all__ = [
     "misc",
     "plot",
     "read",
+    "regrid",
     "write",
 ]


### PR DESCRIPTION
Quick fix to add regrid operator to `__init__.py`