### PR TITLE
Use non-interactive backend for plotting

### DIFF
--- a/src/CSET/operators/plot.py
+++ b/src/CSET/operators/plot.py
@@ -36,6 +36,9 @@ from markdown_it import MarkdownIt
 from CSET._common import get_recipe_metadata, render_file, slugify
 from CSET.operators._utils import get_cube_yxcoordname, is_transect
 
+# Use a non-interactive plotting backend.
+mpl.use("agg")
+
 ############################
 # Private helper functions #
 ############################


### PR DESCRIPTION
By default matplotlib tries to use an interactive backend for plotting. This is not only less efficient, but it also causes issues when running on non-GUI systems. We don't need it, so we can explicitly use a non- interactive backend.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
