### PR TITLE
Note that structured LFRic is needed rather than UMified

### DIFF
--- a/cset-workflow/meta/rose-meta.conf
+++ b/cset-workflow/meta/rose-meta.conf
@@ -442,7 +442,7 @@ sort-key=surface2
 
 [template variables=LFRIC_PLOT_SPATIAL_SURFACE_MODEL_FIELD]
 ns=Diagnostics
-description=Create plots for the specified surface fields for UMified LFRic data.
+description=Create plots for the specified surface fields for structured LFRic data.
 help=See includes/lfric_plot_spatial_surface_model_field.cylc
 type=python_boolean
 compulsory=true
@@ -458,7 +458,7 @@ sort-key=surface3
 
 [template variables=LFRIC_DOMAIN_MEAN_SURFACE_TIME_SERIES]
 ns=Diagnostics
-description=Create time series plot of surface field domain mean for UMified LFRic data.
+description=Create time series plot of surface field domain mean for structured LFRic data.
 help=See includes/lfric_deterministic_domain_mean_surface_time_series.cylc
 type=python_boolean
 compulsory=true


### PR DESCRIPTION
This updates the rose edit help text to clarify that any structured LFRic date is acceptable, rather than just data that has had its metadata converted to be like the UM.

Fixes #550

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [x] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [ ] Added an entry to the top of `docs/source/changelog.rst`
- [ ] Conda lock files have been updated if dependencies changed.
- [x] Marked the PR as ready to review.
