### PR TITLE
Remove unneeded fallback code for old recipe step keys

### DIFF
--- a/src/CSET/_common.py
+++ b/src/CSET/_common.py
@@ -18,7 +18,6 @@ import io
 import json
 import logging
 import re
-import warnings
 from collections.abc import Iterable
 from pathlib import Path
 from typing import Union
@@ -107,15 +106,7 @@ def check_recipe_has_steps(recipe: dict):
     if not isinstance(recipe, dict):
         raise TypeError("Recipe must contain a mapping.")
     if "parallel" not in recipe:
-        if "steps" in recipe:
-            warnings.warn(
-                "'steps' recipe key is deprecated, use 'parallel' instead.",
-                DeprecationWarning,
-                stacklevel=3,
-            )
-            parallel_steps_key = "steps"
-        else:
-            raise ValueError("Recipe must contain a 'parallel' key.")
+        raise ValueError("Recipe must contain a 'parallel' key.")
     try:
         if len(recipe[parallel_steps_key]) < 1:
             raise ValueError("Recipe must have at least 1 parallel step.")

--- a/src/CSET/operators/__init__.py
+++ b/src/CSET/operators/__init__.py
@@ -105,9 +105,7 @@ def _write_metadata(recipe: dict):
     metadata = recipe.copy()
     # Remove steps, as not needed, and might contain non-serialisable types.
     metadata.pop("parallel", None)
-    metadata.pop("steps", None)
     metadata.pop("collate", None)
-    metadata.pop("post-steps", None)
     with open("meta.json", "wt", encoding="UTF-8") as fp:
         json.dump(metadata, fp)
     os.sync()

--- a/src/CSET/operators/__init__.py
+++ b/src/CSET/operators/__init__.py
@@ -18,7 +18,6 @@ import inspect
 import json
 import logging
 import os
-import warnings
 from pathlib import Path
 from typing import Union
 
@@ -213,17 +212,7 @@ def execute_recipe_parallel(
     except (FileExistsError, NotADirectoryError) as err:
         logging.error("Output directory is a file. %s", output_directory)
         raise err
-    # If parallel doesn't exist try steps.
-    try:
-        steps = recipe["parallel"]
-    except KeyError:
-        if "steps" in recipe:
-            warnings.warn(
-                "'steps' recipe key is deprecated. Use 'parallel' instead.",
-                DeprecationWarning,
-                stacklevel=1,
-            )
-        steps = recipe["steps"]
+    steps = recipe["parallel"]
     _run_steps(recipe, steps, step_input, output_directory, style_file)
 
 
@@ -258,15 +247,6 @@ def execute_recipe_collate(
     output_directory = Path(output_directory).resolve()
     assert output_directory.is_dir()
     recipe = parse_recipe(recipe_yaml, recipe_variables)
-    # If collate doesn't exist try post-steps, else treat it as having no steps.
-    try:
-        steps = recipe["collate"]
-    except KeyError:
-        if "post-steps" in recipe:
-            warnings.warn(
-                "'post-steps' recipe key is deprecated. Use 'collate' instead.",
-                DeprecationWarning,
-                stacklevel=1,
-            )
-        steps = recipe.get("post-steps", tuple())
+    # If collate doesn't exist treat it as having no steps.
+    steps = recipe.get("collate", [])
     _run_steps(recipe, steps, output_directory, output_directory, style_file)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -94,12 +94,6 @@ def test_parse_recipe_exception_parallel_not_sequence():
         common.parse_recipe("parallel: 7")
 
 
-def test_parse_recipe_deprecated_steps():
-    """Deprecation warning when falling back to steps key."""
-    with pytest.warns(DeprecationWarning):
-        common.parse_recipe('steps: [{"operator": "misc.noop"}]')
-
-
 def test_parse_recipe_exception_non_dict():
     """Exception for recipe that parses to a non-dict."""
     with pytest.raises(TypeError):


### PR DESCRIPTION
<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

We've had this deprecated for a while now. Time to remove it.

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [ ] All tests and CI checks pass.
- [ ] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [ ] Marked the PR as ready to review.
