### PR TITLE
Parsing of float in workflow

### DIFF
--- a/cset-workflow/includes/lfric_plot_spatial_mlevel_model_field.cylc
+++ b/cset-workflow/includes/lfric_plot_spatial_mlevel_model_field.cylc
@@ -2,13 +2,14 @@
 [runtime]
 {% for model_field in LFRIC_MODEL_LEVEL_MODEL_FIELDS %}
 {% for mlevel in LFRIC_MODEL_LEVELS %}
-    [[process_lfric_generic_mlevel_spatial_plot_sequence_{{model_field}}_{{mlevel}}]]
+    {% set formatted_level = mlevel|string|replace('.', 'p') %}
+    [[process_lfric_generic_mlevel_spatial_plot_sequence_{{model_field}}_{{formatted_level}}]]
     inherit = PARALLEL
         [[[environment]]]
         CSET_RECIPE_NAME = "lfric_generic_mlevel_spatial_plot_sequence.yaml"
         CSET_ADDOPTS = "--VARNAME='{{model_field}}' --MLEVEL='{{mlevel}}'"
 
-    [[collate_lfric_generic_mlevel_spatial_plot_sequence_{{model_field}}_{{mlevel}}]]
+    [[collate_lfric_generic_mlevel_spatial_plot_sequence_{{model_field}}_{{formatted_level}}]]
     inherit = COLLATE
         [[[environment]]]
         CSET_RECIPE_NAME = "lfric_generic_mlevel_spatial_plot_sequence.yaml"

--- a/cset-workflow/includes/plot_spatial_mlevel_model_field.cylc
+++ b/cset-workflow/includes/plot_spatial_mlevel_model_field.cylc
@@ -2,13 +2,14 @@
 [runtime]
 {% for model_field in MODEL_LEVEL_MODEL_FIELDS %}
 {% for mlevel in UM_MODEL_LEVELS %}
-    [[process_generic_mlevel_spatial_plot_sequence_{{model_field}}_{{mlevel}}]]
+    {% set formatted_level = mlevel|string|replace('.', 'p') %}
+    [[process_generic_mlevel_spatial_plot_sequence_{{model_field}}_{{formatted_level}}]]
     inherit = PARALLEL
         [[[environment]]]
         CSET_RECIPE_NAME = "generic_mlevel_spatial_plot_sequence.yaml"
         CSET_ADDOPTS = "--VARNAME='{{model_field}}' --MLEVEL='{{mlevel}}'"
 
-    [[collate_generic_mlevel_spatial_plot_sequence_{{model_field}}_{{mlevel}}]]
+    [[collate_generic_mlevel_spatial_plot_sequence_{{model_field}}_{{formatted_level}}]]
     inherit = COLLATE
         [[[environment]]]
         CSET_RECIPE_NAME = "generic_mlevel_spatial_plot_sequence.yaml"


### PR DESCRIPTION
Parsing a float into the workflow to generate the task name causes errors, as a period is not an acceptable character in the cylc workflow. This change parses the dot into a p for the workflow task names. 

There might be a more general solution we could apply though, as I expect this might crop up with other diagnostics/variable combinations in new recipes.

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [x] Documentation has been updated to reflect change.
- [x] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
