### PR TITLE
Ignore cartopy DownloadWarning in pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,9 +47,10 @@ build-backend = "setuptools.build_meta"
 [tool.pytest.ini_options]
 addopts = ["--import-mode=importlib"]
 filterwarnings = [
-    # https://github.com/dateutil/dateutil/issues/1314
-    "ignore::DeprecationWarning:dateutil",
     "ignore:numpy.ndarray size changed:RuntimeWarning",
+    # Cartopy downloads coastlines, etc. Caching does not catch this for the
+    # first CI run on each branch.
+    "ignore::cartopy.io.DownloadWarning",
 ]
 minversion = "7"
 pythonpath = ["src"]


### PR DESCRIPTION
As CI starts from a fresh slate each time we won't yet have the resources downloaded. We do cache them, but caches are only per-branch, and thus we still need to download on the first run per branch.

Also removed the dateutil warning filter, as that issue has been fixed.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [ ] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [ ] Marked the PR as ready to review.
