### PR TITLE
Unify .gitignore to cover both workflow and library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+################################
+# General python project stuff #
+################################
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
@@ -131,3 +135,17 @@ dmypy.json
 
 # Ruff
 .ruff_cache/
+
+
+#######################
+# CSET specific stuff #
+#######################
+
+# Exclude site-specific files that are held in a separate private repo.
+cset-workflow/site/
+cset-workflow/opt/
+restricted*
+cset-workflow/app/demo_pointstat/
+
+# User workflow configuration.
+cset-workflow/rose-suite.conf

--- a/cset-workflow/.gitignore
+++ b/cset-workflow/.gitignore
@@ -1,8 +1,0 @@
-# Exclude site-specific files that are held in a seperate private repo.
-/site/
-/opt/
-restricted*
-/app/demo_pointstat/
-
-# User workflow configuration.
-/rose-suite.conf


### PR DESCRIPTION
Now everything is in one repository, we don't need the seperate .gitignore for the workflow.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
