### PR TITLE
Exclude __main__.py from test coverage measurement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ testpaths = ["tests"]
 branch = true
 relative_files = true
 source = ["src"]
+omit = ["__main__.py"]
 
 [tool.tox]
 legacy_tox_ini = '''


### PR DESCRIPTION
It can't be measured outside of an editable install, and doesn't contain any logic.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [x] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
