### PR TITLE
Create the plot index in finish_website to avoid a data race between concurrent index writers

### DIFF
--- a/src/CSET/_common.py
+++ b/src/CSET/_common.py
@@ -328,3 +328,20 @@ def iter_maybe(thing) -> Iterable:
     if isinstance(thing, Iterable) and not isinstance(thing, str):
         return thing
     return (thing,)
+
+
+def combine_dicts(d1: dict, d2: dict) -> dict:
+    """Recursively combines two dictionaries.
+
+    Duplicate atoms favour the second dictionary.
+    """
+    # Update existing keys.
+    for key in d1.keys() & d2.keys():
+        if isinstance(d1[key], dict):
+            d1[key] = combine_dicts(d1[key], d2[key])
+        else:
+            d1[key] = d2[key]
+    # Add any new keys.
+    for key in d2.keys() - d1.keys():
+        d1[key] = d2[key]
+    return d1

--- a/src/CSET/_workflow_utils/finish_website.py
+++ b/src/CSET/_workflow_utils/finish_website.py
@@ -21,7 +21,8 @@ logging.basicConfig(
 def construct_index():
     """Construct the plot index.
 
-    Index should has the form {"Category Name": {"recipe_id": "Plot Name"}}
+    Index should has the form ``{"Category Name": {"recipe_id": "Plot Name"}}``
+    where ``recipe_id`` is the name of the plot's directory.
     """
     index = {}
     plots_dir = Path(os.environ["CYLC_WORKFLOW_SHARE_DIR"] + "/web/plots")

--- a/src/CSET/_workflow_utils/finish_website.py
+++ b/src/CSET/_workflow_utils/finish_website.py
@@ -2,14 +2,58 @@
 
 """Write finished status to website front page.
 
-Does the final update to the workflow status on the front page of the web
-interface.
+Constructs the plot index, and does the final update to the workflow status on
+the front page of the web interface.
 """
 
+import json
+import logging
 import os
+from pathlib import Path
+
+from CSET._common import combine_dicts
+
+logging.basicConfig(
+    level=os.getenv("LOGLEVEL", "INFO"), format="%(asctime)s %(levelname)s %(message)s"
+)
+
+
+def construct_index():
+    """Construct the plot index.
+
+    Index should has the form {"Category Name": {"recipe_id": "Plot Name"}}
+    """
+    index = {}
+    plots_dir = Path(os.environ["CYLC_WORKFLOW_SHARE_DIR"] + "/web/plots")
+    # Loop over all directories, and append to index.
+    for directory in (d for d in plots_dir.iterdir() if d.is_dir()):
+        try:
+            with open(directory / "meta.json", "rt", encoding="UTF-8") as fp:
+                plot_metadata = json.load(fp)
+            record = {
+                plot_metadata["category"]: {directory.name: plot_metadata["title"]}
+            }
+        except FileNotFoundError:
+            # Skip directories without metadata, as are likely not plots.
+            logging.debug("No meta.json in %s, skipping.", directory)
+            continue
+        except (json.JSONDecodeError, KeyError, TypeError) as err:
+            logging.error("%s is invalid, skipping.\n%s", directory / "meta.json", err)
+            continue
+        index = combine_dicts(index, record)
+
+    with open(plots_dir / "index.json", "wt", encoding="UTF-8") as fp:
+        json.dump(index, fp)
+
+
+def update_workflow_status():
+    """Update the workflow status on the front page of the web interface."""
+    web_dir = Path(os.environ["CYLC_WORKFLOW_SHARE_DIR"] + "/web")
+    with open(web_dir / "status.html", "wt") as fp:
+        fp.write("<p>Finished</p>\n")
 
 
 def run():
-    """Run workflow script."""
-    with open(f"{os.getenv('WEB_DIR')}/status.html", "wt") as fp:
-        fp.write("<p>Finished</p>\n")
+    """Do the final steps to finish the website."""
+    construct_index()
+    update_workflow_status()

--- a/src/CSET/_workflow_utils/finish_website.py
+++ b/src/CSET/_workflow_utils/finish_website.py
@@ -27,6 +27,7 @@ def construct_index():
     index = {}
     plots_dir = Path(os.environ["CYLC_WORKFLOW_SHARE_DIR"] + "/web/plots")
     # Loop over all directories, and append to index.
+    # Only visits the directories directly under the plots directory.
     for directory in (d for d in plots_dir.iterdir() if d.is_dir()):
         try:
             with open(directory / "meta.json", "rt", encoding="UTF-8") as fp:

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -268,3 +268,11 @@ def test_iter_maybe_string():
     for value in created_iterable:
         # The same object is inside the iterable.
         assert value is atom
+
+
+def test_combine_dicts():
+    """Test combine_dicts function."""
+    d1 = {"a": 1, "b": 2, "c": {"d": 3, "e": 4}}
+    d2 = {"b": 3, "c": {"d": 5, "f": 6}}
+    expected = {"a": 1, "b": 3, "c": {"d": 5, "e": 4, "f": 6}}
+    assert common.combine_dicts(d1, d2) == expected

--- a/tests/workflow_utils/test_finish_website.py
+++ b/tests/workflow_utils/test_finish_website.py
@@ -90,6 +90,8 @@ def test_construct_index_invalid(monkeypatch, tmp_path, caplog):
 
 def test_entrypoint(monkeypatch):
     """Test running the finish_website module."""
+    # Count the number of times the other functions are run, to ensure they
+    # are both run.
     counter = 0
 
     def increment_counter():

--- a/tests/workflow_utils/test_run_cset_recipe.py
+++ b/tests/workflow_utils/test_run_cset_recipe.py
@@ -14,7 +14,6 @@
 
 """Tests for run_cset_recipe workflow utility."""
 
-import json
 import os
 import subprocess
 import zipfile
@@ -23,61 +22,6 @@ from pathlib import Path
 import pytest
 
 from CSET._workflow_utils import run_cset_recipe
-
-
-def test_combine_dicts():
-    """Test combine_dicts function."""
-    d1 = {"a": 1, "b": 2, "c": {"d": 3, "e": 4}}
-    d2 = {"b": 3, "c": {"d": 5, "f": 6}}
-    expected = {"a": 1, "b": 3, "c": {"d": 5, "e": 4, "f": 6}}
-    assert run_cset_recipe.combine_dicts(d1, d2) == expected
-
-
-def test_append_to_index(monkeypatch, tmp_path):
-    """Test appending to index."""
-    index_path = tmp_path / "web/plots/index.json"
-    index_path.parent.mkdir(parents=True)
-    monkeypatch.setenv("CYLC_WORKFLOW_SHARE_DIR", str(tmp_path))
-    with open(index_path, "wt", encoding="UTF-8") as fp:
-        json.dump(
-            {
-                "Category Name": {"recipe_id_a": "Title A"},
-                "Other Category": {"recipe_id_b": "Title B"},
-            },
-            fp,
-        )
-    record = {"Category Name": {"recipe_id": "Plot Name"}}
-    run_cset_recipe.append_to_index(record)
-    expected = {
-        "Category Name": {"recipe_id": "Plot Name", "recipe_id_a": "Title A"},
-        "Other Category": {"recipe_id_b": "Title B"},
-    }
-    with open(index_path, "rt", encoding="UTF-8") as fp:
-        assert json.load(fp) == expected
-
-
-def test_append_to_index_missing(monkeypatch, tmp_path):
-    """Test appending to index when index does not yet exist."""
-    index_path = tmp_path / "web/plots/index.json"
-    index_path.parent.mkdir(parents=True)
-    monkeypatch.setenv("CYLC_WORKFLOW_SHARE_DIR", str(tmp_path))
-    record = {"Category Name": {"recipe_id": "Plot Name"}}
-    run_cset_recipe.append_to_index(record)
-    with open(index_path, "rt", encoding="UTF-8") as fp:
-        assert json.load(fp) == record
-
-
-def test_append_to_index_invalid(monkeypatch, tmp_path):
-    """Test appending to index when existing content is invalid."""
-    index_path = tmp_path / "web/plots/index.json"
-    index_path.parent.mkdir(parents=True)
-    monkeypatch.setenv("CYLC_WORKFLOW_SHARE_DIR", str(tmp_path))
-    with open(index_path, "wt", encoding="UTF-8") as fp:
-        fp.write("Not JSON!")
-    record = {"Category Name": {"recipe_id": "Plot Name"}}
-    run_cset_recipe.append_to_index(record)
-    with open(index_path, "rt", encoding="UTF-8") as fp:
-        assert json.load(fp) == record
 
 
 def test_subprocess_env(monkeypatch):


### PR DESCRIPTION
This avoids a race condition if the file locking isn't working, such as on network filesystems, that causes plots to be missed from the index.

Fixes #614

Depends on #792

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [x] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [x] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.

GitHub Copilot was used this PR.