### PR TITLE
Upload hidden coverage files to fix GitHub Actions breakage

### DIFF
--- a/.github/workflows/pull_request_checks.yml
+++ b/.github/workflows/pull_request_checks.yml
@@ -51,6 +51,7 @@ jobs:
           name: coverage-data-${{ matrix.py-ver }}
           path: .coverage.*
           retention-days: 1
+          include-hidden-files: true
 
   coverage-report:
     if: github.event_name == 'pull_request'


### PR DESCRIPTION
Fixes #827

GitHub broke this when the changed it to no-longer upload hidden files by default, without bumping the major version. (https://github.com/actions/upload-artifact/issues/602) Reeee!

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
