### PR TITLE
Use pcolormesh for Quicklook surface spatial plots

### DIFF
--- a/src/CSET/recipes/generic_surface_spatial_plot_sequence.yaml
+++ b/src/CSET/recipes/generic_surface_spatial_plot_sequence.yaml
@@ -27,7 +27,7 @@ collate:
   - operator: read.read_cube
     filename_pattern: intermediate/*.nc
 
-  - operator: plot.spatial_contour_plot
+  - operator: plot.spatial_pcolormesh_plot
     sequence_coordinate: time
 
   - operator: write.write_cube_to_nc


### PR DESCRIPTION
It is significantly faster, and gives a better idea of resolution.

Depends on #787, so should be merged afterwards.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
