### PR TITLE
Remove unneeded `name` global attribute

### DIFF
--- a/src/CSET/operators/read.py
+++ b/src/CSET/operators/read.py
@@ -280,7 +280,7 @@ def _lfric_normalise_callback(cube: iris.cube.Cube, field, filename):
     # Remove unwanted attributes.
     cube.attributes.pop("timeStamp", None)
     cube.attributes.pop("uuid", None)
-    # There might also be a "name" attribute to ditch, which is the filename.
+    cube.attributes.pop("name", None)
 
     # Sort STASH code list.
     stash_list = cube.attributes.get("um_stash_source")


### PR DESCRIPTION
When XIOS outputs LFRic to seperate streams, it requires there to be a global name attribute on the cube, containing the filename. As this attribute will be different between the different files, preventing merging, we need to remove it during data loading.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
