### PR TITLE
Move all website files under the workflow shared directory

### DIFF
--- a/cset-workflow/app/housekeeping/bin/housekeep.sh
+++ b/cset-workflow/app/housekeeping/bin/housekeep.sh
@@ -22,5 +22,5 @@ then
     # Housekeeping: Standard
     echo 'Removing intermediate data.'
     rm -rfv -- "$CYLC_WORKFLOW_SHARE_DIR"/cycle/*/data \
-              "$CYLC_WORKFLOW_SHARE_DIR"/plots/*/intermediate
+              "$CYLC_WORKFLOW_SHARE_DIR"/web/plots/*/intermediate
 fi

--- a/cset-workflow/app/run_cset_recipe/bin/run-cset-recipe.py
+++ b/cset-workflow/app/run_cset_recipe/bin/run-cset-recipe.py
@@ -39,8 +39,8 @@ def append_to_index(record: dict):
 
     Record should have the form {"Category Name": {"recipe_id": "Plot Name"}}
     """
-    # Plot index is at {run}/share/plots/index.json
-    index_path = Path(os.getenv("CYLC_WORKFLOW_SHARE_DIR"), "plots/index.json")
+    # Plot index is at {run}/share/web/plots/index.json
+    index_path = Path(os.getenv("CYLC_WORKFLOW_SHARE_DIR"), "web/plots/index.json")
     with open(index_path, "a+t", encoding="UTF-8") as fp:
         # Lock file until closed.
         fcntl.flock(fp, fcntl.LOCK_EX)
@@ -111,7 +111,7 @@ def recipe_id():
 def output_directory():
     """Get the plot output directory for the recipe."""
     share_directory = os.environ["CYLC_WORKFLOW_SHARE_DIR"]
-    return f"{share_directory}/plots/{recipe_id()}"
+    return f"{share_directory}/web/plots/{recipe_id()}"
 
 
 def data_directory():

--- a/cset-workflow/flow.cylc
+++ b/cset-workflow/flow.cylc
@@ -128,8 +128,6 @@ URL = https://metoffice.github.io/CSET
 
     [[install_website_skeleton]]
     # Copies the static files that make up the web interface.
-        [[[environment]]]
-        CLEAN_WEB_DIR = {{CLEAN_WEB_DIR}}
 
     [[fetch_fcst]]
     # Fetch data from disk or a file based archival system.

--- a/cset-workflow/meta/rose-meta.conf
+++ b/cset-workflow/meta/rose-meta.conf
@@ -189,16 +189,6 @@ type=quoted
 compulsory=true
 sort-key=web1
 
-[template variables=CLEAN_WEB_DIR]
-ns=General
-description=Delete existing output in WEB_DIR.
-help=Whether to remove any existing files in WEB_DIR before running CSET. CSET
-    will not overwrite files, so if this is not set the workflow will stop on
-    encountering pre-existing files.
-type=python_boolean
-compulsory=true
-sort-key=web3
-
 [template variables=CSET_RUNAHEAD_LIMIT]
 ns=General
 description=Number of simultaneous cycles.

--- a/cset-workflow/rose-suite.conf.example
+++ b/cset-workflow/rose-suite.conf.example
@@ -1,5 +1,4 @@
 [template variables]
-CLEAN_WEB_DIR=True
 !!CONDA_METPLUS_VENV_LOCATION=""
 CONDA_PATH=""
 CONDA_VENV_CREATE=True


### PR DESCRIPTION
Now the full output of CSET is under the workflow run directory, giving more consistent behaviour around cylc clean, moving output, and keeping old output when rerunning.

All web content is now saved under ${CYLC_WORKFLOW_SHARE_DIR}/web/ and a symbolic link is created from the webserver's directory.

Fixes #761

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
