### PR TITLE
Don't check documentation hyperlinks in commit CI

### DIFF
--- a/.github/workflows/pull_request_checks.yml
+++ b/.github/workflows/pull_request_checks.yml
@@ -135,9 +135,6 @@ jobs:
           echo '::group::Building the documentation'
           sphinx-build -b html --color -W --keep-going "docs/source" "docs/build/html"
           echo '::endgroup::'
-          echo '::group::Checking for broken hyperlinks'
-          sphinx-build -b linkcheck --color -W --keep-going "docs/source" "docs/build/linkcheck"
-          echo '::endgroup::'
       - name: Upload documentation artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/weekly-checks.yml
+++ b/.github/workflows/weekly-checks.yml
@@ -1,0 +1,51 @@
+name: Weekly Checks
+
+on:
+  schedule:
+    - cron: "8 4 * * 1"
+  workflow_dispatch:
+
+jobs:
+  check-documentation-hyperlinks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache conda environment
+        id: conda-env-cache
+        uses: actions/cache@v4
+        with:
+          key: conda|${{runner.os}}-${{runner.arch}}|${{hashFiles('requirements/locks/py312-lock-linux-64.txt')}}
+          path: |
+            ~/conda-env
+            ~/.local/share/cartopy
+
+      - name: Create conda environment
+        if: steps.conda-env-cache.outputs.cache-hit != 'true'
+        run: |
+          # Check cache hasn't pulled a partial key match.
+          test ! -e "${HOME}/conda-env"
+          conda create --prefix="${HOME}/conda-env" --file=requirements/locks/py312-lock-linux-64.txt
+
+      - name: Add conda environment to PATH
+        run: echo "${HOME}/conda-env/bin" >> $GITHUB_PATH
+
+      - name: Build documentation
+        run: |
+          # Install module so it can be imported during docs generation.
+          echo '::group::Installing local package'
+          python3 -m pip install .
+          echo '::endgroup::'
+          # Generate the documentation
+          echo '::group::Building the documentation'
+          sphinx-build -b html --color "docs/source" "docs/build/html"
+          echo '::endgroup::'
+          echo '::group::Checking for broken hyperlinks'
+          sphinx-build -b linkcheck --color -W --keep-going "docs/source" "docs/build/linkcheck"
+          echo '::endgroup::'
+      - uses: actions/upload-artifact@v4
+        with:
+          name: html-docs
+          path: docs/build/html/
+          retention-days: 1
+          if-no-files-found: error


### PR DESCRIPTION
<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->
Don't check documentation hyperlinks in commit CI

This was too flakey to run this regularily, and blocks development if any linked external website goes down.

By having this in a separate workflow, we won't block development, but will still receive an email when the links don't resolve.

Fixes #748 

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
