### PR TITLE
Allow Point cell methods for empty constraint, making it possible to unify UM and LFRic recipes

### DIFF
--- a/src/CSET/operators/constraints.py
+++ b/src/CSET/operators/constraints.py
@@ -118,7 +118,7 @@ def generate_cell_methods_constraint(cell_methods: list, **kwargs) -> iris.Const
     """Generate constraint from cell methods.
 
     Operator that takes a list of cell methods and generates a constraint from
-    that.
+    that. Use [] to specify non-aggregated data.
 
     Arguments
     ---------
@@ -129,11 +129,19 @@ def generate_cell_methods_constraint(cell_methods: list, **kwargs) -> iris.Const
     -------
     cell_method_constraint: iris.Constraint
     """
+    if len(cell_methods) == 0:
 
-    def check_cell_methods(cube: iris.cube.Cube):
-        return cube.cell_methods == tuple(cell_methods)
+        def check_no_aggregation(cube: iris.cube.Cube) -> bool:
+            """Check that any cell methods are "point", meaning no aggregation."""
+            return set(cm.method for cm in cube.cell_methods) <= {"point"}
 
-    cell_methods_constraint = iris.Constraint(cube_func=check_cell_methods)
+        cell_methods_constraint = iris.Constraint(cube_func=check_no_aggregation)
+    else:
+
+        def check_cell_methods(cube: iris.cube.Cube) -> bool:
+            return cube.cell_methods == tuple(cell_methods)
+
+        cell_methods_constraint = iris.Constraint(cube_func=check_cell_methods)
     return cell_methods_constraint
 
 

--- a/tests/operators/test_constraints.py
+++ b/tests/operators/test_constraints.py
@@ -42,8 +42,15 @@ def test_generate_var_constraint_stash():
 
 def test_generate_cell_methods_constraint():
     """Generate iris cube constraint for cell methods."""
-    cell_methods_constraint = constraints.generate_cell_methods_constraint([])
+    cell_methods_constraint = constraints.generate_cell_methods_constraint(["mean"])
     expected_cell_methods_constraint = "Constraint(cube_func=<function generate_cell_methods_constraint.<locals>.check_cell_methods at"
+    assert expected_cell_methods_constraint in repr(cell_methods_constraint)
+
+
+def test_generate_cell_methods_constraint_no_aggregation():
+    """Generate iris cube constraint for no aggregation cell methods."""
+    cell_methods_constraint = constraints.generate_cell_methods_constraint([])
+    expected_cell_methods_constraint = "Constraint(cube_func=<function generate_cell_methods_constraint.<locals>.check_no_aggregation at"
     assert expected_cell_methods_constraint in repr(cell_methods_constraint)
 
 


### PR DESCRIPTION
This allows UM and LFRic recipes to be the same, so we can remove the LFRic specific ones.

~~This probably wants some tests before merging, but its 18:00 now, so that can wait for another day.~~ - Test now added.

Fixes #777

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [x] Documentation has been updated to reflect change.
- [x] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [x] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.

GitHub Copilot was used while making this change.