### PR TITLE
Add dummy tasks to prevent workflow graph failures

### DIFF
--- a/cset-workflow/flow.cylc
+++ b/cset-workflow/flow.cylc
@@ -130,6 +130,7 @@ URL = https://metoffice.github.io/CSET
             ROSE_APP_OPT_CONF_KEYS = {{METPLUS_OPT_CONFIG_KEYS}}
         {% endif %}
 
+    # Noop tasks to ensure a complete/efficient workflow graph
     [[DUMMY_TASK]]
     script = true
     platform = localhost
@@ -143,6 +144,12 @@ URL = https://metoffice.github.io/CSET
 
     [[cycle_complete]]
     inherit = DUMMY_TASK
+
+    [[dummy_process]]
+    inherit = DUMMY_TASK, PROCESS
+
+    [[dummy_process_case_aggregation]]
+    inherit = DUMMY_TASK, PROCESS_CASE_AGGREGATION
 
     [[build_conda]]
     # Create the conda environment if it does not yet exist, possibly installing


### PR DESCRIPTION
This prevents the "family trigger on non-family namespace" error from occurring when you have no tasks enabled for a specific family of cylc tasks.

Fixes #616 (which reoccurred)

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
