### PR TITLE
Disable strict checking that TLS certificates are well formed

### DIFF
--- a/src/CSET/_workflow_utils/fetch_data.py
+++ b/src/CSET/_workflow_utils/fetch_data.py
@@ -123,6 +123,8 @@ class HTTPFileRetriever(FileRetrieverABC):
             True if files were transferred, otherwise False.
         """
         ctx = ssl.create_default_context()
+        # Needed to enable compatibility with malformed iBoss TLS certificates.
+        ctx.verify_flags &= ~ssl.VERIFY_X509_STRICT
         save_path = (
             f"{output_dir.removesuffix('/')}/"
             + urllib.parse.urlparse(file_path).path.split("/")[-1]


### PR DESCRIPTION
This restores compatibility with the iBoss TLS interception certificate that the Met Office is using. There is an upstream ticket open to get this certificate well formed, after which we can remove this line.

Fixes #903

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
