### PR TITLE
Update common-errors.rst

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -12,6 +12,8 @@ Unreleased
 .. Add your changes here, highlighting any user facing changes. E.g:
 .. "* `@gh-user`_ did foo to bar in :pr:`9999`. This enables baz."
 
+* `@Sylviabohnenstengel`_ documented the common error of operating on a CubeList
+  instead of a Cube in :pr:`541`
 * `@Sylviabohnenstengel`_ documented the common error of no cubes being loaded
   in :pr:`513`
 * `@Sylviabohnenstengel` and `@jfrost-mo` redid the rose-meta sort orders so

--- a/docs/source/usage/common-errors.rst
+++ b/docs/source/usage/common-errors.rst
@@ -56,3 +56,14 @@ have different time intervals. For example ``field1`` has hourly data, whereas
 ``PT3H`` or, if we intend to process the hourly data with a
 ``CSET_CYCLE_PERIOD`` of 1 hour we need to run two different CSET workflows
 instead.
+
+AttributeError: 'CubeList' object has no attribute 'collapsed'
+--------------------------------------------------------------
+the operator read.read_cubes does allow to output a CubeList and not only 
+a cube. Most other operators can operate either on cubes or on Cubelist. If 
+you get this error message it is likely that the operator reading in the 
+Cubelist can not perform operations yet on CubeLists. In this case try switching 
+to read.read_cube, which forces a cube as output and not a CubeList. The downside 
+of this is that all metadata, etc. need to match up to allow forming a cube. 
+This requires often working on the constraints.
+

--- a/docs/source/usage/common-errors.rst
+++ b/docs/source/usage/common-errors.rst
@@ -59,11 +59,12 @@ instead.
 
 AttributeError: 'CubeList' object has no attribute 'collapsed'
 --------------------------------------------------------------
-the operator read.read_cubes does allow to output a CubeList and not only 
-a cube. Most other operators can operate either on cubes or on Cubelist. If 
-you get this error message it is likely that the operator reading in the 
-Cubelist can not perform operations yet on CubeLists. In this case try switching 
-to read.read_cube, which forces a cube as output and not a CubeList. The downside 
-of this is that all metadata, etc. need to match up to allow forming a cube. 
-This requires often working on the constraints.
 
+The operator ``read.read_cubes`` outputs a CubeList rather than only a Cube.
+Most other operators can operate either on a single Cube or a CubeList of any
+number of Cubes. If you get this error message it is likely that the operator
+reading in the CubeList can not perform operations yet on CubeLists.
+
+In this case try switching to ``read.read_cube``, which forces a single Cube as
+output and not a CubeList. This requires that all metadata, etc. match up to
+allow forming a single Cube, often requiring refinement of the constraints.


### PR DESCRIPTION
### Description
Adding error message about issues with operating on Cubes or CubeLists as results of using read.read_cube or read.read_cubes.


<!-- Link to an issue, e.g. "Fixes #123" -->
Fixes #

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [x] Documentation has been updated to reflect change.
- [x] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Added an entry to the top of `docs/source/changelog.rst`
- [ ] Conda lock files have been updated if dependencies changed.
- [x] Marked the PR as ready to review.
