### PR TITLE
Add colorbar entries for more standard names

### DIFF
--- a/cset-workflow/extra-meta/colorbar_dict_alphabetical.json
+++ b/cset-workflow/extra-meta/colorbar_dict_alphabetical.json
@@ -8,6 +8,11 @@
     "max": 104000,
     "min": 96000
   },
+  "air_temperature": {
+    "cmap": "jet",
+    "max": 320,
+    "min": 260
+  },
   "atmosphere_mass_content_of_cloud_ice": {
     "max": 0.5,
     "min": 0.0
@@ -116,14 +121,40 @@
     "max": 30.0,
     "min": -30.0
   },
+  "pressure": {
+    "max": 104000,
+    "min": 96000
+  },
   "radar_reflectivity_at_1km_above_the_surface": {
     "max": 50.0,
     "min": -50.0
   },
+  "relative_humidity": {
+    "cmap": "YlGnBu",
+    "max": 120,
+    "min": 20
+  },
   "relative_humidity_at_screen_level": {
     "cmap": "YlGnBu",
-    "max": 105.0,
-    "min": 30.0
+    "max": 120,
+    "min": 20
+  },
+  "straiform_rainfall_rate": {
+    "cmap": "jet",
+    "levels": [
+      0,
+      0.1,
+      0.25,
+      0.5,
+      1,
+      2,
+      4,
+      8,
+      16,
+      32,
+      64,
+      200
+    ]
   },
   "surface_downward_longwave_flux": {
     "max": 450,
@@ -234,5 +265,9 @@
   "wind_speed_at_10m": {
     "max": 30.0,
     "min": 0.0
+  },
+  "wind_speed_of_gust": {
+    "max": 60,
+    "min": 0
   }
 }


### PR DESCRIPTION
Adds entries for:
 * air_temperature
 * pressure
 * relative_humidity
 * wind_speed_of_gust

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
