### PR TITLE
Changes to fix longitude convention to be in the range -180 degrees to 180 degrees where possible

### DIFF
--- a/src/CSET/operators/read.py
+++ b/src/CSET/operators/read.py
@@ -296,10 +296,11 @@ def _longitude_fix_callback(cube: iris.cube.Cube, field, filename):
     try:
         y, x = utils.get_cube_yxcoordname(cube)
     except ValueError:
+        # Don't modify non-spatial cubes.
         return cube
     long_coord = cube.coord(x)
     long_points = long_coord.points.copy()
-    long_centre = np.mean(long_points)
+    long_centre = np.median(long_points)
     while long_centre < -180.0:
         long_centre += 360.0
         long_points += 360.0

--- a/src/CSET/operators/regrid.py
+++ b/src/CSET/operators/regrid.py
@@ -290,14 +290,19 @@ def regrid_to_single_point(
     )
 
     # Check to see if selected point is outside the domain
-    if (
-        (lat_pt < lat_min)
-        or (lat_pt > lat_max)
-        or (lon_pt < lon_min)
-        or (lon_pt > lon_max)
-    ):
+    if (lat_pt < lat_min) or (lat_pt > lat_max):
         raise ValueError("Selected point is outside the domain.")
-    elif (
+    else:
+        if (lon_pt < lon_min) or (lon_pt > lon_max):
+            if (lon_pt + 360.0 >= lon_min) and (lon_pt + 360.0 <= lon_max):
+                lon_pt += 360.0
+            elif (lon_pt - 360.0 >= lon_min) and (lon_pt - 360.0 <= lon_max):
+                lon_pt -= 360.0
+            else:
+                raise ValueError("Selected point is outside the domain.")
+
+    # Check to see if selected point is near the domain boundaries
+    if (
         (lat_pt < lat_min_bound)
         or (lat_pt > lat_max_bound)
         or (lon_pt < lon_min_bound)

--- a/src/CSET/operators/regrid.py
+++ b/src/CSET/operators/regrid.py
@@ -218,9 +218,11 @@ def regrid_to_single_point(
         An iris cube of the data to regrid. As a minimum, it needs to be 2D with
         latitude, longitude coordinates.
     lon_pt: float
-        Selected value of longitude.
+        Selected value of longitude: this should be in the range -180 degrees to
+        180 degrees.
     lat_pt: float
-        Selected value of latitude.
+        Selected value of latitude: this should be in the range -90 degrees to
+        90 degrees.
     method: str
         Method used to determine the values at the selected longitude and
         latitude. The recommended approach is to use iris.analysis.Nearest(),

--- a/tests/operators/test_regrid.py
+++ b/tests/operators/test_regrid.py
@@ -224,14 +224,14 @@ def test_longitude_fix_callback_missing_coord(cube):
     # Missing X coordinate.
     source = cube.copy()
     source.remove_coord("grid_longitude")
-    with pytest.raises(ValueError):
-        read._longitude_fix_callback(source, None, None)
+    cube_fix = read._longitude_fix_callback(source, None, None)
+    assert cube_fix == source
 
     # Missing Y coordinate.
     source = cube.copy()
     source.remove_coord("grid_latitude")
-    with pytest.raises(ValueError):
-        read._longitude_fix_callback(source, None, None)
+    cube_fix = read._longitude_fix_callback(source, None, None)
+    assert cube_fix == source
 
 
 def test_regrid_to_single_point_unknown_crs_x(cube):

--- a/tests/operators/test_regrid.py
+++ b/tests/operators/test_regrid.py
@@ -171,7 +171,9 @@ def test_regrid_to_single_point_west(cube):
     # Test extracting a single point.
     # Test that the grid latitude rotation works when the
     # centre of the grid is too far west.
-    cube.coord("grid_longitude").points -= 720.0
+    long_coord = cube.coord("grid_longitude").points.copy()
+    long_coord -= 720.0
+    cube.coord("grid_longitude").points = long_coord
     regrid_cube = regrid.regrid_to_single_point(
         cube, 0.5, -1.5, "Nearest", boundary_margin=1
     )

--- a/tests/operators/test_regrid.py
+++ b/tests/operators/test_regrid.py
@@ -20,6 +20,7 @@ import iris.cube
 import numpy as np
 import pytest
 
+import CSET.operators.read as read
 import CSET.operators.regrid as regrid
 from CSET.operators.regrid import BoundaryWarning
 
@@ -174,8 +175,9 @@ def test_regrid_to_single_point_west(cube):
     long_coord = cube.coord("grid_longitude").points.copy()
     long_coord -= 720.0
     cube.coord("grid_longitude").points = long_coord
+    cube_fix = read._longitude_fix_callback(cube, None, None)
     regrid_cube = regrid.regrid_to_single_point(
-        cube, 0.5, -1.5, "Nearest", boundary_margin=1
+        cube_fix, 0.5, -1.5, "Nearest", boundary_margin=1
     )
     expected_cube = "<iris 'Cube' of air_temperature / (K) (time: 3)>"
     assert repr(regrid_cube) == expected_cube

--- a/tests/operators/test_regrid.py
+++ b/tests/operators/test_regrid.py
@@ -152,7 +152,34 @@ def test_regrid_onto_xyspacing_unknown_method(regrid_source_cube):
 
 
 @pytest.mark.filterwarnings("ignore:Selected point is within")
-def test_regrid_to_single_point(cube):
+def test_regrid_to_single_point_east(cube):
+    """Regrid to single point."""
+    # Test extracting a single point.
+    # Test that the grid latitude rotation works when the
+    # centre of the grid is too far east (note that the
+    # test cube, by default, is too far east, centred east
+    # of 180 deg).
+    regrid_cube = regrid.regrid_to_single_point(
+        cube, 0.5, -1.5, "Nearest", boundary_margin=1
+    )
+    expected_cube = "<iris 'Cube' of air_temperature / (K) (time: 3)>"
+    assert repr(regrid_cube) == expected_cube
+
+
+def test_regrid_to_single_point_west(cube):
+    """Regrid to single point."""
+    # Test extracting a single point.
+    # Test that the grid latitude rotation works when the
+    # centre of the grid is too far west.
+    cube.coord("grid_longitude").points -= 720.0
+    regrid_cube = regrid.regrid_to_single_point(
+        cube, 0.5, -1.5, "Nearest", boundary_margin=1
+    )
+    expected_cube = "<iris 'Cube' of air_temperature / (K) (time: 3)>"
+    assert repr(regrid_cube) == expected_cube
+
+
+def test_regrid_to_single_point_longitude_transform_1(cube):
     """Regrid to single point."""
     # Test extracting a single point.
     regrid_cube = regrid.regrid_to_single_point(
@@ -162,11 +189,11 @@ def test_regrid_to_single_point(cube):
     assert repr(regrid_cube) == expected_cube
 
 
-def test_regrid_to_single_point_longitude_transform(cube):
+def test_regrid_to_single_point_longitude_transform_2(cube):
     """Regrid to single point."""
     # Test extracting a single point.
     regrid_cube = regrid.regrid_to_single_point(
-        cube, 0.5, -1.5, "Nearest", boundary_margin=1
+        cube, 0.5, -361.5, "Nearest", boundary_margin=1
     )
     expected_cube = "<iris 'Cube' of air_temperature / (K) (time: 3)>"
     assert repr(regrid_cube) == expected_cube
@@ -203,10 +230,16 @@ def test_regrid_to_single_point_unknown_crs_y(cube):
         regrid.regrid_to_single_point(cube, 0.5, 358.5, "Nearest")
 
 
-def test_regrid_to_single_point_outside_domain(regrid_source_cube):
+def test_regrid_to_single_point_outside_domain_longitude(regrid_source_cube):
     """Error if coordinates are outside the model domain."""
     with pytest.raises(ValueError):
         regrid.regrid_to_single_point(regrid_source_cube, 0.5, 178.5, "Nearest")
+
+
+def test_regrid_to_single_point_outside_domain_latitude(regrid_source_cube):
+    """Error if coordinates are outside the model domain."""
+    with pytest.raises(ValueError):
+        regrid.regrid_to_single_point(regrid_source_cube, 80.5, 358.5, "Nearest")
 
 
 @pytest.mark.filterwarnings("ignore:Selected point is within")

--- a/tests/operators/test_regrid.py
+++ b/tests/operators/test_regrid.py
@@ -223,16 +223,15 @@ def test_longitude_fix_callback_missing_coord(cube):
     """Missing coordinate raises error."""
     # Missing X coordinate.
     source = cube.copy()
-    source.coord("grid_longitude").rename("west")
+    source.remove_coord("grid_longitude")
     with pytest.raises(ValueError):
         read._longitude_fix_callback(source, None, None)
 
-
-#    # Missing Y coordinate.
-#    source = cube.copy()
-#    source.coord("grid_latitude").rename("north")
-#    with pytest.raises(ValueError):
-#        read._longitude_fix_callback(source, None, None)
+    # Missing Y coordinate.
+    source = cube.copy()
+    source.remove_coord("grid_latitude")
+    with pytest.raises(ValueError):
+        read._longitude_fix_callback(source, None, None)
 
 
 def test_regrid_to_single_point_unknown_crs_x(cube):

--- a/tests/operators/test_regrid.py
+++ b/tests/operators/test_regrid.py
@@ -219,6 +219,21 @@ def test_regrid_to_single_point_missing_coord(cube):
         regrid.regrid_to_single_point(source, 0.5, 358.5, "Nearest")
 
 
+def test_longitude_fix_callback_missing_coord(cube):
+    """Missing coordinate raises error."""
+    # Missing X coordinate.
+    source = cube.copy()
+    source.coord("grid_longitude").rename("west")
+    with pytest.raises(ValueError):
+        read._longitude_fix_callback(source, None, None)
+
+    # Missing Y coordinate.
+    source = cube.copy()
+    source.coord("grid_latitude").rename("north")
+    with pytest.raises(ValueError):
+        read._longitude_fix_callback(source, None, None)
+
+
 def test_regrid_to_single_point_unknown_crs_x(cube):
     """X coordinate reference system is unrecognised."""
     # Exchange to unsupported coordinate system.

--- a/tests/operators/test_regrid.py
+++ b/tests/operators/test_regrid.py
@@ -160,8 +160,9 @@ def test_regrid_to_single_point_east(cube):
     # centre of the grid is too far east (note that the
     # test cube, by default, is too far east, centred east
     # of 180 deg).
+    cube_fix = read._longitude_fix_callback(cube, None, None)
     regrid_cube = regrid.regrid_to_single_point(
-        cube, 0.5, -1.5, "Nearest", boundary_margin=1
+        cube_fix, 0.5, -1.5, "Nearest", boundary_margin=1
     )
     expected_cube = "<iris 'Cube' of air_temperature / (K) (time: 3)>"
     assert repr(regrid_cube) == expected_cube

--- a/tests/operators/test_regrid.py
+++ b/tests/operators/test_regrid.py
@@ -227,11 +227,12 @@ def test_longitude_fix_callback_missing_coord(cube):
     with pytest.raises(ValueError):
         read._longitude_fix_callback(source, None, None)
 
-    # Missing Y coordinate.
-    source = cube.copy()
-    source.coord("grid_latitude").rename("north")
-    with pytest.raises(ValueError):
-        read._longitude_fix_callback(source, None, None)
+
+#    # Missing Y coordinate.
+#    source = cube.copy()
+#    source.coord("grid_latitude").rename("north")
+#    with pytest.raises(ValueError):
+#        read._longitude_fix_callback(source, None, None)
 
 
 def test_regrid_to_single_point_unknown_crs_x(cube):

--- a/tests/operators/test_regrid.py
+++ b/tests/operators/test_regrid.py
@@ -155,7 +155,19 @@ def test_regrid_onto_xyspacing_unknown_method(regrid_source_cube):
 def test_regrid_to_single_point(cube):
     """Regrid to single point."""
     # Test extracting a single point.
-    regrid_cube = regrid.regrid_to_single_point(cube, 0.5, 358.5, "Nearest")
+    regrid_cube = regrid.regrid_to_single_point(
+        cube, 0.5, 358.5, "Nearest", boundary_margin=1
+    )
+    expected_cube = "<iris 'Cube' of air_temperature / (K) (time: 3)>"
+    assert repr(regrid_cube) == expected_cube
+
+
+def test_regrid_to_single_point_longitude_transform(cube):
+    """Regrid to single point."""
+    # Test extracting a single point.
+    regrid_cube = regrid.regrid_to_single_point(
+        cube, 0.5, -1.5, "Nearest", boundary_margin=1
+    )
     expected_cube = "<iris 'Cube' of air_temperature / (K) (time: 3)>"
     assert repr(regrid_cube) == expected_cube
 
@@ -166,7 +178,7 @@ def test_regrid_to_single_point_missing_coord(cube):
     source = cube.copy()
     source.remove_coord("grid_longitude")
     with pytest.raises(ValueError):
-        regrid.regrid_to_single_point(source, 0.5, 358.5, "Nearest", boundary_margin=0)
+        regrid.regrid_to_single_point(source, 0.5, 358.5, "Nearest", boundary_margin=1)
 
     # Missing Y coordinate.
     source = cube.copy()

--- a/tests/operators/test_regrid.py
+++ b/tests/operators/test_regrid.py
@@ -152,14 +152,13 @@ def test_regrid_onto_xyspacing_unknown_method(regrid_source_cube):
         )
 
 
-@pytest.mark.filterwarnings("ignore:Selected point is within")
 def test_regrid_to_single_point_east(cube):
-    """Regrid to single point."""
-    # Test extracting a single point.
-    # Test that the grid latitude rotation works when the
-    # centre of the grid is too far east (note that the
-    # test cube, by default, is too far east, centred east
-    # of 180 deg).
+    """Test extracting a single point.
+
+    Test that the grid latitude rotation works when the
+    centre of the grid is too far east (that is, the centre
+    of the longitude range is further east than 180 deg).
+    """
     cube_fix = read._longitude_fix_callback(cube, None, None)
     regrid_cube = regrid.regrid_to_single_point(
         cube_fix, 0.5, -1.5, "Nearest", boundary_margin=1
@@ -169,10 +168,12 @@ def test_regrid_to_single_point_east(cube):
 
 
 def test_regrid_to_single_point_west(cube):
-    """Regrid to single point."""
-    # Test extracting a single point.
-    # Test that the grid latitude rotation works when the
-    # centre of the grid is too far west.
+    """Test extracting a single point.
+
+    Test that the grid latitude rotation works when the
+    centre of the grid is too far west (that is, the centre
+    of the longitude range is further west than -180 deg).
+    """
     long_coord = cube.coord("grid_longitude").points.copy()
     long_coord -= 720.0
     cube.coord("grid_longitude").points = long_coord
@@ -185,8 +186,12 @@ def test_regrid_to_single_point_west(cube):
 
 
 def test_regrid_to_single_point_longitude_transform_1(cube):
-    """Regrid to single point."""
-    # Test extracting a single point.
+    """Test extracting a single point.
+
+    Test that, if a longitude selection is made that is too
+    far east (further east than 180 deg), the code corrects it
+    back into the standard range (-180 deg to 180 deg).
+    """
     regrid_cube = regrid.regrid_to_single_point(
         cube, 0.5, 358.5, "Nearest", boundary_margin=1
     )
@@ -195,8 +200,12 @@ def test_regrid_to_single_point_longitude_transform_1(cube):
 
 
 def test_regrid_to_single_point_longitude_transform_2(cube):
-    """Regrid to single point."""
-    # Test extracting a single point.
+    """Test extracting a single point.
+
+    Test that, if a longitude selection is made that is too
+    far west (further west than -180 deg), the code corrects it
+    back into the standard range (-180 deg to 180 deg).
+    """
     regrid_cube = regrid.regrid_to_single_point(
         cube, 0.5, -361.5, "Nearest", boundary_margin=1
     )
@@ -224,13 +233,13 @@ def test_longitude_fix_callback_missing_coord(cube):
     # Missing X coordinate.
     source = cube.copy()
     source.remove_coord("grid_longitude")
-    cube_fix = read._longitude_fix_callback(source, None, None)
+    cube_fix = read._longitude_fix_callback(source.copy(), None, None)
     assert cube_fix == source
 
     # Missing Y coordinate.
     source = cube.copy()
     source.remove_coord("grid_latitude")
-    cube_fix = read._longitude_fix_callback(source, None, None)
+    cube_fix = read._longitude_fix_callback(source.copy(), None, None)
     assert cube_fix == source
 
 


### PR DESCRIPTION
This Pull Request is to merge in the changes in the branch associated with Issue #879. The aim is to deal with issues with incompatibility with longitude co-ordinates and ensure that, as far as possible, longitude co-ordinates and selected longitudes are in the range -180 degrees to 180 degrees.

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [x] Documentation has been updated to reflect change.
- [x] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [x] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
