### PR TITLE
Reduce useless log messages

### DIFF
--- a/src/CSET/__init__.py
+++ b/src/CSET/__init__.py
@@ -206,9 +206,20 @@ def setup_logging(verbosity: int):
     logger = logging.getLogger()
     # Record everything at least INFO for the log file.
     logger.setLevel(min(loglevel, logging.INFO))
+    # Hide matplotlib's many font messages.
+    logger.addFilter(
+        lambda record: not (
+            isinstance(record, str) and record.msg.startswith("findfont:")
+        )
+    )
     stderr_log = logging.StreamHandler()
     # Filter stderr log to just what is requested.
     stderr_log.addFilter(lambda record: record.levelno >= loglevel)
+    stderr_log.addFilter(
+        lambda record: not (
+            isinstance(record, str) and record.msg.startswith("findfont:")
+        )
+    )
     stderr_log.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(message)s"))
     logger.addHandler(stderr_log)
 

--- a/src/CSET/operators/read.py
+++ b/src/CSET/operators/read.py
@@ -15,6 +15,7 @@
 """Operators for reading various types of files from disk."""
 
 import ast
+import functools
 import logging
 import warnings
 from collections.abc import Iterable
@@ -247,6 +248,12 @@ def _deterministic_callback(cube, field, filename):
         )
 
 
+@functools.lru_cache(10)
+def _warn_once(msg):
+    """Print a warning message, skipping recent duplicates."""
+    logging.warning(msg)
+
+
 def _um_normalise_callback(cube: iris.cube.Cube, field, filename):
     """Normalise UM STASH variable long names to LFRic variable names.
 
@@ -260,10 +267,10 @@ def _um_normalise_callback(cube: iris.cube.Cube, field, filename):
             (name, grid) = STASH_TO_LFRIC[str(stash)]
             cube.long_name = name
         except KeyError:
-            logging.warning("Unknown STASH code: %s", stash)
-            logging.warning("Please check file stash_to_lfric.py to update.")
             # Don't change cubes with unknown stash codes.
-            pass
+            _warn_once(
+                f"Unknown STASH code: {stash}. Please check file stash_to_lfric.py to update."
+            )
 
 
 def _lfric_normalise_callback(cube: iris.cube.Cube, field, filename):


### PR DESCRIPTION
This limits warnings about unknown STASH codes to one per stash code, and filters out the list of fonts that matplotlib loves to log.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
