### PR TITLE
Add nicer error messages for unhandled exceptions

### DIFF
--- a/src/CSET/__init__.py
+++ b/src/CSET/__init__.py
@@ -26,7 +26,11 @@ from CSET._common import ArgumentError
 
 
 def main():
-    """CLI entrypoint."""
+    """CLI entrypoint.
+
+    Handles argument parsing, setting up logging, top level error capturing,
+    and execution of the desired subcommand.
+    """
     parser = argparse.ArgumentParser(
         prog="cset", description="Convective Scale Evaluation Tool"
     )
@@ -159,9 +163,18 @@ def main():
         # Execute the specified subcommand.
         args.func(args, unparsed_args)
     except ArgumentError as err:
-        logging.error(err)
+        # Error message for when needed template variables are missing.
+        print(err, file=sys.stderr)
         parser.print_usage()
-        sys.exit(3)
+        sys.exit(127)
+    except Exception as err:
+        # Provide slightly nicer error messages for unhandled exceptions.
+        print(err, file=sys.stderr)
+        # Display the time and full traceback when debug logging.
+        logging.debug("An unhandled exception occurred.")
+        if logging.root.isEnabledFor(logging.DEBUG):
+            raise
+        sys.exit(1)
 
 
 def calculate_loglevel(args) -> int:


### PR DESCRIPTION
This prevents the sudden wall of tracebacks when you have just typoed a file path. The full traceback is still output for DEBUG logging (-vv).

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [x] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
