### PR TITLE
Increase default memory to 4G for processes

### DIFF
--- a/cset-workflow/flow.cylc
+++ b/cset-workflow/flow.cylc
@@ -91,6 +91,8 @@ URL = https://metoffice.github.io/CSET
     [[PROCESS]]
     script = rose task-run -v --app-key=run_cset_recipe
     execution time limit = PT1H
+    [[[directives]]]
+        --mem=4000
 
     [[FETCH_DATA]]
     script = rose task-run -v --app-key=fetch_fcst


### PR DESCRIPTION
I have had a few OOM errors with producing standard difference plots, and this is 648x648 domains. I suspect this will get worse with larger domains. I have mixed feelings about not addressing underlying issues, but might not be possible (matplotlib and cartopy are probably likely culprits), vs having something which doesn't intermittently fail on tasks. 4G is a modest amount (previous 2Gb).

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [X] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [ ] Marked the PR as ready to review.
