### PR TITLE
Use `UserWarning`s

### DIFF
--- a/src/CSET/operators/convection.py
+++ b/src/CSET/operators/convection.py
@@ -20,6 +20,7 @@ precalculated values in the required input form may also be used.
 """
 
 import copy
+import warnings
 
 import numpy as np
 
@@ -83,10 +84,6 @@ def cape_ratio(SBCAPE, MUCAPE, MUCIN, MUCIN_thresh=-75.0):
     the timestep. Therefore this diagnostic is applicable after precipitation has
     occurred, not before as is the usual interpretation of CAPE related diagnostics.
 
-    You might encounter ``RuntimeWarning: divide by zero encountered in divide``
-    or ``RuntimeWarning: invalid value encountered in divide`` this is expected
-    for when CAPE is zero. The data will be replaced by NaNs.
-
     References
     ----------
     .. [1] Clark, A. J., Kain J. S., Marsh P. T., Correia J., Xue M., and Kong
@@ -124,7 +121,10 @@ def cape_ratio(SBCAPE, MUCAPE, MUCIN, MUCIN_thresh=-75.0):
     # Filter MUCAPE by MUCIN to all for possible (realistic) MUCAPE.
     MUCAPE_data[MUCIN.data <= MUCIN_thresh] = 0.0
     # Now calculate the main diagnostic
-    EC_Flagb = 1 - (SBCAPE_data / MUCAPE_data)
+    with warnings.catch_warnings():
+        # Ignore possible divide by zero warnings, as they are replaced by NaNs.
+        warnings.simplefilter("ignore", RuntimeWarning)
+        EC_Flagb = 1 - (SBCAPE_data / MUCAPE_data)
     # Filter to reduce NaN values and -inf values for plotting ease.
     # There are multiple types of NaN values so need to convert them all to same type.
     EC_Flagb[np.isnan(EC_Flagb)] = np.nan

--- a/src/CSET/operators/read.py
+++ b/src/CSET/operators/read.py
@@ -15,6 +15,7 @@
 """Operators for reading various types of files from disk."""
 
 import logging
+import warnings
 from pathlib import Path
 
 import iris
@@ -23,6 +24,10 @@ import iris.cube
 import numpy as np
 
 from CSET._common import iter_maybe
+
+
+class NoDataWarning(UserWarning):
+    """Warning that no data has been loaded."""
 
 
 def read_cube(
@@ -155,7 +160,9 @@ def read_cubes(
             )
     logging.debug("Loaded cubes: %s", cubes)
     if len(cubes) == 0:
-        logging.warning("No cubes loaded, check your constraints!")
+        warnings.warn(
+            "No cubes loaded, check your constraints!", NoDataWarning, stacklevel=2
+        )
     return cubes
 
 

--- a/src/CSET/recipes/__init__.py
+++ b/src/CSET/recipes/__init__.py
@@ -24,6 +24,10 @@ from pathlib import Path
 import ruamel.yaml
 
 
+class FileExistsWarning(UserWarning):
+    """Warning a file already exists, and some unusual action shall be taken."""
+
+
 def _version_agnostic_importlib_resources_file() -> Path:
     """Transitional wrapper to importlib.resources.files().
 
@@ -91,7 +95,9 @@ def unpack_recipe(recipe_dir: Path, recipe_name: str) -> None:
     logging.debug("Saving recipe to %s", output_file)
     if output_file.exists():
         warnings.warn(
-            f"{file.name} already exists in target directory, skipping.", stacklevel=2
+            f"{file.name} already exists in target directory, skipping.",
+            FileExistsWarning,
+            stacklevel=2,
         )
         return
     logging.info("Unpacking %s to %s", file.name, output_file)

--- a/tests/operators/test_read.py
+++ b/tests/operators/test_read.py
@@ -34,9 +34,8 @@ def test_read_cubes():
 
 def test_read_cubes_no_cubes_warning():
     """Warning emitted when constraint gives no cubes."""
-    # TODO: Warning doesn't reach pytest for some reason.
-    # with pytest.warns(Warning, match="No cubes loaded"):
-    cubes = read.read_cubes("tests/test_data/air_temp.nc", "non-existent")
+    with pytest.warns(UserWarning, match="No cubes loaded"):
+        cubes = read.read_cubes("tests/test_data/air_temp.nc", "non-existent")
     assert len(cubes) == 0
 
 

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -32,7 +32,7 @@ def test_unpack(tmp_path: Path):
     CSET.recipes.unpack_recipe(tmp_path, "extract_instant_air_temp.yaml")
     assert (tmp_path / "extract_instant_air_temp.yaml").is_file()
     # Unpack everything and check a warning is produced when files collide.
-    with pytest.warns():
+    with pytest.warns(UserWarning):
         CSET.recipes.unpack_recipe(tmp_path, "extract_instant_air_temp.yaml")
 
 


### PR DESCRIPTION
<!-- Thanks for contributing! Please add a short description of your change. -->

Use subclasses of UserWarning for warnings throughout the code and Filter irrelevant warnings in CAPE ratio diagnostic.

<!-- Link to an issue, e.g. "Fixes #123" -->
Fixes #586

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [ ] All tests and CI checks pass.
- [ ] Added an entry to the top of `docs/source/changelog.rst`
- [ ] Conda lock files have been updated if dependencies changed.
- [x] Marked the PR as ready to review.
