### PR TITLE
Replace all remaining usage of typing.Union with `|`

### DIFF
--- a/src/CSET/_common.py
+++ b/src/CSET/_common.py
@@ -21,7 +21,6 @@ import logging
 import re
 from collections.abc import Iterable
 from pathlib import Path
-from typing import Union
 
 import ruamel.yaml
 
@@ -30,7 +29,7 @@ class ArgumentError(ValueError):
     """Provided arguments are not understood."""
 
 
-def parse_recipe(recipe_yaml: Union[Path, str], variables: dict = None) -> dict:
+def parse_recipe(recipe_yaml: Path | str, variables: dict = None) -> dict:
     """Parse a recipe into a python dictionary.
 
     Parameters
@@ -184,7 +183,7 @@ def parse_variable_options(arguments: list[str]) -> dict:
     return recipe_variables
 
 
-def template_variables(recipe: Union[dict, list], variables: dict) -> dict:
+def template_variables(recipe: dict | list, variables: dict) -> dict:
     """Insert variables into recipe.
 
     Parameters

--- a/src/CSET/graph.py
+++ b/src/CSET/graph.py
@@ -19,7 +19,6 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
-from typing import Union
 from uuid import uuid4
 
 import pygraphviz
@@ -28,7 +27,7 @@ from CSET._common import parse_recipe
 
 
 def save_graph(
-    recipe_file: Union[Path, str],
+    recipe_file: Path | str,
     save_path: Path = None,
     auto_open: bool = False,
     detailed: bool = False,

--- a/src/CSET/operators/__init__.py
+++ b/src/CSET/operators/__init__.py
@@ -19,7 +19,6 @@ import json
 import logging
 import os
 from pathlib import Path
-from typing import Union
 
 from iris import FUTURE
 
@@ -182,7 +181,7 @@ def _run_steps(
 
 
 def execute_recipe(
-    recipe_yaml: Union[Path, str],
+    recipe_yaml: Path | str,
     input_directory: Path,
     output_directory: Path,
     recipe_variables: dict = None,
@@ -193,9 +192,9 @@ def execute_recipe(
 
     Parameters
     ----------
-    recipe_yaml: Path or str
-        Path to a file containing, or string of, a recipe's YAML describing the
-        operators that need running. If a Path is provided it is opened and
+    recipe_yaml: Path | str
+        Path to a file containing, or a string of, a recipe's YAML describing
+        the operators that need running. If a Path is provided it is opened and
         read.
     input_directory: Path
         Pathlike to directory containing input files.

--- a/src/CSET/operators/collapse.py
+++ b/src/CSET/operators/collapse.py
@@ -15,7 +15,6 @@
 """Operators to perform various kind of collapse on either 1 or 2 dimensions."""
 
 import warnings
-from typing import Union
 
 import iris
 import iris.analysis
@@ -24,7 +23,7 @@ import iris.cube
 
 def collapse(
     cube: iris.cube.Cube,
-    coordinate: Union[str, list[str]],
+    coordinate: str | list[str],
     method: str,
     additional_percent: float = None,
     **kwargs,

--- a/src/CSET/operators/filters.py
+++ b/src/CSET/operators/filters.py
@@ -15,7 +15,6 @@
 """Operators to perform various kind of filtering."""
 
 import logging
-from typing import Union
 
 import iris
 import iris.cube
@@ -67,7 +66,7 @@ def apply_mask(
 
 
 def filter_cubes(
-    cube: Union[iris.cube.Cube, iris.cube.CubeList],
+    cube: iris.cube.Cube | iris.cube.CubeList,
     constraint: iris.Constraint,
     **kwargs,
 ) -> iris.cube.Cube:
@@ -104,7 +103,7 @@ def filter_cubes(
 
 
 def filter_multiple_cubes(
-    cubes: Union[iris.cube.Cube, iris.cube.CubeList],
+    cubes: iris.cube.Cube | iris.cube.CubeList,
     **kwargs,
 ) -> iris.cube.CubeList:
     """Filter a CubeList on multiple constraints, returning another CubeList.

--- a/src/CSET/operators/misc.py
+++ b/src/CSET/operators/misc.py
@@ -16,7 +16,6 @@
 
 import itertools
 from collections.abc import Iterable
-from typing import Union
 
 from iris.cube import Cube, CubeList
 
@@ -42,7 +41,7 @@ def noop(x, **kwargs):
 
 
 def remove_attribute(
-    cubes: Union[Cube, CubeList], attribute: Union[str, Iterable], **kwargs
+    cubes: Cube | CubeList, attribute: str | Iterable, **kwargs
 ) -> CubeList:
     """Remove a cube attribute.
 

--- a/src/CSET/operators/write.py
+++ b/src/CSET/operators/write.py
@@ -16,7 +16,6 @@
 
 import secrets
 from pathlib import Path
-from typing import Union
 
 import iris
 import iris.cube
@@ -25,7 +24,7 @@ from CSET._common import get_recipe_metadata, slugify
 
 
 def write_cube_to_nc(
-    cube: Union[iris.cube.Cube, iris.cube.CubeList],
+    cube: iris.cube.Cube | iris.cube.CubeList,
     filename: str = None,
     overwrite: bool = False,
     **kwargs,


### PR DESCRIPTION
This syntax has been available since python 3.9, which is beyond our minimum supported version of python 3.10, therefore it can all be removed.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
