### PR TITLE
Make cube fixture safe to modify

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,7 +29,8 @@ def tmp_working_dir(tmp_path, monkeypatch):
     return tmp_path
 
 
-# Session scope fixtures, so the test data only has to be loaded once.
+# Session scope fixtures, so the test data only has to be loaded from disk
+# once, then make an in-memory copy whenever it is reused.
 @pytest.fixture(scope="session")
 def cubes_readonly():
     """Get an iris CubeList. NOT safe to modify."""


### PR DESCRIPTION
We now do a copy in the fixture itself, and remove unnecessary copies inside the tests, which makes the test code simpler.

Fixes #745

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [x] Documentation has been updated to reflect change.
- [x] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Added an entry to the top of `docs/source/changelog.rst`
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Said if Generative AI, such as GitHub Copilot, has been used in this PR.
- [x] Marked the PR as ready to review.
