### PR TITLE
Use "spawn" start method for multiprocessing

### DIFF
--- a/src/CSET/operators/ageofair.py
+++ b/src/CSET/operators/ageofair.py
@@ -404,6 +404,10 @@ def compute_ageofair(
     logging.info("STARTING AOA DIAG...")
     start = datetime.datetime.now()
 
+    # Use "spawn" method to avoid warnings before the default is changed in
+    # python 3.14. See the (not very good) warning here:
+    # https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods
+    mp_context = multiprocessing.get_context("spawn")
     # Main call for calculating age of air diagnostic
     if ensemble_mode:
         for e in range(0, len(XWIND.coord("realization").points)):
@@ -425,7 +429,7 @@ def compute_ageofair(
                 tmpdir.name,
             )
             if multicore:
-                with multiprocessing.Pool(num_usable_cores) as pool:
+                with mp_context.Pool(num_usable_cores) as pool:
                     pool.map(func, range(0, XWIND.shape[4]))
             else:
                 # Convert to list to ensure everything is processed.
@@ -452,7 +456,7 @@ def compute_ageofair(
             tmpdir.name,
         )
         if multicore:
-            with multiprocessing.Pool(num_usable_cores) as pool:
+            with mp_context.Pool(num_usable_cores) as pool:
                 pool.map(func, range(0, XWIND.shape[3]))
         else:
             # Convert to list to ensure everything is processed.


### PR DESCRIPTION
This avoids potential issues caused by mixing forking and threading in the same process. The default for multiprocessing will be changed to "spawn" in python 3.14.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
