### PR TITLE
Documentation update for mask operator

### DIFF
--- a/src/CSET/operators/filters.py
+++ b/src/CSET/operators/filters.py
@@ -38,11 +38,8 @@ def apply_mask(
 
     Returns
     -------
-    A masked field.
-
-    Return type
-    -----------
-    iris.cube.Cube
+    masked_field: iris.cube.Cube
+        A cube of the masked field.
 
     Notes
     -----


### PR DESCRIPTION
Formatting for the apply_mask operator in the documentation was wrong. A quick fix is applied.

Fixes #989

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [x] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [ ] All tests and CI checks pass.
- [ ] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [ ] Marked the PR as ready to review.
