### PR TITLE
add dummy tasks for collate and parallel

### DIFF
--- a/cset-workflow/flow.cylc
+++ b/cset-workflow/flow.cylc
@@ -95,6 +95,7 @@ URL = https://metoffice.github.io/CSET
     [[dummy_collate]]
     inherit = COLLATE
     script = true
+    platform = localhost
 
     [[dummy_parallel]]
     inherit = PARALLEL

--- a/cset-workflow/flow.cylc
+++ b/cset-workflow/flow.cylc
@@ -100,7 +100,7 @@ URL = https://metoffice.github.io/CSET
     [[dummy_parallel]]
     inherit = PARALLEL
     script = true
-
+    platform = localhost
 
     [[build_conda]]
     # Create the conda environment if it does not yet exist.

--- a/cset-workflow/flow.cylc
+++ b/cset-workflow/flow.cylc
@@ -87,10 +87,19 @@ URL = https://metoffice.github.io/CSET
 
     [[FETCH_DATA]]
 
+    # Dummy tasks needed for workflow scheduling.
     [[process_finish]]
-    # Dummy task needed for workflow scheduling.
     script = true
     platform = localhost
+
+    [[dummy_collate]]
+    inherit = COLLATE
+    script = true
+
+    [[dummy_parallel]]
+    inherit = PARALLEL
+    script = true
+
 
     [[build_conda]]
     # Create the conda environment if it does not yet exist.


### PR DESCRIPTION
Adding dummy tasks of `COLLATE` and `PARALLEL` families so cylc validates OK when there are no tasks using that families imported from the include files.
Not sure this is the perfect solution, it looks a bit clunky to have a task that does nothing.

Fixes #616 

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [ ] Added an entry to the top of `docs/source/changelog.rst`
- [ ] Conda lock files have been updated if dependencies changed.
- [x] Marked the PR as ready to review.
