### PR TITLE
Fix spelling of stratiform_rainfall_rate in colorbar definition

### DIFF
--- a/src/CSET/operators/_colorbar_definition.json
+++ b/src/CSET/operators/_colorbar_definition.json
@@ -139,7 +139,7 @@
     "max": 120,
     "min": 20
   },
-  "straiform_rainfall_rate": {
+  "stratiform_rainfall_rate": {
     "cmap": "jet",
     "levels": [
       0,


### PR DESCRIPTION
This ensures that the correct colorbar is used for plotting the rainfall.

Fixes #877

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
