### PR TITLE
Stop ruff warning about ignore-init-module-imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,7 +132,6 @@ src = ["src", "test"]
 
 [tool.ruff.lint]
 extend-select = ["B", "D", "I"]
-ignore-init-module-imports = true
 
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"


### PR DESCRIPTION
This setting was deprecated, so we now no longer specify it. The default behavor is now the same as what the setting gave us.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
