### PR TITLE
Require tasks to succeed in DEBUG mode

### DIFF
--- a/cset-workflow/flow.cylc
+++ b/cset-workflow/flow.cylc
@@ -40,14 +40,14 @@ URL = https://metoffice.github.io/CSET
         {% for date in CSET_CASE_DATES %}
             R1/{{date}} = """
             setup_complete[^] => FETCH_DATA:succeed-all => fetch_complete
-            fetch_complete => PROCESS:finish-all => housekeeping_raw
+            fetch_complete => PROCESS:{% if LOGLEVEL == "DEBUG" %}succeed-all{% else %}finish-all{% endif %} => housekeeping_raw
             """
         {% endfor %}
     {% elif CSET_CYCLING_MODE == "trial" %}
         # Analyse from each forecast.
         {{CSET_TRIAL_CYCLE_PERIOD}} = """
         setup_complete[^] => FETCH_DATA:succeed-all => fetch_complete
-        fetch_complete => PROCESS:finish-all => housekeeping_raw
+        fetch_complete => PROCESS:{% if LOGLEVEL == "DEBUG" %}succeed-all{% else %}finish-all{% endif %} => housekeeping_raw
         """
     {% endif %}
 

--- a/cset-workflow/meta/rose-meta.conf
+++ b/cset-workflow/meta/rose-meta.conf
@@ -13,6 +13,8 @@ title=Logging level
 description=How detailed the logs should be.
 help=INFO only shows a general overview of what is happening, while DEBUG
     enables in-operator logging, but produces a lot of output.
+
+    DEBUG log level also causes failed tasks to hold the workflow.
 values="INFO", "DEBUG"
 value-titles=Info, Debug
 compulsory=true


### PR DESCRIPTION
This makes debugging the workflow easier, without causing other runs to block on a single failed task.

Fixes #327

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [x] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
