### PR TITLE
Revert "Add iris-grib to dev dependencies"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ dependencies = [
     "isodate",
     "markdown-it-py >= 3.0",
     "nc-time-axis",
-    "iris-grib",
 ]
 
 [project.urls]

--- a/requirements/environment.yml
+++ b/requirements/environment.yml
@@ -12,7 +12,6 @@ dependencies:
   - isodate
   - markdown-it-py >= 3.0
   - nc-time-axis
-  - iris-grib
 
   # Build dependencies
   - setuptools>=64


### PR DESCRIPTION
This reverts commit d5c1bf0ee77a6d111a6822983cef79005504fb83.

For whatever reason the eccodes package fails to download on Met Office systems. This will require futher investigation, but backing out for now so it doesn't block building the conda environment from the main branch.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [ ] All tests and CI checks pass.
- [ ] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [ ] Marked the PR as ready to review.
