### PR TITLE
Clarify error message on missing files

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -18,6 +18,7 @@ Unreleased
 * `@daflack`_ added science review guidance to the documentation in :pr:`649`
 * `@jfrost-mo`_ ensured cartopy data files are included in the GitHub Actions
   cache in :pr:`647`
+* `@jfrost-mo`_ improved the error message for missing data files in :pr:`663`
 * `@jfrost-mo`_ grouped the package install logs in GitHub Actions in :pr:`645`
 * `@daflack`_ added an inflow layer properties diagnostic in :pr:`353`
 * `@jfrost-mo`_ fixed LFRic cube metadata on load in :pr:`627`. This means that

--- a/src/CSET/operators/read.py
+++ b/src/CSET/operators/read.py
@@ -283,7 +283,7 @@ def _check_input_files(input_path: Path | str, filename_pattern: str) -> Iterabl
         files = tuple(sorted(input_path.glob(filename_pattern)))
         if len(files) == 0:
             raise FileNotFoundError(
-                f"No files found matching glob {filename_pattern} within {input_path}"
+                f"No files found matching filename_pattern {filename_pattern} within {input_path}"
             )
     elif input_path.is_file():
         files = (input_path,)


### PR DESCRIPTION
<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

Replaces "glob" with "filename_pattern", as that is what the argument to the read operator is called.

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Added an entry to the top of `docs/source/changelog.rst`
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
