### PR TITLE
Suggest descriptive PR titles instead of changelog entry

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,7 +9,7 @@ Aim to have all relevant checks ticked off before merging. See the [developer's 
 - [ ] Documentation has been updated to reflect change.
 - [ ] New code has tests, and affected old tests have been updated.
 - [ ] All tests and CI checks pass.
-- [ ] Added an entry to the top of `docs/source/changelog.rst`
+- [ ] Ensured the pull request title is descriptive.
 - [ ] Conda lock files have been updated if dependencies have changed.
 - [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
 - [ ] Marked the PR as ready to review.

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -11,7 +11,8 @@ Unreleased
 
 * `@dasha-shchep`_ Fixes METPLUS metadata issue in :pr:`692`
 
-.. Add your changes here, highlighting any user facing changes. E.g:
+.. Add changes here, probably taken from GitHub release notes.
+.. Highlight any user facing changes. E.g:
 .. "* `@gh-user`_ did foo to bar in :pr:`9999`. This enables baz."
 
 * `@Sylviabohnenstengel`_ documentation: add info on quick pytesting in :pr: `696`

--- a/docs/source/contributing/index.rst
+++ b/docs/source/contributing/index.rst
@@ -47,18 +47,14 @@ you need to add the file again with git add and rerun the commit.
 .. image:: failing_pr_check.png
     :alt: Pull request checks, with a couple failing. The details link is highlighted.
 
-Added an entry to the top of ``docs/source/changelog.rst``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Ensured the pull request title is descriptive
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-For any non-trivial change an entry in the :doc:`/changelog` should be created.
-Put a line describing your change in the Unreleased section at the top of the
-file. Take inspiration from the other entries, and link to your PR using the
-``:pr:`123``` directive. If this is your first time contributing also link your
-GitHub username to your profile by adding the following line in that section:
+The PR title is used for the release notes. Therefore it should be
+sufficiently descriptive, and in particular should highlight any breaking
+changes.
 
-.. code-block:: rst
-
-    .. _@username: https://github.com/username
+The PR title can be edited by clicking the "Edit" button to its right.
 
 Conda lock files have been updated if dependencies changed
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/contributing/releases.rst
+++ b/docs/source/contributing/releases.rst
@@ -86,6 +86,15 @@ On this page you will need to add several things.
 Once that is all written you simply need to press "Publish release". A release
 will be automatically made, and the package will be pushed to PyPI and beyond.
 
+After the release has been made you will want to add the release notes into a
+new section in the :doc:`/changelog`. If this is someone's first time
+contributing also link their GitHub username to their profile by adding the
+following line at the bottom of that section:
+
+.. code-block:: rst
+
+    .. _@username: https://github.com/username
+
 .. _CalVer: https://calver.org/
 .. _Releases: https://github.com/MetOffice/CSET/releases
 .. _Draft a new release: https://github.com/MetOffice/CSET/releases/new


### PR DESCRIPTION
The changelog entries were a good idea, but they cause merge conflicts on almost every PR. Instead we would be better served with descriptive pull request titles, that in addition to being useful during development, allow automatically generating the GitHub release notes.

The changelog entries can then be copied in by the release manager.

Fixes #690

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [x] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [ ] Added an entry to the top of `docs/source/changelog.rst`
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
