### PR TITLE
Use CSET read operator to load test data, and improve various fragile tests

### DIFF
--- a/src/CSET/operators/_utils.py
+++ b/src/CSET/operators/_utils.py
@@ -232,7 +232,7 @@ def ensure_aggregatable_across_cases(
     ---------
     cube: iris.cube.Cube | iris.cube.CubeList
         If a Cube is provided it is checked to determine if it has the
-        the necessary dimensional coordinates to be aggregateable.
+        the necessary dimensional coordinates to be aggregatable.
         These necessary coordinates are 'forecast_period' and
         'forecast_reference_time'.If a CubeList is provided a Cube is created
         by slicing over all time coordinates and the resulting list is merged

--- a/src/CSET/operators/convection.py
+++ b/src/CSET/operators/convection.py
@@ -23,8 +23,6 @@ import copy
 import logging
 import warnings
 
-import iris
-import iris.cube
 import numpy as np
 
 
@@ -199,10 +197,10 @@ def inflow_layer_properties(EIB, BLheight, Orography):
     interpretation of CAPE related diagnostics.
 
     You might encounter warnings with the following text ``Orography assumed not
-    to vary with time or ensemble member.`` or ``Orography assumed not to vary
-    with time and ensemble member.`` these warnings are expected when the
-    orography files are not 2-dimensional, and do not cause any problems unless
-    ordering is not as expected.
+    to vary with ensemble member.`` or ``Orography assumed not to vary with time
+    and ensemble member.`` these warnings are expected when the orography files
+    are not 2-dimensional, and do not cause any problems unless ordering is not
+    as expected.
 
     References
     ----------
@@ -229,11 +227,8 @@ def inflow_layer_properties(EIB, BLheight, Orography):
     EC_Flagd = np.zeros(EIB.shape)
     # Check dimensions for Orography cube and replace with 2D array if not 2D.
     if Orography.ndim == 3:
-        try:
-            Orography = Orography.slices_over("realization").next()
-        except iris.exceptions.CoordinateNotFoundError:
-            Orography = Orography.slices_over("time").next()
-        logging.warning("Orography assumed not to vary with time or ensemble member")
+        Orography = Orography.slices_over("realization").next()
+        logging.warning("Orography assumed not to vary with ensemble member")
     elif Orography.ndim == 4:
         Orography = Orography.slices_over(("time", "realization")).next()
         logging.warning("Orography assumed not to vary with time or ensemble member. ")

--- a/src/CSET/operators/read.py
+++ b/src/CSET/operators/read.py
@@ -339,8 +339,9 @@ def _lfric_time_coord_fix_callback(cube: iris.cube.Cube, field, filename):
     # always ends up as an AuxCoord.
     if cube.coords("time"):
         time_coord = cube.coord("time")
-        if not isinstance(time_coord, iris.coords.DimCoord) and cube.coord_dims(
-            time_coord
+        if (
+            not isinstance(time_coord, iris.coords.DimCoord)
+            and len(cube.coord_dims(time_coord)) == 1
         ):
             iris.util.promote_aux_coord_to_dim_coord(cube, time_coord)
 

--- a/tests/operators/test_ageofair.py
+++ b/tests/operators/test_ageofair.py
@@ -19,25 +19,25 @@ import iris.cube
 import numpy as np
 import pytest
 
-import CSET.operators.ageofair as ageofair
+from CSET.operators import ageofair, read
 
 
 @pytest.fixture()
 def xwind() -> iris.cube.Cube:
     """Get regridded xwind to run tests on."""
-    return iris.load_cube("tests/test_data/ageofair/aoa_in_rgd.nc", "x_wind")
+    return read.read_cube("tests/test_data/ageofair/aoa_in_rgd.nc", "x_wind")
 
 
 @pytest.fixture()
 def ywind() -> iris.cube.Cube:
     """Get regridded ywind to run tests on."""
-    return iris.load_cube("tests/test_data/ageofair/aoa_in_rgd.nc", "y_wind")
+    return read.read_cube("tests/test_data/ageofair/aoa_in_rgd.nc", "y_wind")
 
 
 @pytest.fixture()
 def wwind() -> iris.cube.Cube:
     """Get regridded wwind to run tests on."""
-    return iris.load_cube(
+    return read.read_cube(
         "tests/test_data/ageofair/aoa_in_rgd.nc", "upward_air_velocity"
     )
 
@@ -45,7 +45,7 @@ def wwind() -> iris.cube.Cube:
 @pytest.fixture()
 def geopot() -> iris.cube.Cube:
     """Get regridded geopotential height to run tests on."""
-    return iris.load_cube(
+    return read.read_cube(
         "tests/test_data/ageofair/aoa_in_rgd.nc", "geopotential_height"
     )
 
@@ -53,13 +53,13 @@ def geopot() -> iris.cube.Cube:
 @pytest.fixture()
 def ens_regridded() -> iris.cube.CubeList:
     """Get regridded ensemble cubelist to run tests on."""
-    return iris.load("tests/test_data/ageofair/aoa_in_ens.nc")
+    return read.read_cubes("tests/test_data/ageofair/aoa_in_ens.nc")
 
 
 @pytest.fixture()
 def ens_regridded_out() -> iris.cube.Cube:
     """Get age of air ensemble output to check results are consistent."""
-    return iris.load_cube("tests/test_data/ageofair/aoa_out_ens.nc")
+    return read.read_cube("tests/test_data/ageofair/aoa_out_ens.nc")
 
 
 def test_calc_dist():
@@ -83,7 +83,7 @@ def test_aoa_nocyclic(xwind, ywind, wwind, geopot):
         ageofair.compute_ageofair(
             xwind, ywind, wwind, geopot, plev=500, cyclic=False
         ).data,
-        iris.load_cube("tests/test_data/ageofair/aoa_out_nocyclic.nc").data,
+        read.read_cube("tests/test_data/ageofair/aoa_out_nocyclic.nc").data,
         rtol=1e-06,
         atol=1e-02,
     )
@@ -101,7 +101,7 @@ def test_aoa_cyclic_parallel_processing(xwind, ywind, wwind, geopot):
             cyclic=True,
             multicore=True,
         ).data,
-        iris.load_cube("tests/test_data/ageofair/aoa_out_cyclic.nc").data,
+        read.read_cube("tests/test_data/ageofair/aoa_out_cyclic.nc").data,
         rtol=1e-06,
         atol=1e-02,
     )
@@ -119,7 +119,7 @@ def test_aoa_cyclic_single_process(xwind, ywind, wwind, geopot):
             cyclic=True,
             multicore=False,
         ).data,
