### PR TITLE
Reduce verbosity of pip install in workflow

### DIFF
--- a/cset-workflow/app/build_conda/bin/install-local-cset.sh
+++ b/cset-workflow/app/build_conda/bin/install-local-cset.sh
@@ -22,8 +22,8 @@ then
         cp -r "${cset_source_path}"/* "${cset_source_path}"/.git "${cset_install_path}"
     fi
 
-    # Build and install into python environment.
-    pip install --verbose --progress-bar off --no-deps -- "${cset_install_path}"
+    # Build and install into conda environment.
+    pip install --progress-bar off --no-deps -- "${cset_install_path}"
 fi
 
 echo "Using CSET version: $(cset --version)"


### PR DESCRIPTION
With the verbose flag it produces a large amount of unnecessary logs; everything we care about is in the non-verbose output.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
