### PR TITLE
Add iris-grib library support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "isodate",
     "markdown-it-py >= 3.0",
     "nc-time-axis",
+    "iris-grib",
 ]
 
 [project.urls]

--- a/requirements/environment.yml
+++ b/requirements/environment.yml
@@ -12,6 +12,7 @@ dependencies:
   - isodate
   - markdown-it-py >= 3.0
   - nc-time-axis
+  - iris-grib
 
   # Build dependencies
   - setuptools>=64


### PR DESCRIPTION
A lot of AI data is written in grib, which is a WMO standard format. We need the iris-grib library to support loading these files.

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [ ] All tests and CI checks pass.
- [ ] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [ ] Marked the PR as ready to review.
