### PR TITLE
Latitude/Longitude lines and set_extent fix

### DIFF
--- a/src/CSET/operators/plot.py
+++ b/src/CSET/operators/plot.py
@@ -23,6 +23,7 @@ import math
 import sys
 from typing import Literal
 
+import cartopy.crs as ccrs
 import iris
 import iris.coords
 import iris.cube
@@ -266,8 +267,20 @@ def _plot_and_save_spatial_plot(
                 np.max(cube.coord(lonaxis).points),
                 np.min(cube.coord(lataxis).points),
                 np.max(cube.coord(lataxis).points),
-            ]
+            ],
+            crs=ccrs.PlateCarree(),
         )
+
+        gl = axes.gridlines(
+            crs=ccrs.PlateCarree(),
+            draw_labels=True,
+            linewidth=0.5,
+            color="gray",
+            alpha=0.5,
+            linestyle="--",
+        )
+        gl.top_labels = False
+        gl.right_labels = False
     except ValueError:
         # Skip if no x and y map coordinates.
         pass


### PR DESCRIPTION
Addresses #930 by adding latitude/longitude contours to spatial maps if spatial map.
Also fixes issue where set_extent does not work properly, by passing it the map projection.

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [ ] All tests and CI checks pass.
- [ ] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [ ] Marked the PR as ready to review.