-        iris.load_cube("tests/test_data/ageofair/aoa_out_cyclic.nc").data,
+        read.read_cube("tests/test_data/ageofair/aoa_out_cyclic.nc").data,
         rtol=1e-06,
         atol=1e-02,
     )

--- a/tests/operators/test_collapse.py
+++ b/tests/operators/test_collapse.py
@@ -19,13 +19,13 @@ import iris.cube
 import numpy as np
 import pytest
 
-from CSET.operators import collapse
+from CSET.operators import collapse, read
 
 
 @pytest.fixture()
 def long_forecast() -> iris.cube.Cube:
     """Get long_forecast to run tests on."""
-    return iris.load_cube(
+    return read.read_cube(
         "tests/test_data/long_forecast_air_temp_fcst_1.nc", "air_temperature"
     )
 
@@ -33,7 +33,7 @@ def long_forecast() -> iris.cube.Cube:
 @pytest.fixture()
 def long_forecast_multi_day() -> iris.cube.Cube:
     """Get long_forecast_multi_day to run tests on."""
-    return iris.load_cube(
+    return read.read_cube(
         "tests/test_data/long_forecast_air_temp_multi_day.nc", "air_temperature"
     )
 
@@ -41,7 +41,7 @@ def long_forecast_multi_day() -> iris.cube.Cube:
 @pytest.fixture()
 def long_forecast_many_cubes() -> iris.cube.Cube:
     """Get long_forecast_may_cubes to run tests on."""
-    return iris.load(
+    return read.read_cubes(
         "tests/test_data/long_forecast_air_temp_fcst_*.nc", "air_temperature"
     )
 

--- a/tests/operators/test_convection.py
+++ b/tests/operators/test_convection.py
@@ -19,61 +19,61 @@ import iris.cube
 import numpy as np
 import pytest
 
-import CSET.operators.convection as convection
+from CSET.operators import convection, read
 
 
 @pytest.fixture
 def SBCAPE() -> iris.cube.Cube:
     """Get a SBCAPE cube."""
-    return iris.load_cube("tests/test_data/convection/SBCAPE.nc")
+    return read.read_cube("tests/test_data/convection/SBCAPE.nc")
 
 
 @pytest.fixture
 def MUCAPE() -> iris.cube.Cube:
     """Get an MUCAPE cube."""
-    return iris.load_cube("tests/test_data/convection/MUCAPE.nc")
+    return read.read_cube("tests/test_data/convection/MUCAPE.nc")
 
 
 @pytest.fixture
 def MUCIN() -> iris.cube.Cube:
     """Get a MUCIN cube."""
-    return iris.load_cube("tests/test_data/convection/MUCIN.nc")
+    return read.read_cube("tests/test_data/convection/MUCIN.nc")
 
 
 @pytest.fixture
 def EIB() -> iris.cube.Cube:
     """Get an EIB cube."""
-    return iris.load_cube("tests/test_data/convection/EIB.nc")
+    return read.read_cube("tests/test_data/convection/EIB.nc")
 
 
 @pytest.fixture
 def BLheight() -> iris.cube.Cube:
     """Get a BLheight cube."""
-    return iris.load_cube("tests/test_data/convection/BLheight.nc")
+    return read.read_cube("tests/test_data/convection/BLheight.nc")
 
 
 @pytest.fixture
 def orography_2D() -> iris.cube.Cube:
     """Get a 2D Orography cube."""
-    return iris.load_cube("tests/test_data/convection/Orography2D.nc")
+    return read.read_cube("tests/test_data/convection/Orography2D.nc")
 
 
 @pytest.fixture
 def orography_3D() -> iris.cube.Cube:
     """Get a 3D Orography cube (time)."""
-    return iris.load_cube("tests/test_data/convection/Orography3D.nc")
+    return read.read_cube("tests/test_data/convection/Orography3D.nc")
 
 
 @pytest.fixture
 def orography_3D_ens() -> iris.cube.Cube:
     """Get a 3D Orography cube (realization)."""
-    return iris.load_cube("tests/test_data/convection/Orography3D_ens.nc")
+    return read.read_cube("tests/test_data/convection/Orography3D_ens.nc")
 
 
 @pytest.fixture
 def orography_4D() -> iris.cube.Cube:
     """Get a 4D Orography cube (time and realization)."""
-    return iris.load_cube("tests/test_data/convection/Orography4D.nc")
+    return read.read_cube("tests/test_data/convection/Orography4D.nc")
 
 
 def test_cape_ratio(SBCAPE, MUCAPE, MUCIN):
@@ -81,13 +81,13 @@ def test_cape_ratio(SBCAPE, MUCAPE, MUCIN):
     # Calculate the diagnostic.
     cape_75 = convection.cape_ratio(SBCAPE, MUCAPE, MUCIN)
     # Compare with KGO.
-    precalculated_75 = iris.load_cube("tests/test_data/convection/ECFlagB.nc")
+    precalculated_75 = read.read_cube("tests/test_data/convection/ECFlagB.nc")
     assert np.allclose(cape_75.data, precalculated_75.data, atol=1e-5, equal_nan=True)
 
     # Calculate the diagnostic.
     cape_1p5 = convection.cape_ratio(SBCAPE, MUCAPE, MUCIN, MUCIN_thresh=-1.5)
     # Compare with KGO.
-    precalculated_1p5 = iris.load_cube("tests/test_data/convection/ECFlagB_2.nc")
+    precalculated_1p5 = read.read_cube("tests/test_data/convection/ECFlagB_2.nc")
     assert np.allclose(cape_1p5.data, precalculated_1p5.data, atol=1e-5, equal_nan=True)
 
 
@@ -102,7 +102,7 @@ def test_cape_ratio_non_masked_arrays(SBCAPE, MUCAPE, MUCIN):
     cape_75 = convection.cape_ratio(SBCAPE, MUCAPE, MUCIN)
 
     # Compare with KGO.
-    precalculated_75 = iris.load_cube("tests/test_data/convection/ECFlagB.nc")
+    precalculated_75 = read.read_cube("tests/test_data/convection/ECFlagB.nc")
     assert np.allclose(cape_75.data, precalculated_75.data, atol=1e-5, equal_nan=True)
 
 
@@ -111,7 +111,7 @@ def test_inflow_layer_properties(EIB, BLheight, orography_2D):
     inflow_layer_properties = convection.inflow_layer_properties(
         EIB, BLheight, orography_2D
     )
-    precalculated = iris.load_cube("tests/test_data/convection/ECFlagD.nc")
+    precalculated = read.read_cube("tests/test_data/convection/ECFlagD.nc")
     assert np.allclose(inflow_layer_properties.data, precalculated.data)
 
 
@@ -122,7 +122,7 @@ def test_inflow_layer_properties_non_masked_arrays(EIB, BLheight, orography_2D):
     inflow_layer_properties = convection.inflow_layer_properties(
         EIB, BLheight, orography_2D
     )
-    precalculated = iris.load_cube("tests/test_data/convection/ECFlagD.nc")
+    precalculated = read.read_cube("tests/test_data/convection/ECFlagD.nc")
     assert np.allclose(inflow_layer_properties.data, precalculated.data)
 
 
@@ -131,7 +131,7 @@ def test_inflow_layer_properties_3D_orography_time(EIB, BLheight, orography_3D):
     inflow_layer_properties = convection.inflow_layer_properties(
         EIB, BLheight, orography_3D
     )
-    precalculated = iris.load_cube("tests/test_data/convection/ECFlagD.nc")
+    precalculated = read.read_cube("tests/test_data/convection/ECFlagD.nc")
     assert np.allclose(inflow_layer_properties.data, precalculated.data)
 
 
@@ -140,7 +140,7 @@ def test_inflow_layer_properties_3D_orography_ensemble(EIB, BLheight, orography_
     inflow_layer_properties = convection.inflow_layer_properties(
         EIB, BLheight, orography_3D_ens
     )
-    precalculated = iris.load_cube("tests/test_data/convection/ECFlagD.nc")
+    precalculated = read.read_cube("tests/test_data/convection/ECFlagD.nc")
     assert np.allclose(inflow_layer_properties.data, precalculated.data)
 
 
@@ -149,5 +149,5 @@ def test_inflow_layer_properties_4D_orography(EIB, BLheight, orography_4D):
     inflow_layer_properties = convection.inflow_layer_properties(
         EIB, BLheight, orography_4D
     )
-    precalculated = iris.load_cube("tests/test_data/convection/ECFlagD.nc")
+    precalculated = read.read_cube("tests/test_data/convection/ECFlagD.nc")
     assert np.allclose(inflow_layer_properties.data, precalculated.data)

--- a/tests/operators/test_convection.py
+++ b/tests/operators/test_convection.py
@@ -76,13 +76,24 @@ def orography_4D() -> iris.cube.Cube:
     return read.read_cube("tests/test_data/convection/Orography4D.nc")
 
 
-def test_cape_ratio(SBCAPE, MUCAPE, MUCIN):
+@pytest.fixture(scope="session")
+def cape_ratio_kgo() -> iris.cube.Cube:
+    """Known good output for CAPE ratio."""
+    return read.read_cube("tests/test_data/convection/ECFlagB.nc")
+
+
+@pytest.fixture(scope="session")
+def inflow_kgo() -> iris.cube.Cube:
+    """Known good output for inflow layer properties."""
+    return read.read_cube("tests/test_data/convection/ECFlagD.nc")
+
+
+def test_cape_ratio(SBCAPE, MUCAPE, MUCIN, cape_ratio_kgo):
     """Compare with precalculated ratio KGOs."""
     # Calculate the diagnostic.
     cape_75 = convection.cape_ratio(SBCAPE, MUCAPE, MUCIN)
     # Compare with KGO.
-    precalculated_75 = read.read_cube("tests/test_data/convection/ECFlagB.nc")
-    assert np.allclose(cape_75.data, precalculated_75.data, atol=1e-5, equal_nan=True)
+    assert np.allclose(cape_75.data, cape_ratio_kgo.data, atol=1e-5, equal_nan=True)
 
     # Calculate the diagnostic.
     cape_1p5 = convection.cape_ratio(SBCAPE, MUCAPE, MUCIN, MUCIN_thresh=-1.5)
@@ -91,7 +102,7 @@ def test_cape_ratio(SBCAPE, MUCAPE, MUCIN):
     assert np.allclose(cape_1p5.data, precalculated_1p5.data, atol=1e-5, equal_nan=True)
 
 
-def test_cape_ratio_non_masked_arrays(SBCAPE, MUCAPE, MUCIN):
+def test_cape_ratio_non_masked_arrays(SBCAPE, MUCAPE, MUCIN, cape_ratio_kgo):
     """Calculate with non-masked arrays and compare with precalculated ratio."""
     # Replace masked values with NaNs.
     SBCAPE.data = SBCAPE.data.filled(np.nan)
@@ -102,52 +113,52 @@ def test_cape_ratio_non_masked_arrays(SBCAPE, MUCAPE, MUCIN):
     cape_75 = convection.cape_ratio(SBCAPE, MUCAPE, MUCIN)
 
     # Compare with KGO.
-    precalculated_75 = read.read_cube("tests/test_data/convection/ECFlagB.nc")
-    assert np.allclose(cape_75.data, precalculated_75.data, atol=1e-5, equal_nan=True)
+    assert np.allclose(cape_75.data, cape_ratio_kgo.data, atol=1e-5, equal_nan=True)
 
 
-def test_inflow_layer_properties(EIB, BLheight, orography_2D):
+def test_inflow_layer_properties(EIB, BLheight, orography_2D, inflow_kgo):
     """Compare with precalculated properties."""
     inflow_layer_properties = convection.inflow_layer_properties(
         EIB, BLheight, orography_2D
     )
-    precalculated = read.read_cube("tests/test_data/convection/ECFlagD.nc")
-    assert np.allclose(inflow_layer_properties.data, precalculated.data)
+    assert np.allclose(inflow_layer_properties.data, inflow_kgo.data)
 
 
-def test_inflow_layer_properties_non_masked_arrays(EIB, BLheight, orography_2D):
+def test_inflow_layer_properties_non_masked_arrays(
+    EIB, BLheight, orography_2D, inflow_kgo
+):
     """Use non-masked data and compare with precalculated properties."""
     # Unmask the data.
     EIB.data = EIB.data.filled(np.nan)
     inflow_layer_properties = convection.inflow_layer_properties(
         EIB, BLheight, orography_2D
     )
-    precalculated = read.read_cube("tests/test_data/convection/ECFlagD.nc")
-    assert np.allclose(inflow_layer_properties.data, precalculated.data)
+    assert np.allclose(inflow_layer_properties.data, inflow_kgo.data)
 
 
-def test_inflow_layer_properties_3D_orography_time(EIB, BLheight, orography_3D):
+def test_inflow_layer_properties_3D_orography_time(
+    EIB, BLheight, orography_3D, inflow_kgo
+):
     """Reduce a 3D orography (time) field down to 2D."""
     inflow_layer_properties = convection.inflow_layer_properties(
         EIB, BLheight, orography_3D
     )
-    precalculated = read.read_cube("tests/test_data/convection/ECFlagD.nc")
-    assert np.allclose(inflow_layer_properties.data, precalculated.data)
+    assert np.allclose(inflow_layer_properties.data, inflow_kgo.data)
 
 
-def test_inflow_layer_properties_3D_orography_ensemble(EIB, BLheight, orography_3D_ens):
+def test_inflow_layer_properties_3D_orography_ensemble(
+    EIB, BLheight, orography_3D_ens, inflow_kgo
+):
     """Reduce a 3D orography (realisation) field down to 2D."""
     inflow_layer_properties = convection.inflow_layer_properties(
         EIB, BLheight, orography_3D_ens
     )
-    precalculated = read.read_cube("tests/test_data/convection/ECFlagD.nc")
-    assert np.allclose(inflow_layer_properties.data, precalculated.data)
+    assert np.allclose(inflow_layer_properties.data, inflow_kgo.data)
 
 
-def test_inflow_layer_properties_4D_orography(EIB, BLheight, orography_4D):
+def test_inflow_layer_properties_4D_orography(EIB, BLheight, orography_4D, inflow_kgo):
     """Reduce a 4D orography (time and realisation) field down to 2D."""
     inflow_layer_properties = convection.inflow_layer_properties(
         EIB, BLheight, orography_4D
     )
-    precalculated = read.read_cube("tests/test_data/convection/ECFlagD.nc")
-    assert np.allclose(inflow_layer_properties.data, precalculated.data)
+    assert np.allclose(inflow_layer_properties.data, inflow_kgo.data)

--- a/tests/operators/test_ensembles.py
+++ b/tests/operators/test_ensembles.py
@@ -19,31 +19,31 @@ import iris.cube
 import numpy as np
 import pytest
 
-import CSET.operators.ensembles as ensembles
+from CSET.operators import ensembles, read
 
 
 @pytest.fixture()
 def xwind() -> iris.cube.Cube:
     """Get xwind to run tests on."""
-    return iris.load_cube("tests/test_data/ageofair/aoa_in_ens.nc", "x_wind")
+    return read.read_cube("tests/test_data/ageofair/aoa_in_ens.nc", "x_wind")
 
 
 @pytest.fixture()
 def xwind_deterministic() -> iris.cube.Cube:
     """Get xwind to run tests on."""
-    return iris.load_cube("tests/test_data/ageofair/aoa_in_rgd.nc", "x_wind")
+    return read.read_cube("tests/test_data/ageofair/aoa_in_rgd.nc", "x_wind")
 
 
 @pytest.fixture()
 def ywind() -> iris.cube.Cube:
     """Get ywind to run tests on."""
-    return iris.load_cube("tests/test_data/ageofair/aoa_in_ens.nc", "y_wind")
+    return read.read_cube("tests/test_data/ageofair/aoa_in_ens.nc", "y_wind")
 
 
 @pytest.fixture()
 def ywind_deterministic() -> iris.cube.Cube:
     """Get xwind to run tests on."""
-    return iris.load_cube("tests/test_data/ageofair/aoa_in_rgd.nc", "y_wind")
+    return read.read_cube("tests/test_data/ageofair/aoa_in_rgd.nc", "y_wind")
 
 
 def test_DKE(xwind, ywind):

--- a/tests/operators/test_filters.py
+++ b/tests/operators/test_filters.py
@@ -127,7 +127,7 @@ def load_verticalcoord_cubelist() -> iris.cube.CubeList:
     return iris.load("tests/test_data/vertlevtestdata.nc", "y_wind")
 
 
-def test_generate_level_constraint_returnsinglelevel(load_verticalcoord_cubelist):
+def test_generate_level_constraint_return_single_level(load_verticalcoord_cubelist):
     """For a cubelist that contains 3 cubes on different vertical levels.
 
     Return one without a vertical coordinate.
@@ -147,7 +147,7 @@ def test_generate_level_constraint_returnsinglelevel(load_verticalcoord_cubelist
     assert expected_coordstr in repr(extracted.coords)
 
 
-def test_generate_level_constraint_returnallpressure(load_verticalcoord_cubelist):
+def test_generate_level_constraint_return_all_pressure(load_verticalcoord_cubelist):
     """For a cubelist that contains 3 cubes on different vertical levels.
 
     Return one with a pressure on all levels.
@@ -163,7 +163,7 @@ def test_generate_level_constraint_returnallpressure(load_verticalcoord_cubelist
     )
 
 
-def test_generate_level_constraint_returnallmodlev(load_verticalcoord_cubelist):
+def test_generate_level_constraint_return_all_model_levels(load_verticalcoord_cubelist):
     """For a cubelist that contains 3 cubes on different vertical levels.
 
     Return one with a model level on all levels.

--- a/tests/operators/test_filters.py
+++ b/tests/operators/test_filters.py
@@ -122,12 +122,12 @@ def test_filter_multiple_cubes_none_returned(cubes):
 
 # Session scope fixtures, so the test data only has to be loaded once.
 @pytest.fixture(scope="session")
-def load_verticalcoord_cubelist() -> iris.cube.CubeList:
+def load_vertical_coord_cubelist() -> iris.cube.CubeList:
     """Get a cubelist with multiple vertical level cubes."""
     return iris.load("tests/test_data/vertlevtestdata.nc", "y_wind")
 
 
-def test_generate_level_constraint_return_single_level(load_verticalcoord_cubelist):
+def test_generate_level_constraint_return_single_level(load_vertical_coord_cubelist):
     """For a cubelist that contains 3 cubes on different vertical levels.
 
     Return one without a vertical coordinate.
@@ -140,14 +140,14 @@ def test_generate_level_constraint_return_single_level(load_verticalcoord_cubeli
     )
     combined = constraints.combine_constraints(constraint_1, a=constraint_2)
 
-    extracted = load_verticalcoord_cubelist.extract(combined)[0]
+    extracted = load_vertical_coord_cubelist.extract(combined)[0]
 
     expected_coordstr = "<bound method Cube.coords of <iris 'Cube' of y_wind / (m s-1) (latitude: 2; longitude: 2)>>"
 
     assert expected_coordstr in repr(extracted.coords)
 
 
-def test_generate_level_constraint_return_all_pressure(load_verticalcoord_cubelist):
+def test_generate_level_constraint_return_all_pressure(load_vertical_coord_cubelist):
     """For a cubelist that contains 3 cubes on different vertical levels.
 
     Return one with a pressure on all levels.
@@ -159,11 +159,13 @@ def test_generate_level_constraint_return_all_pressure(load_verticalcoord_cubeli
     expected_coordstr = "<bound method Cube.coords of <iris 'Cube' of y_wind / (m s-1) (pressure: 34; latitude: 2; longitude: 2)>>"
 
     assert expected_coordstr in repr(
-        load_verticalcoord_cubelist.extract(constraint_1)[0].coords
+        load_vertical_coord_cubelist.extract(constraint_1)[0].coords
     )
 
 
-def test_generate_level_constraint_return_all_model_levels(load_verticalcoord_cubelist):
+def test_generate_level_constraint_return_all_model_levels(
+    load_vertical_coord_cubelist,
+):
     """For a cubelist that contains 3 cubes on different vertical levels.
 
     Return one with a model level on all levels.
@@ -175,7 +177,7 @@ def test_generate_level_constraint_return_all_model_levels(load_verticalcoord_cu
     expected_coordstr = "<bound method Cube.coords of <iris 'Cube' of y_wind / (m s-1) (model_level_number: 70; latitude: 2; longitude: 2)>>"
 
     assert expected_coordstr in repr(
-        load_verticalcoord_cubelist.extract(constraint_1)[0].coords
+        load_vertical_coord_cubelist.extract(constraint_1)[0].coords
     )
 
 

--- a/tests/operators/test_regrid.py
+++ b/tests/operators/test_regrid.py
@@ -20,16 +20,14 @@ import iris.cube
 import numpy as np
 import pytest
 
-import CSET.operators.read as read
-import CSET.operators.regrid as regrid
-from CSET.operators.regrid import BoundaryWarning
+from CSET.operators import _utils, read, regrid
 
 
 # Session scope fixtures, so the test data only has to be loaded once.
 @pytest.fixture(scope="session")
 def regrid_source_cube() -> iris.cube.Cube:
     """Get a cube to regrid."""
-    return iris.load_cube(
+    return read.read_cube(
         "tests/test_data/regrid/regrid_rectilinearGeogCS.nc", "surface_altitude"
     )
 
@@ -37,7 +35,7 @@ def regrid_source_cube() -> iris.cube.Cube:
 @pytest.fixture(scope="session")
 def regrid_test_cube() -> iris.cube.Cube:
     """Get a regridded cube to compare."""
-    return iris.load_cube("tests/test_data/regrid/out_rectilinearGeogCS_0p5deg.nc")
+    return read.read_cube("tests/test_data/regrid/out_rectilinearGeogCS_0p5deg.nc")
 
 
 def test_regrid_onto_cube(regrid_source_cube, regrid_test_cube):
@@ -57,35 +55,53 @@ def test_regrid_onto_cube_cubes(regrid_source_cube, regrid_test_cube):
     """Test regrid case where target cube to project onto is specified for multiple cubes."""
     # Create cubelist with multiple cubes.
     cubelist_to_regrid = iris.cube.CubeList([regrid_source_cube, regrid_source_cube])
+    # Regrid all those cubes.
     regridded_cubes = regrid.regrid_onto_cube(
         cubelist_to_regrid, regrid_test_cube, method="Linear"
     )
-    expected_cubelist = "[<iris 'Cube' of surface_altitude / (m) (latitude: 16; longitude: 16)>,\n<iris 'Cube' of surface_altitude / (m) (latitude: 16; longitude: 16)>]"
-    assert repr(regridded_cubes) in expected_cubelist
+    # Check it regridded correctly.
+    assert len(regridded_cubes) == 2
+    for cube in regridded_cubes:
+        lat_name, lon_name = _utils.get_cube_yxcoordname(cube)
+        assert (
+            cube.coord(lat_name).points == regrid_test_cube.coord(lat_name).points
+        ).all()
+        assert (
+            cube.coord(lon_name).points == regrid_test_cube.coord(lon_name).points
+        ).all()
 
 
-def test_regrid_onto_xyspacing_cubes(regrid_source_cube, regrid_test_cube):
+def test_regrid_onto_xyspacing_cubes(regrid_source_cube):
     """Test regrid case where xyspacing to project onto is specified for multiple cubes."""
     # Create cubelist with multiple cubes
     cubelist_to_regrid = iris.cube.CubeList([regrid_source_cube, regrid_source_cube])
     regridded_cubes = regrid.regrid_onto_xyspacing(
         cubelist_to_regrid, xspacing=0.5, yspacing=0.5, method="Linear"
     )
-    expected_cubelist = "[<iris 'Cube' of surface_altitude / (m) (latitude: 16; longitude: 16)>,\n<iris 'Cube' of surface_altitude / (m) (latitude: 16; longitude: 16)>]"
-    assert repr(regridded_cubes) in expected_cubelist
+    # Check it regridded correctly.
+    assert len(regridded_cubes) == 2
+    for cube in regridded_cubes:
+        lat_name, lon_name = _utils.get_cube_yxcoordname(cube)
+        lat_coord = cube.coord(lat_name)
+        lon_coord = cube.coord(lon_name)
+        # Inclusive interval from -1.0 to 6.5 in steps of 0.5.
+        assert (lat_coord.points == [x / 10.0 for x in range(-10, 70, 5)]).all()
+        # Inclusive interval from 32.0 to 39.5 in steps of 0.5.
+        assert (lon_coord.points == [x / 10.0 for x in range(320, 400, 5)]).all()
 
 
 def test_regrid_onto_cube_unknown_crs(regrid_source_cube, regrid_test_cube):
     """Coordinate reference system is unrecognised."""
+    lat_name, lon_name = _utils.get_cube_yxcoordname(regrid_source_cube)
     # Exchange X to unsupported coordinate system.
     source_changed_x = regrid_source_cube.copy()
-    source_changed_x.coord("longitude").coord_system = iris.coord_systems.OSGB()
+    source_changed_x.coord(lon_name).coord_system = iris.coord_systems.OSGB()
     with pytest.raises(NotImplementedError):
         regrid.regrid_onto_cube(source_changed_x, regrid_test_cube, method="Linear")
 
     # Exchange Y to unsupported coordinate system.
     source_changed_y = regrid_source_cube.copy()
-    source_changed_y.coord("latitude").coord_system = iris.coord_systems.OSGB()
+    source_changed_y.coord(lat_name).coord_system = iris.coord_systems.OSGB()
     with pytest.raises(NotImplementedError):
         regrid.regrid_onto_cube(source_changed_y, regrid_test_cube, method="Linear")
 
@@ -119,9 +135,10 @@ def test_regrid_onto_xyspacing(regrid_source_cube, regrid_test_cube):
 
 def test_regrid_onto_xyspacing_unknown_crs(regrid_source_cube):
     """Coordinate reference system is unrecognised."""
+    lat_name, lon_name = _utils.get_cube_yxcoordname(regrid_source_cube)
     # Exchange X to unsupported coordinate system.
     source_changed_x = regrid_source_cube.copy()
-    source_changed_x.coord("longitude").coord_system = iris.coord_systems.OSGB()
+    source_changed_x.coord(lon_name).coord_system = iris.coord_systems.OSGB()
     with pytest.raises(NotImplementedError):
         regrid.regrid_onto_xyspacing(
             source_changed_x, xspacing=0.5, yspacing=0.5, method="Linear"
@@ -129,7 +146,7 @@ def test_regrid_onto_xyspacing_unknown_crs(regrid_source_cube):
 
     # Exchange Y to unsupported coordinate system.
     source_changed_y = regrid_source_cube.copy()
-    source_changed_y.coord("latitude").coord_system = iris.coord_systems.OSGB()
+    source_changed_y.coord(lat_name).coord_system = iris.coord_systems.OSGB()
     with pytest.raises(NotImplementedError):
         regrid.regrid_onto_xyspacing(
             source_changed_y, xspacing=0.5, yspacing=0.5, method="Linear"
@@ -163,8 +180,13 @@ def test_regrid_to_single_point_east(cube):
     regrid_cube = regrid.regrid_to_single_point(
         cube_fix, 0.5, -1.5, "Nearest", boundary_margin=1
     )
-    expected_cube = "<iris 'Cube' of air_temperature / (K) (time: 3)>"
-    assert repr(regrid_cube) == expected_cube
+    lat_name, lon_name = _utils.get_cube_yxcoordname(regrid_cube)
+    lat_coord = regrid_cube.coord(lat_name)
+    lon_coord = regrid_cube.coord(lon_name)
+    assert lat_coord.shape == (1,)
+    assert lon_coord.shape == (1,)
+    assert lat_coord.points[0] == 0.5
+    assert lon_coord.points[0] == -1.5
 
 
 def test_regrid_to_single_point_west(cube):
@@ -181,8 +203,13 @@ def test_regrid_to_single_point_west(cube):
     regrid_cube = regrid.regrid_to_single_point(
         cube_fix, 0.5, -1.5, "Nearest", boundary_margin=1
     )
-    expected_cube = "<iris 'Cube' of air_temperature / (K) (time: 3)>"
-    assert repr(regrid_cube) == expected_cube
+    lat_name, lon_name = _utils.get_cube_yxcoordname(regrid_cube)
+    lat_coord = regrid_cube.coord(lat_name)
+    lon_coord = regrid_cube.coord(lon_name)
+    assert lat_coord.shape == (1,)
+    assert lon_coord.shape == (1,)
+    assert lat_coord.points[0] == 0.5
+    assert lon_coord.points[0] == -1.5
 
 
 def test_regrid_to_single_point_longitude_transform_1(cube):
@@ -195,8 +222,13 @@ def test_regrid_to_single_point_longitude_transform_1(cube):
     regrid_cube = regrid.regrid_to_single_point(
         cube, 0.5, 358.5, "Nearest", boundary_margin=1
     )
-    expected_cube = "<iris 'Cube' of air_temperature / (K) (time: 3)>"
-    assert repr(regrid_cube) == expected_cube
+    lat_name, lon_name = _utils.get_cube_yxcoordname(regrid_cube)
+    lat_coord = regrid_cube.coord(lat_name)
+    lon_coord = regrid_cube.coord(lon_name)
+    assert lat_coord.shape == (1,)
+    assert lon_coord.shape == (1,)
+    assert lat_coord.points[0] == 0.5
+    assert lon_coord.points[0] == -1.5
 
 
 def test_regrid_to_single_point_longitude_transform_2(cube):
@@ -209,8 +241,13 @@ def test_regrid_to_single_point_longitude_transform_2(cube):
     regrid_cube = regrid.regrid_to_single_point(
         cube, 0.5, -361.5, "Nearest", boundary_margin=1
     )
-    expected_cube = "<iris 'Cube' of air_temperature / (K) (time: 3)>"
-    assert repr(regrid_cube) == expected_cube
+    lat_name, lon_name = _utils.get_cube_yxcoordname(regrid_cube)
+    lat_coord = regrid_cube.coord(lat_name)
+    lon_coord = regrid_cube.coord(lon_name)
+    assert lat_coord.shape == (1,)
+    assert lon_coord.shape == (1,)
+    assert lat_coord.points[0] == 0.5
+    assert lon_coord.points[0] == -1.5
 
 
 def test_regrid_to_single_point_missing_coord(cube):
@@ -284,9 +321,9 @@ def test_regrid_to_single_point_unknown_method(cube):
 def test_boundary_warning(regrid_source_cube):
     """Ensures a warning is raised when chosen point is too close to boundary."""
     with pytest.warns(
-        BoundaryWarning, match="Selected point is within 8 gridlengths"
+        regrid.BoundaryWarning, match="Selected point is within 8 gridlengths"
     ) as warning:
         regrid.regrid_to_single_point(regrid_source_cube, -0.9, 393.0, "Nearest")
 
     assert len(warning) == 1
-    assert issubclass(warning[-1].category, BoundaryWarning)
+    assert issubclass(warning[-1].category, regrid.BoundaryWarning)

--- a/tests/operators/test_transect.py
+++ b/tests/operators/test_transect.py
@@ -22,42 +22,36 @@ import iris.cube
 import numpy as np
 import pytest
 
-from CSET.operators import plot, transect
+from CSET.operators import plot, read, transect
 
 
 # Session scope fixtures, so the test data only has to be loaded once.
 @pytest.fixture(scope="session")
-def load_cube_pl() -> iris.cube.Cube:
-    """Load cube containing UM pressure level data."""
-    return iris.load_cube("tests/test_data/transect_test_umpl.nc")
-
-
-@pytest.fixture(scope="session")
-def load_cube_pl_out() -> iris.cube.Cube:
+def transect_source_cube_out() -> iris.cube.Cube:
     """Load cube containing UM pressure level data transect."""
-    return iris.load_cube("tests/test_data/transect_out_umpl.nc")
+    return read.read_cube("tests/test_data/transect_out_umpl.nc")
 
 
 @pytest.fixture(scope="session")
 def load_cube_ml() -> iris.cube.Cube:
     """Load cube containing UM model level data."""
-    return iris.load_cube("tests/test_data/transect_test_umml.nc")
+    return read.read_cube("tests/test_data/transect_test_umml.nc")
 
 
 @pytest.fixture(scope="session")
 def load_cube_ml_out() -> iris.cube.Cube:
     """Load cube containing UM model level data transect."""
-    return iris.load_cube("tests/test_data/transect_out_umml.nc")
+    return read.read_cube("tests/test_data/transect_out_umml.nc")
 
 
 @pytest.fixture(scope="session")
-def test_transect_pl(load_cube_pl, load_cube_pl_out):
+def test_transect_pl(transect_source_cube, transect_source_cube_out):
     """Test case of computing transect on UM pressure level data."""
     assert np.allclose(
         transect.calc_transect(
-            load_cube_pl, startcoords=(-10.94, 19.06), endcoords=(-10.82, 19.18)
+            transect_source_cube, startcoords=(-10.94, 19.06), endcoords=(-10.82, 19.18)
         ).data,
-        load_cube_pl_out.data,
+        transect_source_cube_out.data,
         rtol=1e-06,
         atol=1e-02,
     )
@@ -76,75 +70,75 @@ def test_transect_ml(load_cube_ml, load_cube_ml_out):
     )
 
 
-def test_transect_45deg(load_cube_pl, load_cube_pl_out):
+def test_transect_45deg(transect_source_cube, transect_source_cube_out):
     """Test case of 45 degree angle where map coordinate should be longitude."""
     with pytest.raises(iris.exceptions.CoordinateNotFoundError):
         transect.calc_transect(
-            load_cube_pl, startcoords=(-10.94, 19.06), endcoords=(-10.86, 19.14)
+            transect_source_cube, startcoords=(-10.94, 19.06), endcoords=(-10.86, 19.14)
         ).coord("latitude")
 
 
-def test_transect_coord_outofboundsLLat(load_cube_pl):
+def test_transect_coord_outofboundsLLat(transect_source_cube):
     """Test case of computing transect on coords out of range (low start lat)."""
     with pytest.raises(IndexError):
         transect.calc_transect(
-            load_cube_pl, startcoords=(-11.94, 19.06), endcoords=(-10.82, 19.18)
+            transect_source_cube, startcoords=(-11.94, 19.06), endcoords=(-10.82, 19.18)
         )
 
 
-def test_transect_coord_outofboundsLLon(load_cube_pl):
+def test_transect_coord_outofboundsLLon(transect_source_cube):
     """Test case of computing transect on coords out of range (low start lon)."""
     with pytest.raises(IndexError):
         transect.calc_transect(
-            load_cube_pl, startcoords=(-10.94, 10.06), endcoords=(-10.82, 19.18)
+            transect_source_cube, startcoords=(-10.94, 10.06), endcoords=(-10.82, 19.18)
         )
 
 
-def test_transect_coord_outofboundsHLat(load_cube_pl):
+def test_transect_coord_outofboundsHLat(transect_source_cube):
     """Test case of computing transect on coords out of range (high end lat)."""
     with pytest.raises(IndexError):
         transect.calc_transect(
-            load_cube_pl, startcoords=(-10.94, 19.06), endcoords=(-5.82, 19.18)
+            transect_source_cube, startcoords=(-10.94, 19.06), endcoords=(-5.82, 19.18)
         )
 
 
-def test_transect_coord_outofboundsHLon(load_cube_pl):
+def test_transect_coord_outofboundsHLon(transect_source_cube):
     """Test case of computing transect on coords out of range (high end lon)."""
     with pytest.raises(IndexError):
         transect.calc_transect(
-            load_cube_pl, startcoords=(-10.94, 19.06), endcoords=(-10.82, 25.18)
+            transect_source_cube, startcoords=(-10.94, 19.06), endcoords=(-10.82, 25.18)
         )
 
 
-def test_transect_90degangle(load_cube_pl):
+def test_transect_90degangle(transect_source_cube):
     """Test case of computing transect on 90 degree angle (no delta lon)."""
     with pytest.raises(iris.exceptions.CoordinateNotFoundError):
         transect.calc_transect(
-            load_cube_pl, startcoords=(-10.94, 19.18), endcoords=(-10.82, 19.18)
+            transect_source_cube, startcoords=(-10.94, 19.18), endcoords=(-10.82, 19.18)
         ).coord("longitude")
 
 
-def test_transect_180degangle(load_cube_pl):
+def test_transect_180degangle(transect_source_cube):
     """Test case of computing transect on 180 degree angle (no delta lat)."""
     with pytest.raises(iris.exceptions.CoordinateNotFoundError):
         transect.calc_transect(
-            load_cube_pl, startcoords=(-10.94, 19.06), endcoords=(-10.94, 19.18)
+            transect_source_cube, startcoords=(-10.94, 19.06), endcoords=(-10.94, 19.18)
         ).coord("latitude")
 
 
-def test_transect_plotasfuncoflatitude(load_cube_pl):
+def test_transect_plotasfuncoflatitude(transect_source_cube):
     """Test case of computing transect where it should return as function of latitude."""
     with pytest.raises(iris.exceptions.CoordinateNotFoundError):
         transect.calc_transect(
-            load_cube_pl, startcoords=(-10.94, 19.06), endcoords=(-10.82, 19.14)
+            transect_source_cube, startcoords=(-10.94, 19.06), endcoords=(-10.82, 19.14)
         ).coord("longitude")
 
 
-def test_transect_plotasfuncoflongitude(load_cube_pl):
+def test_transect_plotasfuncoflongitude(transect_source_cube):
     """Test case of computing transect where it should return as function of longitude."""
     with pytest.raises(iris.exceptions.CoordinateNotFoundError):
         transect.calc_transect(
-            load_cube_pl, startcoords=(-10.94, 19.06), endcoords=(-10.86, 19.18)
+            transect_source_cube, startcoords=(-10.94, 19.06), endcoords=(-10.86, 19.18)
         ).coord("latitude")
 
 
@@ -164,15 +158,19 @@ def test_transect_model_level_spatial_pcolormesh_plot(
     assert Path("plot_449744.0.png").is_file()
 
 
-def test_transect_pressure_spatial_contour_plot(load_cube_pl_out, tmp_working_dir):
+def test_transect_pressure_spatial_contour_plot(
+    transect_source_cube_out, tmp_working_dir
+):
     """Plot a contour plot of the transect pressure data."""
-    plot.spatial_contour_plot(load_cube_pl_out, filename="plot")
+    plot.spatial_contour_plot(transect_source_cube_out, filename="plot")
     assert Path("plot_449469.0.png").is_file()
     assert Path("plot_449472.0.png").is_file()
 
 
-def test_transect_pressure_spatial_pcolormesh_plot(load_cube_pl_out, tmp_working_dir):
+def test_transect_pressure_spatial_pcolormesh_plot(
+    transect_source_cube_out, tmp_working_dir
+):
     """Plot a pcolormesh plot of the transect pressure data."""
-    plot.spatial_pcolormesh_plot(load_cube_pl_out, filename="plot")
+    plot.spatial_pcolormesh_plot(transect_source_cube_out, filename="plot")
     assert Path("plot_449469.0.png").is_file()
     assert Path("plot_449472.0.png").is_file()

--- a/tests/operators/test_utils.py
+++ b/tests/operators/test_utils.py
@@ -69,19 +69,19 @@ def test_get_cube_yxcoordname(regrid_rectilinear_cube):
     )
 
 
-def test_is_transect_multiplespatialcoords(regrid_rectilinear_cube):
+def test_is_transect_multiple_spatial_coords(regrid_rectilinear_cube):
     """Check that function returns False as more than one spatial map coord."""
     assert not operator_utils.is_transect(regrid_rectilinear_cube)
 
 
-def test_is_transect_noverticalcoord(transect_source_cube):
+def test_is_transect_no_vertical_coord(transect_source_cube):
     """Check that function returns False as no vertical coord found."""
     # Retain only time and latitude coordinate, so it passes the first spatial coord test.
     transect_source_cube_slice = transect_source_cube[:, 0, :, 0]
     assert not operator_utils.is_transect(transect_source_cube_slice)
 
 
-def test_is_transect_correctcoord(transect_source_cube):
+def test_is_transect_correct_coord(transect_source_cube):
     """Check that function returns True as one map and vertical coord found."""
     # Retain only time and latitude coordinate, so it passes the first spatial coord test.
     transect_source_cube_slice = transect_source_cube[:, :, :, 0]

--- a/tests/operators/test_utils.py
+++ b/tests/operators/test_utils.py
@@ -88,17 +88,15 @@ def test_is_transect_correct_coord(transect_source_cube):
     assert operator_utils.is_transect(transect_source_cube_slice)
 
 
-def test_is_spatialdim_false():
+def test_is_spatialdim_false(transect_source_cube):
     """Check that is spatial test returns false if cube does not contain spatial coordinates."""
-    cube = iris.load_cube("tests/test_data/transect_test_umpl.nc")
-    cube = cube[:, :, 0, 0]  # Remove spatial dimcoords
+    cube = transect_source_cube[:, :, 0, 0]  # Remove spatial dimcoords.
     assert not operator_utils.is_spatialdim(cube)
 
 
-def test_is_spatialdim_true():
+def test_is_spatialdim_true(transect_source_cube):
     """Check that is spatial test returns true if cube contains spatial coordinates."""
-    cube = iris.load_cube("tests/test_data/transect_test_umpl.nc")
-    assert operator_utils.is_spatialdim(cube)
+    assert operator_utils.is_spatialdim(transect_source_cube)
 
 
 def test_fully_equalise_attributes_remove_unique_attributes():

--- a/tests/operators/test_utils.py
+++ b/tests/operators/test_utils.py
@@ -21,12 +21,13 @@ import numpy as np
 import pytest
 
 import CSET.operators._utils as operator_utils
+from CSET.operators import read
 
 
 @pytest.fixture()
 def long_forecast() -> iris.cube.Cube:
     """Get long_forecast to run tests on."""
-    return iris.load_cube(
+    return read.read_cube(
         "tests/test_data/long_forecast_air_temp_fcst_1.nc", "air_temperature"
     )
 
@@ -34,7 +35,7 @@ def long_forecast() -> iris.cube.Cube:
 @pytest.fixture()
 def long_forecast_multi_day() -> iris.cube.Cube:
     """Get long_forecast_multi_day to run tests on."""
-    return iris.load_cube(
+    return read.read_cube(
         "tests/test_data/long_forecast_air_temp_multi_day.nc", "air_temperature"
     )
 
@@ -42,7 +43,7 @@ def long_forecast_multi_day() -> iris.cube.Cube:
 @pytest.fixture()
 def long_forecast_many_cubes() -> iris.cube.Cube:
     """Get long_forecast_may_cubes to run tests on."""
-    return iris.load(
+    return read.read_cubes(
         "tests/test_data/long_forecast_air_temp_fcst_*.nc", "air_temperature"
     )
 

--- a/tests/operators/test_utils.py
+++ b/tests/operators/test_utils.py
@@ -174,7 +174,7 @@ def test_is_time_aggregatable(long_forecast_multi_day):
     assert operator_utils.is_time_aggregatable(long_forecast_multi_day)
 
 
-def test_ensure_aggregatable_across_cases_true_aggregateable_cube(
+def test_ensure_aggregatable_across_cases_true_aggregatable_cube(
     long_forecast_multi_day,
 ):
     """Check that an aggregatable cube is returned with no changes."""
@@ -186,7 +186,7 @@ def test_ensure_aggregatable_across_cases_true_aggregateable_cube(
     )
 
 
-def test_ensure_aggregatable_across_cases_false_aggregateable_cube(long_forecast):
+def test_ensure_aggregatable_across_cases_false_aggregatable_cube(long_forecast):
     """Check that a non-aggregatable cube raises an error."""
     with pytest.raises(ValueError):
         operator_utils.ensure_aggregatable_across_cases(long_forecast)


### PR DESCRIPTION
<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

A fairly wide ranging set of test improvements. The main focus is ensuring we are using the CSET read operators to load data, so it is representative of what CSET will actually be handling. The only place that remains using `iris.load` is the tests for the read operators themselves.

There are also several robustness improvements to tests, to check the desired property directly rather than some tangential thing, such as the `repr()`.

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
