### PR TITLE
Regrid to take CubeList and Cubes

### DIFF
--- a/src/CSET/operators/regrid.py
+++ b/src/CSET/operators/regrid.py
@@ -46,7 +46,7 @@ def regrid_onto_cube(
     Returns
     -------
     iris.cube | iris.cube.CubeList
-        An iris cube of the data that has been regridded, or a cubelist of the cubes
+        An iris cube of the data that has been regridded, or a CubeList of the cubes
         that have been regridded in the same order they were passed in toregrid.
 
     Raises

--- a/src/CSET/operators/regrid.py
+++ b/src/CSET/operators/regrid.py
@@ -27,7 +27,7 @@ def regrid_onto_cube(
     method: str,
     **kwargs,
 ) -> iris.cube.Cube | iris.cube.CubeList:
-    """Regrid a cube or cubelist, projecting onto a target cube.
+    """Regrid a cube or CubeList, projecting onto a target cube.
 
     All cubes must have at least 2 spatial (map) dimensions.
 

--- a/src/CSET/operators/regrid.py
+++ b/src/CSET/operators/regrid.py
@@ -22,7 +22,10 @@ from CSET.operators._utils import get_cube_yxcoordname
 
 
 def regrid_onto_cube(
-    incube: iris.cube.Cube, target: iris.cube.Cube, method: str, **kwargs
+    incube: iris.cube.Cube | iris.cube.CubeList,
+    target: iris.cube.Cube,
+    method: str,
+    **kwargs,
 ) -> iris.cube.Cube:
     """Regrid a cube, projecting onto a target cube.
 

--- a/src/CSET/operators/regrid.py
+++ b/src/CSET/operators/regrid.py
@@ -34,7 +34,7 @@ def regrid_onto_cube(
     Arguments
     ----------
     toregrid: iris.cube | iris.cube.CubeList
-        An iris cube of the data to regrid, or multiple cubes to regrid in a cubelist.
+        An iris Cube of data to regrid, or multiple cubes to regrid in a CubeList.
         A minimum requirement is that the cube(s) need to be 2D with a latitude,
         longitude coordinates.
     target: Cube

--- a/src/CSET/operators/regrid.py
+++ b/src/CSET/operators/regrid.py
@@ -18,6 +18,7 @@ import iris
 import iris.cube
 import numpy as np
 
+from CSET._common import iter_maybe
 from CSET.operators._utils import get_cube_yxcoordname
 
 
@@ -60,15 +61,11 @@ def regrid_onto_cube(
     -----
     Currently rectlinear grids (uniform) are supported.
     """
-    # If only one cube, put into cubelist as an iterable.
-    if type(toregrid) == iris.cube.Cube:
-        toregrid = iris.cube.CubeList([toregrid])
-
-    # To store regridded cubes
+    # To store regridded cubes.
     regridded_cubes = iris.cube.CubeList()
 
-    # Iterate over all cubes and regrid
-    for cube in toregrid:
+    # Iterate over all cubes and regrid.
+    for cube in iter_maybe(toregrid):
         # Get y,x coord names
         y_coord, x_coord = get_cube_yxcoordname(cube)
 
@@ -140,15 +137,11 @@ def regrid_onto_xyspacing(
     Currently rectlinear grids (uniform) are supported.
 
     """
-    # If only one cube, put into cubelist as an iterable.
-    if type(toregrid) == iris.cube.Cube:
-        toregrid = iris.cube.CubeList([toregrid])
-
-    # To store regridded cubes
+    # To store regridded cubes.
     regridded_cubes = iris.cube.CubeList()
 
-    # Iterate over all cubes and regrid
-    for cube in toregrid:
+    # Iterate over all cubes and regrid.
+    for cube in iter_maybe(toregrid):
         # Get x,y coord names
         y_coord, x_coord = get_cube_yxcoordname(cube)
 

--- a/tests/operators/test_regrid.py
+++ b/tests/operators/test_regrid.py
@@ -55,7 +55,6 @@ def test_regrid_onto_cube_cubes(regrid_source_cube, regrid_test_cube):
     """Test regrid case where target cube to project onto is specified for multiple cubes."""
     # Create cubelist with multiple cubes.
     cubelist_to_regrid = iris.cube.CubeList([regrid_source_cube, regrid_source_cube])
-
     regridded_cubes = regrid.regrid_onto_cube(
         cubelist_to_regrid, regrid_test_cube, method="Linear"
     )

--- a/tests/operators/test_regrid.py
+++ b/tests/operators/test_regrid.py
@@ -59,7 +59,6 @@ def test_regrid_onto_cube_cubes(regrid_source_cube, regrid_test_cube):
     regridded_cubes = regrid.regrid_onto_cube(
         cubelist_to_regrid, regrid_test_cube, method="Linear"
     )
-
     expected_cubelist = "[<iris 'Cube' of surface_altitude / (m) (latitude: 16; longitude: 16)>,\n<iris 'Cube' of surface_altitude / (m) (latitude: 16; longitude: 16)>]"
     assert repr(regridded_cubes) in expected_cubelist
 

--- a/tests/operators/test_regrid.py
+++ b/tests/operators/test_regrid.py
@@ -53,7 +53,7 @@ def test_regrid_onto_cube(regrid_source_cube, regrid_test_cube):
 
 def test_regrid_onto_cube_cubes(regrid_source_cube, regrid_test_cube):
     """Test regrid case where target cube to project onto is specified for multiple cubes."""
-    # Create cubelist with multiple cubes
+    # Create cubelist with multiple cubes.
     cubelist_to_regrid = iris.cube.CubeList([regrid_source_cube, regrid_source_cube])
 
     regridded_cubes = regrid.regrid_onto_cube(

--- a/tests/operators/test_regrid.py
+++ b/tests/operators/test_regrid.py
@@ -51,6 +51,34 @@ def test_regrid_onto_cube(regrid_source_cube, regrid_test_cube):
     )
 
 
+def test_regrid_onto_cube_cubes(regrid_source_cube, regrid_test_cube):
+    """Test regrid case where target cube to project onto is specified for multiple cubes."""
+    # Create cubelist with multiple cubes
+    cubelist_to_regrid = iris.cube.CubeList([regrid_source_cube, regrid_source_cube])
+
+    regridded_cubes = regrid.regrid_onto_cube(
+        cubelist_to_regrid, regrid_test_cube, method="Linear"
+    )
+
+    expected_cubelist = "[<iris 'Cube' of surface_altitude / (m) (latitude: 16; longitude: 16)>,\n<iris 'Cube' of surface_altitude / (m) (latitude: 16; longitude: 16)>]"
+
+    assert repr(regridded_cubes) in expected_cubelist
+
+
+def test_regrid_onto_xyspacing_cubes(regrid_source_cube, regrid_test_cube):
+    """Test regrid case where xyspacing to project onto is specified for multiple cubes."""
+    # Create cubelist with multiple cubes
+    cubelist_to_regrid = iris.cube.CubeList([regrid_source_cube, regrid_source_cube])
+
+    regridded_cubes = regrid.regrid_onto_xyspacing(
+        cubelist_to_regrid, xspacing=0.5, yspacing=0.5, method="Linear"
+    )
+
+    expected_cubelist = "[<iris 'Cube' of surface_altitude / (m) (latitude: 16; longitude: 16)>,\n<iris 'Cube' of surface_altitude / (m) (latitude: 16; longitude: 16)>]"
+
+    assert repr(regridded_cubes) in expected_cubelist
+
+
 def test_regrid_onto_cube_unknown_crs(regrid_source_cube, regrid_test_cube):
     """Coordinate reference system is unrecognised."""
     # Exchange X to unsupported coordinate system.

--- a/tests/operators/test_regrid.py
+++ b/tests/operators/test_regrid.py
@@ -71,7 +71,6 @@ def test_regrid_onto_xyspacing_cubes(regrid_source_cube, regrid_test_cube):
     )
 
     expected_cubelist = "[<iris 'Cube' of surface_altitude / (m) (latitude: 16; longitude: 16)>,\n<iris 'Cube' of surface_altitude / (m) (latitude: 16; longitude: 16)>]"
-
     assert repr(regridded_cubes) in expected_cubelist
 
 

--- a/tests/operators/test_regrid.py
+++ b/tests/operators/test_regrid.py
@@ -66,7 +66,6 @@ def test_regrid_onto_xyspacing_cubes(regrid_source_cube, regrid_test_cube):
     """Test regrid case where xyspacing to project onto is specified for multiple cubes."""
     # Create cubelist with multiple cubes
     cubelist_to_regrid = iris.cube.CubeList([regrid_source_cube, regrid_source_cube])
-
     regridded_cubes = regrid.regrid_onto_xyspacing(
         cubelist_to_regrid, xspacing=0.5, yspacing=0.5, method="Linear"
     )

--- a/tests/operators/test_regrid.py
+++ b/tests/operators/test_regrid.py
@@ -69,7 +69,6 @@ def test_regrid_onto_xyspacing_cubes(regrid_source_cube, regrid_test_cube):
     regridded_cubes = regrid.regrid_onto_xyspacing(
         cubelist_to_regrid, xspacing=0.5, yspacing=0.5, method="Linear"
     )
-
     expected_cubelist = "[<iris 'Cube' of surface_altitude / (m) (latitude: 16; longitude: 16)>,\n<iris 'Cube' of surface_altitude / (m) (latitude: 16; longitude: 16)>]"
     assert repr(regridded_cubes) in expected_cubelist
 

--- a/tests/operators/test_regrid.py
+++ b/tests/operators/test_regrid.py
@@ -61,7 +61,6 @@ def test_regrid_onto_cube_cubes(regrid_source_cube, regrid_test_cube):
     )
 
     expected_cubelist = "[<iris 'Cube' of surface_altitude / (m) (latitude: 16; longitude: 16)>,\n<iris 'Cube' of surface_altitude / (m) (latitude: 16; longitude: 16)>]"
-
     assert repr(regridded_cubes) in expected_cubelist
 
 


### PR DESCRIPTION
Fixes #720. Holding off implementation of caching regridder, as this only works if cubes in the cubelist passed to the function are on the same grid (which can't be assumed).

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [x] Documentation has been updated to reflect change.
- [x] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
