### PR TITLE
Fix overwriting when using transect on multiple variables

### DIFF
--- a/cset-workflow/includes/transect.cylc
+++ b/cset-workflow/includes/transect.cylc
@@ -1,14 +1,14 @@
 {% if EXTRACT_TRANSECT %}
 {% for var in CS_VARS %}
 [runtime]
-    [[parallel_transect]]
+    [[parallel_transect_{{var}}]]
     inherit = PARALLEL
     execution time limit = PT60M
         [[[environment]]]
         CSET_RECIPE_NAME = "transect.yaml"
         CSET_ADDOPTS = "--CS_STARTCOORDS='{{CS_STARTCOORDS}}' --CS_FINISHCOORDS='{{CS_FINISHCOORDS}}' --CS_VARS='{{var}}' --CS_VERTLEV='{{CS_VERTLEV}}'"
 
-    [[collate_transect]]
+    [[collate_transect_{{var}}]]
     inherit = COLLATE
     execution time limit = PT60M
         [[[environment]]]

--- a/cset-workflow/includes/transect.cylc
+++ b/cset-workflow/includes/transect.cylc
@@ -6,13 +6,13 @@
     execution time limit = PT60M
         [[[environment]]]
         CSET_RECIPE_NAME = "transect.yaml"
-        CSET_ADDOPTS = "--CS_STARTCOORDS='{{CS_STARTCOORDS}}' --CS_FINISHCOORDS='{{CS_FINISHCOORDS}}' --CS_VARS='{{var}}' --CS_VERTLEV='{{CS_VERTLEV}}'"
+        CSET_ADDOPTS = "--CS_STARTCOORDS='{{CS_STARTCOORDS}}' --CS_FINISHCOORDS='{{CS_FINISHCOORDS}}' --CS_VAR='{{var}}' --CS_VERTLEV='{{CS_VERTLEV}}'"
 
     [[collate_transect_{{var}}]]
     inherit = COLLATE
     execution time limit = PT60M
         [[[environment]]]
         CSET_RECIPE_NAME = "transect.yaml"
-        CSET_ADDOPTS = "--CS_STARTCOORDS='{{CS_STARTCOORDS}}' --CS_FINISHCOORDS='{{CS_FINISHCOORDS}}' --CS_VARS='{{var}}' --CS_VERTLEV='{{CS_VERTLEV}}'"
+        CSET_ADDOPTS = "--CS_STARTCOORDS='{{CS_STARTCOORDS}}' --CS_FINISHCOORDS='{{CS_FINISHCOORDS}}' --CS_VAR='{{var}}' --CS_VERTLEV='{{CS_VERTLEV}}'"
 {% endfor %}
 {% endif %}

--- a/src/CSET/recipes/transect.yaml
+++ b/src/CSET/recipes/transect.yaml
@@ -1,4 +1,4 @@
-title: Transect
+title: Transect $CS_VARS
 description: |
   Extracts a transect for a specified variable between two points and plots it.
 
@@ -26,9 +26,14 @@ parallel:
 
 collate:
   - operator: read.read_cube
+    constraint:
+        operator: constraints.generate_var_constraint
+        varname: $CS_VARS
+
     filename_pattern: intermediate/*
 
   - operator: write.write_cube_to_nc
+    filename: transect_$CS_VARS.nc
     overwrite: True
 
   - operator: plot.spatial_contour_plot

--- a/src/CSET/recipes/transect.yaml
+++ b/src/CSET/recipes/transect.yaml
@@ -1,4 +1,4 @@
-title: Transect $CS_VARS
+title: Transect of $CS_VAR
 description: |
   Extracts a transect for a specified variable between two points and plots it.
 
@@ -11,7 +11,7 @@ parallel:
             time_start: $VALIDITY_TIME
         var_constraint:
             operator: constraints.generate_var_constraint
-            varname: $CS_VARS
+            varname: $CS_VAR
         level_constraint:
             operator: constraints.generate_level_constraint
             coordinate: $CS_VERTLEV
@@ -22,7 +22,7 @@ parallel:
     endcoords: $CS_FINISHCOORDS
 
   - operator: write.write_cube_to_nc
-    filename: intermediate/transect
+    filename: intermediate/transectu
 
 collate:
   - operator: read.read_cube
@@ -33,7 +33,6 @@ collate:
     filename_pattern: intermediate/*
 
   - operator: write.write_cube_to_nc
-    filename: transect_$CS_VARS.nc
     overwrite: True
 
   - operator: plot.spatial_contour_plot

--- a/src/CSET/recipes/transect.yaml
+++ b/src/CSET/recipes/transect.yaml
@@ -28,7 +28,7 @@ collate:
   - operator: read.read_cube
     constraint:
         operator: constraints.generate_var_constraint
-        varname: $CS_VARS
+        varname: $CS_VAR
 
     filename_pattern: intermediate/*
 

--- a/src/CSET/recipes/transect.yaml
+++ b/src/CSET/recipes/transect.yaml
@@ -22,7 +22,7 @@ parallel:
     endcoords: $CS_FINISHCOORDS
 
   - operator: write.write_cube_to_nc
-    filename: intermediate/transectu
+    filename: intermediate/transect
 
 collate:
   - operator: read.read_cube


### PR DESCRIPTION
Currently, when multiple variables are put into the GUI to perform the transect operator on, it overwrites each one with the latest one. This fix makes the tasks, output unique so it appears in the website and prevents conflicts.

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [x] Documentation has been updated to reflect change.
- [x] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [ ] Marked the PR as ready to review.
