### PR TITLE
Remove deprecated postage stamp contour plot operator

### DIFF
--- a/src/CSET/operators/plot.py
+++ b/src/CSET/operators/plot.py
@@ -20,7 +20,6 @@ import json
 import logging
 import math
 import sys
-import warnings
 from typing import Union
 
 import iris
@@ -494,62 +493,6 @@ def spatial_contour_plot(
     # Make a page to display the plots.
     _make_plot_html_page(complete_plot_index)
 
-    return cube
-
-
-# Deprecated
-def postage_stamp_contour_plot(
-    cube: iris.cube.Cube,
-    filename: str = None,
-    coordinate: str = "realization",
-    **kwargs,
-) -> iris.cube.Cube:
-    """Plot postage stamp contour plots from an ensemble.
-
-    Depreciated. Use spatial_contour_plot with a stamp_coordinate argument
-    instead.
-
-    Parameters
-    ----------
-    cube: Cube
-        Iris cube of data to be plotted. It must have a realization coordinate.
-    filename: pathlike, optional
-        The path of the plot to write. Defaults to the recipe name.
-    coordinate: str
-        The coordinate that becomes different plots. Defaults to "realization".
-
-    Returns
-    -------
-    Cube
-        The original cube (so further operations can be applied)
-
-    Raises
-    ------
-    ValueError
-        If the cube doesn't have the right dimensions.
-    TypeError
-        If cube isn't a Cube.
-    """
-    warnings.warn(
-        "postage_stamp_contour_plot is depreciated. Use spatial_contour_plot with a stamp_coordinate argument instead.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    # Get suitable filename.
-    if filename is None:
-        filename = slugify(get_recipe_metadata().get("title", "Untitled"))
-    if not filename.endswith(".png"):
-        filename = filename + ".png"
-
-    # Check cube is suitable.
-    cube = _check_single_cube(cube)
-    try:
-        cube.coord(coordinate)
-    except iris.exceptions.CoordinateNotFoundError as err:
-        raise ValueError(f"Cube must have a {coordinate} coordinate.") from err
-
-    _plot_and_save_postage_stamp_contour_plot(cube, filename, coordinate, title="")
-    _make_plot_html_page([filename])
     return cube
 
 

--- a/src/CSET/recipes/inflow_layer_properties_plot.yaml
+++ b/src/CSET/recipes/inflow_layer_properties_plot.yaml
@@ -5,25 +5,25 @@ description: |
 parallel:
   - operator: read.read_cubes
     constraint:
-        operator: constraints.generate_time_constraint
-        time_start: $VALIDITY_TIME
+      operator: constraints.generate_time_constraint
+      time_start: $VALIDITY_TIME
 
   - operator: convection.inflow_layer_properties
     EIB:
-        operator: filters.filter_cubes
-        constraint:
-            operator: constraints.generate_stash_constraint
-            stash: m01s20i119
+      operator: filters.filter_cubes
+      constraint:
+        operator: constraints.generate_stash_constraint
+        stash: m01s20i119
     BLheight:
-        operator: filters.filter_cubes
-        constraint:
-            operator: constraints.generate_stash_constraint
-            stash: m01s00i025
+      operator: filters.filter_cubes
+      constraint:
+        operator: constraints.generate_stash_constraint
+        stash: m01s00i025
     Orography:
-        operator: filters.filter_cubes
-        constraint:
-            operator: constraints.generate_stash_constraint
-            stash: m01s00i033
+      operator: filters.filter_cubes
+      constraint:
+        operator: constraints.generate_stash_constraint
+        stash: m01s00i033
 
   - operator: write.write_cube_to_nc
     filename: intermediate/inflow_layer
@@ -32,7 +32,7 @@ collate:
   - operator: read.read_cube
     filename_pattern: intermediate/*.nc
 
+  - operator: plot.spatial_contour_plot
+
   - operator: write.write_cube_to_nc
     overwrite: True
-
-  - operator: plot.postage_stamp_contour_plot

--- a/tests/operators/test_plots.py
+++ b/tests/operators/test_plots.py
@@ -73,27 +73,6 @@ def test_postage_stamp_contour_plot_sequence_coord_check(cube, tmp_working_dir):
         plot.spatial_contour_plot(cube)
 
 
-# Deprecated functionality.
-def test_postage_stamp_plots_deprecated(monkeypatch, tmp_path):
-    """Plot postage stamp plots of ensemble data."""
-    ensemble_cube = read.read_cube("tests/test_data/exeter_em*.nc")
-    ensemble_cube_3d = ensemble_cube.slices_over("time").next()
-    monkeypatch.chdir(tmp_path)
-    plot_file = Path("plot.png")
-    with pytest.deprecated_call():
-        plot.postage_stamp_contour_plot(ensemble_cube_3d, filename=plot_file.name)
-    assert plot_file.is_file()
-
-
-def test_postage_stamp_realization_check_deprecated(cube, tmp_working_dir):
-    """Check error when cube has no realization coordinate."""
-    cube = cube.copy()
-    cube.remove_coord("realization")
-    with pytest.deprecated_call():
-        with pytest.raises(ValueError):
-            plot.postage_stamp_contour_plot(cube)
-
-
 def test_plot_line_series(cube, tmp_working_dir):
     """Save a line series plot."""
     cube = collapse.collapse(cube, ["grid_latitude", "grid_longitude"], "MEAN")

--- a/tests/test_data/ensemble_air_temp.yaml
+++ b/tests/test_data/ensemble_air_temp.yaml
@@ -5,5 +5,5 @@ parallel:
       operator: constraints.generate_stash_constraint
       stash: m01s03i236
 
-  - operator: plot.postage_stamp_contour_plot
+  - operator: plot.spatial_contour_plot
     filename: plot.png


### PR DESCRIPTION
<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

We've had this deprecated for a while now. Time to remove it.

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [x] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
