### PR TITLE
Fix issue where pressure coordinate returns Unit object, not str

### DIFF
--- a/src/CSET/operators/read.py
+++ b/src/CSET/operators/read.py
@@ -425,7 +425,7 @@ def _fix_pressure_coord_callback(cube: iris.cube.Cube):
             coord.rename("pressure")
 
         if coord_name == "pressure":
-            if cube.coord("pressure").units != "hPa":
+            if str(cube.coord("pressure").units) != "hPa":
                 cube.coord("pressure").convert_units("hPa")
 
 


### PR DESCRIPTION
`cube.coord("pressure").units` returns a `Unit` object, not str, which I am checking against. 

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [ ] All tests and CI checks pass.
- [ ] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [ ] Marked the PR as ready to review.
