### PR TITLE
update regrid to use utils

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -12,6 +12,7 @@ Unreleased
 .. Add your changes here, highlighting any user facing changes. E.g:
 .. "* `@gh-user`_ did foo to bar in :pr:`9999`. This enables baz."
 
+* `@jwarner8`_ use common operator to identify x/y coord names in regrid operator :pr:`X`
 * `@jwarner8`_ added generic cube util for common functions so all operators can
   use to reduce repetition in :pr:`620`
 * `@jfrost-mo`_ added a code of conduct in :pr:`618`

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -12,7 +12,7 @@ Unreleased
 .. Add your changes here, highlighting any user facing changes. E.g:
 .. "* `@gh-user`_ did foo to bar in :pr:`9999`. This enables baz."
 
-* `@jwarner8`_ use common operator to identify x/y coord names in regrid operator :pr:`X`
+* `@jwarner8`_ use common operator to identify x/y coord names in regrid operator :pr:`626`
 * `@jwarner8`_ added generic cube util for common functions so all operators can
   use to reduce repetition in :pr:`620`
 * `@jfrost-mo`_ added a code of conduct in :pr:`618`

--- a/src/CSET/operators/regrid.py
+++ b/src/CSET/operators/regrid.py
@@ -17,7 +17,8 @@
 import iris
 import iris.cube
 import numpy as np
-from _utils import get_cube_xycoordname
+
+from CSET.operators._utils import get_cube_xycoordname
 
 
 def regrid_onto_cube(

--- a/src/CSET/operators/regrid.py
+++ b/src/CSET/operators/regrid.py
@@ -17,11 +17,7 @@
 import iris
 import iris.cube
 import numpy as np
-
-# Usual names for spatial coordinates.
-# TODO can we determine grid coord names in a more intelligent way?
-X_COORD_NAMES = ["longitude", "grid_longitude", "projection_x_coordinate", "x"]
-Y_COORD_NAMES = ["latitude", "grid_latitude", "projection_y_coordinate", "y"]
+from _utils import get_cube_xycoordname
 
 
 def regrid_onto_cube(
@@ -56,25 +52,10 @@ def regrid_onto_cube(
 
     Notes
     -----
-    The acceptable coordinate names for X and Y coordinates are currently described
-    in X_COORD_NAMES and Y_COORD_NAMES. These cover commonly used coordinate types,
-    though a user can append new ones.
     Currently rectlinear grids (uniform) are supported.
     """
-    # Get a list of coordinate names for the cube
-    coord_names = [coord.name() for coord in incube.coords()]
-
-    # Check which x-coordinate we have, if any
-    x_coords = [coord for coord in coord_names if coord in X_COORD_NAMES]
-    if len(x_coords) != 1:
-        raise ValueError("Could not identify a unique x-coordinate in cube")
-    x_coord = incube.coord(x_coords[0])
-
-    # Check which y-coordinate we have, if any
-    y_coords = [coord for coord in coord_names if coord in Y_COORD_NAMES]
-    if len(y_coords) != 1:
-        raise ValueError("Could not identify a unique y-coordinate in cube")
-    y_coord = incube.coord(y_coords[0])
+    # Get x,y coord names
+    x_coord, y_coord = get_cube_xycoordname(incube)
 
     # List of supported grids - check if it is compatible
     supported_grids = (iris.coord_systems.GeogCS,)
@@ -127,26 +108,11 @@ def regrid_onto_xyspacing(
 
     Notes
     -----
-    The acceptable coordinate names for X and Y coordinates are currently described
-    in X_COORD_NAMES and Y_COORD_NAMES. These cover commonly used coordinate types,
-    though a user can append new ones.
     Currently rectlinear grids (uniform) are supported.
 
     """
-    # Get a list of coordinate names for the cube
-    coord_names = [coord.name() for coord in incube.coords()]
-
-    # Check which x-coordinate we have, if any
-    x_coords = [coord for coord in coord_names if coord in X_COORD_NAMES]
-    if len(x_coords) != 1:
-        raise ValueError("Could not identify a unique x-coordinate in cube")
-    x_coord = incube.coord(x_coords[0])
-
-    # Check which y-coordinate we have, if any
-    y_coords = [coord for coord in coord_names if coord in Y_COORD_NAMES]
-    if len(y_coords) != 1:
-        raise ValueError("Could not identify a unique y-coordinate in cube")
-    y_coord = incube.coord(y_coords[0])
+    # Get x,y coord names
+    x_coord, y_coord = get_cube_xycoordname(incube)
 
     # List of supported grids - check if it is compatible
     supported_grids = (iris.coord_systems.GeogCS,)

--- a/tests/operators/test_regrid.py
+++ b/tests/operators/test_regrid.py
@@ -51,21 +51,6 @@ def test_regrid_onto_cube(regrid_source_cube, regrid_test_cube):
     )
 
 
-def test_regrid_onto_cube_missing_coord(regrid_source_cube, regrid_test_cube):
-    """Missing coordinate raises error."""
-    # Missing X coordinate.
-    source = regrid_source_cube.copy()
-    source.remove_coord("longitude")
-    with pytest.raises(ValueError):
-        regrid.regrid_onto_cube(source, regrid_test_cube, method="Linear")
-
-    # Missing Y coordinate.
-    source = regrid_source_cube.copy()
-    source.remove_coord("latitude")
-    with pytest.raises(ValueError):
-        regrid.regrid_onto_cube(source, regrid_test_cube, method="Linear")
-
-
 def test_regrid_onto_cube_unknown_crs(regrid_source_cube, regrid_test_cube):
     """Coordinate reference system is unrecognised."""
     # Exchange X to unsupported coordinate system.
@@ -106,25 +91,6 @@ def test_regrid_onto_xyspacing(regrid_source_cube, regrid_test_cube):
         rtol=1e-06,
         atol=1e-02,
     )
-
-
-def test_regrid_onto_xyspacing_missing_coord(regrid_source_cube):
-    """Missing coordinate raises error."""
-    # Missing X coordinate.
-    source = regrid_source_cube.copy()
-    source.remove_coord("longitude")
-    with pytest.raises(ValueError):
-        regrid.regrid_onto_xyspacing(
-            source, xspacing=0.5, yspacing=0.5, method="Linear"
-        )
-
-    # Missing Y coordinate.
-    source = regrid_source_cube.copy()
-    source.remove_coord("latitude")
-    with pytest.raises(ValueError):
-        regrid.regrid_onto_xyspacing(
-            source, xspacing=0.5, yspacing=0.5, method="Linear"
-        )
 
 
 def test_regrid_onto_xyspacing_unknown_crs(regrid_source_cube):


### PR DESCRIPTION
<!-- Thanks for contributing! Please add a short description of your change. -->
Update regrid operator to use the generic utils function to identify x and y coordinates.
<!-- Link to an issue, e.g. "Fixes #123" -->
Fixes #

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [x] Documentation has been updated to reflect change.
- [x] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Added an entry to the top of `docs/source/changelog.rst`
- [x] Conda lock files have been updated if dependencies changed.
- [x] Marked the PR as ready to review.
