### PR TITLE
Fix location of AOA docs

### DIFF
--- a/docs/source/reference/operators.rst
+++ b/docs/source/reference/operators.rst
@@ -86,7 +86,6 @@ CSET.operators.mesoscale
 .. automodule:: CSET.operators.mesoscale
    :members:
 
-
 Other
 ~~~~~
 


### PR DESCRIPTION
Age of air documentation was listed under the convection section. But is an operator that doesn't really have a specific category as it is used to determine domain properties, not tied to a specific weather process.

Fixes #988 

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [X] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [ ] All tests and CI checks pass.
- [ ] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [ ] Marked the PR as ready to review.
