### PR TITLE
Preload plot images on web page

### DIFF
--- a/src/CSET/operators/_plot_page_template.html
+++ b/src/CSET/operators/_plot_page_template.html
@@ -102,8 +102,17 @@
             sequence_number.addEventListener("change", update_displayed_plot);
         }
 
+        // Ensure image is already in browser cache.
+        function preload_image(image_url) {
+            let img = new Image();
+            img.src = image_url;
+        }
+
         const plot_urls = {{plots}}
         display_sequence_controls(plot_urls);
+
+        // Preload plots so they appear as you slide.
+        plot_urls.forEach(preload_image);
     </script>
 </head>
 


### PR DESCRIPTION
This ensures that the slider slides smoothly, as the image can be served from the browser cache.

I used JavaScript rather than `<link rel="preload" as="image" href="...">` as it was much easier to implement, as we don't currently have any way to loop over the plots at template time. If this changes we may want to switch, as HTML is both more explicit, and also taxes the browser less due to not having to create a non-displayed image element. The browser also seems to have more conservative limits for rel=preload, so it won't do as many concurrent requests.

Fixes #780

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [ ] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
