### PR TITLE
Fix docstring typo in xycoord identifier in _utils

### DIFF
--- a/src/CSET/operators/_utils.py
+++ b/src/CSET/operators/_utils.py
@@ -23,7 +23,7 @@ import iris
 import iris.cube
 
 
-def get_cube_xycoordname(cube: iris.cube.Cube) -> tuple[str, str]:
+def get_cube_yxcoordname(cube: iris.cube.Cube) -> tuple[str, str]:
     """
     Return horizontal coordinate name(s) from a given cube.
 

--- a/src/CSET/operators/_utils.py
+++ b/src/CSET/operators/_utils.py
@@ -37,14 +37,14 @@ def get_cube_xycoordname(cube: iris.cube.Cube) -> tuple[str, str]:
 
     Returns
     -------
-    (x_coord, y_coord)
+    (y_coord, x_coord)
         A tuple containing the horizontal coordinate name for latitude and longitude respectively
         found within the cube.
 
     Raises
     ------
     ValueError
-        If an x/y horizontal coordinates cannot be found.
+        If a unique y/x horizontal coordinate cannot be found.
     """
     # Acceptable horizontal coordinate names.
     X_COORD_NAMES = ["longitude", "grid_longitude", "projection_x_coordinate", "x"]

--- a/src/CSET/operators/plot.py
+++ b/src/CSET/operators/plot.py
@@ -34,7 +34,7 @@ import numpy as np
 from markdown_it import MarkdownIt
 
 from CSET._common import get_recipe_metadata, render_file, slugify
-from CSET.operators._utils import get_cube_xycoordname
+from CSET.operators._utils import get_cube_yxcoordname
 
 ############################
 # Private helper functions #
@@ -214,7 +214,7 @@ def _plot_and_save_contour_plot(
 
     # Add coastlines if cube contains x and y map coordinates.
     try:
-        get_cube_xycoordname(cube)
+        get_cube_yxcoordname(cube)
         axes.coastlines(resolution="10m")
     except ValueError:
         pass
@@ -277,7 +277,7 @@ def _plot_and_save_postage_stamp_contour_plot(
 
         # Add coastlines if cube contains x and y map coordinates.
         try:
-            get_cube_xycoordname(cube)
+            get_cube_yxcoordname(cube)
             ax.coastlines(resolution="10m")
         except ValueError:
             pass

--- a/src/CSET/operators/regrid.py
+++ b/src/CSET/operators/regrid.py
@@ -18,7 +18,7 @@ import iris
 import iris.cube
 import numpy as np
 
-from CSET.operators._utils import get_cube_xycoordname
+from CSET.operators._utils import get_cube_yxcoordname
 
 
 def regrid_onto_cube(
@@ -55,8 +55,8 @@ def regrid_onto_cube(
     -----
     Currently rectlinear grids (uniform) are supported.
     """
-    # Get x,y coord names
-    x_coord, y_coord = get_cube_xycoordname(incube)
+    # Get y,x coord names
+    y_coord, x_coord = get_cube_yxcoordname(incube)
 
     # List of supported grids - check if it is compatible
     supported_grids = (iris.coord_systems.GeogCS,)
@@ -113,7 +113,7 @@ def regrid_onto_xyspacing(
 
     """
     # Get x,y coord names
-    x_coord, y_coord = get_cube_xycoordname(incube)
+    y_coord, x_coord = get_cube_yxcoordname(incube)
 
     # List of supported grids - check if it is compatible
     supported_grids = (iris.coord_systems.GeogCS,)

--- a/tests/operators/test_utils.py
+++ b/tests/operators/test_utils.py
@@ -30,24 +30,24 @@ def source_cube() -> iris.cube.Cube:
     )
 
 
-def test_missing_coord_get_cube_xycoordname(source_cube):
+def test_missing_coord_get_cube_yxcoordname(source_cube):
     """Missing coordinate raises error."""
     # Missing X coordinate.
     source = source_cube.copy()
     source.remove_coord("longitude")
     with pytest.raises(ValueError):
-        common_operators.get_cube_xycoordname(source)
+        common_operators.get_cube_yxcoordname(source)
 
     # Missing Y coordinate.
     source = source_cube.copy()
     source.remove_coord("latitude")
     with pytest.raises(ValueError):
-        common_operators.get_cube_xycoordname(source)
+        common_operators.get_cube_yxcoordname(source)
 
 
-def test_get_cube_xycoordname(source_cube):
+def test_get_cube_yxcoordname(source_cube):
     """Check that function returns tuple containing horizontal dimension names."""
-    assert (common_operators.get_cube_xycoordname(source_cube)) == (
+    assert (common_operators.get_cube_yxcoordname(source_cube)) == (
         "latitude",
         "longitude",
     )


### PR DESCRIPTION
Quick fix to docstring specifying the expected return (wrong way round). No change in functionality/executable code.