### PR TITLE
Add missing brackets to TemporaryDirectory call when installing local CSET

### DIFF
--- a/cset-workflow/app/install_local_cset/bin/install-local-cset.py
+++ b/cset-workflow/app/install_local_cset/bin/install-local-cset.py
@@ -14,7 +14,7 @@ logging.basicConfig(
 )
 
 if os.getenv("CSET_ENV_USE_LOCAL_CSET") == "True":
-    with tempfile.TemporaryDirectory as cset_install_path:
+    with tempfile.TemporaryDirectory() as cset_install_path:
         cset_source_path = os.path.expandvars(
             os.path.expanduser(os.getenv("CSET_LOCAL_CSET_PATH"))
         )


### PR DESCRIPTION
A small error that slipped through review, that now causes the install task to crash.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [ ] All tests and CI checks pass.
- [ ] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [ ] Marked the PR as ready to review.
