### PR TITLE
Autofix: Disable strict checking that TLS certificates are well formed

### DIFF
--- a/requirements/environment.yml
+++ b/requirements/environment.yml
@@ -5,6 +5,8 @@ dependencies:
   # Runtime dependencies
   - numpy
   - iris >= 3.5
+  - certifi < 2024.5
+  - iris >= 3.5
   - ruamel.yaml >= 0.17
   - mo_pack # For handling pp files.
   - pygraphviz


### PR DESCRIPTION
This change restores compatibility with the iBoss TLS interception certificate that the Met Office is using. There is an upstream ticket open to get this certificate well formed, after which we can remove this line. This fixes issue #903. 
> [!CAUTION]
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!
>
> The fix provided by Latta AI might not be complete and it can serve as an inspiration.

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission

If you no longer want Latta AI to attempt fixing issues on your repository, you can block this account.
    