### PR TITLE
Add attribute constraint operator

### DIFF
--- a/src/CSET/operators/constraints.py
+++ b/src/CSET/operators/constraints.py
@@ -291,3 +291,33 @@ def combine_constraints(
     for constr in kwargs.values():
         combined_constraint = combined_constraint & constr
     return combined_constraint
+
+
+def generate_attribute_constraint(
+    attribute: str, value: str = None, **kwargs
+) -> iris.AttributeConstraint:
+    """Generate constraint on cube attributes.
+
+    Constrains based on the presence of an attribute, and that attribute having
+    a particular value.
+
+    Arguments
+    ---------
+    attribute: str
+        Attribute to constraint on.
+
+    value: str
+        Attribute value to constrain on. If omitted the constraint merely checks
+        for the presence of an attribute.
+
+    Returns
+    -------
+    attribute_constraint: iris.Constraint
+    """
+    if value is None:
+        attribute_constraint = iris.Constraint(
+            cube_func=lambda cube: attribute in cube.attributes
+        )
+    else:
+        attribute_constraint = iris.AttributeConstraint(**{attribute: value})
+    return attribute_constraint


### PR DESCRIPTION
Allows constraining on the presence and value of cube attributes.

Will need tests before being merged.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [ ] All tests and CI checks pass.
- [ ] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [ ] Marked the PR as ready to review.
