### PR TITLE
Pin cartopy to v0.23.0

### DIFF
--- a/cset-workflow/requirements/environment.yml
+++ b/cset-workflow/requirements/environment.yml
@@ -8,3 +8,5 @@ dependencies:
   - pip
   - setuptools>=64
   - setuptools_scm>=8
+  # Needed before iris 3.11 is released.
+  - cartopy = 0.23.0

--- a/requirements/environment.yml
+++ b/requirements/environment.yml
@@ -12,6 +12,8 @@ dependencies:
   - isodate
   - markdown-it-py >= 3.0
   - nc-time-axis
+  # Needed before iris 3.11 is released.
+  - cartopy = 0.23.0
 
   # Build dependencies
   - setuptools>=64


### PR DESCRIPTION
Prevents crash due to incompatible iris patching, which is fixed in the unreleased iris 3.11.

This can be removed once iris 3.11 is released.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [ ] All tests and CI checks pass.
- [ ] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [ ] Marked the PR as ready to review.
