### PR TITLE
Unquote double quoted shell values

### DIFF
--- a/cset-workflow/includes/lfric_deterministic_domain_mean_surface_time_series.cylc
+++ b/cset-workflow/includes/lfric_deterministic_domain_mean_surface_time_series.cylc
@@ -13,10 +13,10 @@
         --SUBAREA_LON_BOUND_RIGHT={{SUBAREA_LON_BOUND_RIGHT}}
         --SUBAREA_LON_BOUND_LEFT={{SUBAREA_LON_BOUND_LEFT}}
         {% else %}
-        --SUBAREA_LAT_BOUND_BOTTOM="None"
-        --SUBAREA_LAT_BOUND_TOP="None"
-        --SUBAREA_LON_BOUND_RIGHT="None"
-        --SUBAREA_LON_BOUND_LEFT="None"
+        --SUBAREA_LAT_BOUND_BOTTOM=None
+        --SUBAREA_LAT_BOUND_TOP=None
+        --SUBAREA_LON_BOUND_RIGHT=None
+        --SUBAREA_LON_BOUND_LEFT=None
         {% endif %}
         """
 
@@ -32,10 +32,10 @@
         --SUBAREA_LON_BOUND_RIGHT={{SUBAREA_LON_BOUND_RIGHT}}
         --SUBAREA_LON_BOUND_LEFT={{SUBAREA_LON_BOUND_LEFT}}
         {% else %}
-        --SUBAREA_LAT_BOUND_BOTTOM="None"
-        --SUBAREA_LAT_BOUND_TOP="None"
-        --SUBAREA_LON_BOUND_RIGHT="None"
-        --SUBAREA_LON_BOUND_LEFT="None"
+        --SUBAREA_LAT_BOUND_BOTTOM=None
+        --SUBAREA_LAT_BOUND_TOP=None
+        --SUBAREA_LON_BOUND_RIGHT=None
+        --SUBAREA_LON_BOUND_LEFT=None
         {% endif %}
         """
 {% endfor %}

--- a/cset-workflow/includes/lfric_plot_spatial_surface_model_field.cylc
+++ b/cset-workflow/includes/lfric_plot_spatial_surface_model_field.cylc
@@ -13,10 +13,10 @@
         --SUBAREA_LON_BOUND_RIGHT={{SUBAREA_LON_BOUND_RIGHT}}
         --SUBAREA_LON_BOUND_LEFT={{SUBAREA_LON_BOUND_LEFT}}
         {% else %}
-        --SUBAREA_LAT_BOUND_BOTTOM="None"
-        --SUBAREA_LAT_BOUND_TOP="None"
-        --SUBAREA_LON_BOUND_RIGHT="None"
-        --SUBAREA_LON_BOUND_LEFT="None"
+        --SUBAREA_LAT_BOUND_BOTTOM=None
+        --SUBAREA_LAT_BOUND_TOP=None
+        --SUBAREA_LON_BOUND_RIGHT=None
+        --SUBAREA_LON_BOUND_LEFT=None
         {% endif %}
         """
 
@@ -32,10 +32,10 @@
         --SUBAREA_LON_BOUND_RIGHT={{SUBAREA_LON_BOUND_RIGHT}}
         --SUBAREA_LON_BOUND_LEFT={{SUBAREA_LON_BOUND_LEFT}}
         {% else %}
-        --SUBAREA_LAT_BOUND_BOTTOM="None"
-        --SUBAREA_LAT_BOUND_TOP="None"
-        --SUBAREA_LON_BOUND_RIGHT="None"
-        --SUBAREA_LON_BOUND_LEFT="None"
+        --SUBAREA_LAT_BOUND_BOTTOM=None
+        --SUBAREA_LAT_BOUND_TOP=None
+        --SUBAREA_LON_BOUND_RIGHT=None
+        --SUBAREA_LON_BOUND_LEFT=None
         {% endif %}
         """
 {% endfor %}

--- a/src/CSET/__init__.py
+++ b/src/CSET/__init__.py
@@ -150,6 +150,9 @@ def main():
     stderr_log.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(message)s"))
     logger.addHandler(stderr_log)
 
+    # Down here so runs after logging is setup.
+    logging.debug("CLI Arguments: %s", cli_args)
+
     if args.subparser is None:
         print("Please choose a command.", file=sys.stderr)
         parser.print_usage()

--- a/src/CSET/_common.py
+++ b/src/CSET/_common.py
@@ -161,9 +161,9 @@ def parse_variable_options(arguments: list[str]) -> dict:
     recipe_variables = {}
     i = 0
     while i < len(arguments):
-        if re.match(r"^--[A-Z_]+=.*$", arguments[i]):
+        if re.fullmatch(r"--[A-Z_]+=.*", arguments[i]):
             key, value = arguments[i].split("=", 1)
-        elif re.match(r"^--[A-Z_]+$", arguments[i]):
+        elif re.fullmatch(r"--[A-Z_]+", arguments[i]):
             try:
                 key = arguments[i].strip("-")
                 value = arguments[i + 1]
@@ -173,6 +173,9 @@ def parse_variable_options(arguments: list[str]) -> dict:
         else:
             raise ArgumentError(f"Unknown argument: {arguments[i]}")
         try:
+            # Remove quotes from arguments, in case left in CSET_ADDOPTS.
+            if re.fullmatch(r"""["'].+["']""", value):
+                value = value[1:-1]
             recipe_variables[key.strip("-")] = ast.literal_eval(value)
         # Capture the many possible exceptions from ast.literal_eval
         except (ValueError, TypeError, SyntaxError, MemoryError, RecursionError):

--- a/src/CSET/operators/constraints.py
+++ b/src/CSET/operators/constraints.py
@@ -191,7 +191,7 @@ def generate_area_constraint(
     -------
     area_constraint: iris.Constraint
     """
-    if lat_start == "None":
+    if lat_start is None:
         return iris.Constraint()
 
     area_constraint = iris.Constraint(

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -129,6 +129,14 @@ def test_parse_variable_options():
         common.parse_variable_options(("--VARIABLE",))
 
 
+def test_parse_variable_options_quoted():
+    """Quoted arguments get unquoted before interpretation."""
+    args = ["--A='None'", "--B", '"None"']
+    expected = {"A": None, "B": None}
+    actual = common.parse_variable_options(args)
+    assert actual == expected
+
+
 def test_template_variables():
     """Multiple variables are correctly templated into recipe."""
     recipe = {"parallel": [{"operator": "misc.noop", "v1": "$VAR_A", "v2": "$VAR_B"}]}


### PR DESCRIPTION
This handles the double quoting that arises from CSET_ADDOPTS arguments never actually being parsed by a shell.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [ ] All tests and CI checks pass.
- [ ] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [ ] Marked the PR as ready to review.
