### PR TITLE
Update environments used throughout CSET to python 3.13

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -22,7 +22,7 @@ jobs:
         id: conda-env-cache
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
         with:
-          key: conda|${{runner.os}}-${{runner.arch}}|${{hashFiles('requirements/locks/py312-lock-linux-64.txt')}}
+          key: conda|${{runner.os}}-${{runner.arch}}|${{hashFiles('requirements/locks/py313-lock-linux-64.txt')}}
           path: |
             ~/conda-env
             ~/.local/share/cartopy
@@ -32,7 +32,7 @@ jobs:
         run: |
           # Check cache hasn't pulled a partial key match.
           test ! -e "${HOME}/conda-env"
-          conda create --prefix="${HOME}/conda-env" --file=requirements/locks/py312-lock-linux-64.txt
+          conda create --prefix="${HOME}/conda-env" --file=requirements/locks/py313-lock-linux-64.txt
 
       - name: Add conda environment to PATH
         run: echo "${HOME}/conda-env/bin" >> $GITHUB_PATH

--- a/.github/workflows/pull_request_checks.yml
+++ b/.github/workflows/pull_request_checks.yml
@@ -125,7 +125,7 @@ jobs:
         id: conda-env-cache
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
         with:
-          key: conda|${{runner.os}}-${{runner.arch}}|${{hashFiles('requirements/locks/py312-lock-linux-64.txt')}}
+          key: conda|${{runner.os}}-${{runner.arch}}|${{hashFiles('requirements/locks/py313-lock-linux-64.txt')}}
           path: |
             ~/conda-env
             ~/.local/share/cartopy
@@ -134,7 +134,7 @@ jobs:
         run: |
           # Check cache hasn't pulled a partial key match.
           test ! -e "${HOME}/conda-env"
-          conda create --prefix="${HOME}/conda-env" --file=requirements/locks/py312-lock-linux-64.txt
+          conda create --prefix="${HOME}/conda-env" --file=requirements/locks/py313-lock-linux-64.txt
       - name: Add conda environment to PATH
         run: echo "${HOME}/conda-env/bin" >> $GITHUB_PATH
       - name: Build documentation with Sphinx

--- a/.github/workflows/weekly-checks.yml
+++ b/.github/workflows/weekly-checks.yml
@@ -16,7 +16,7 @@ jobs:
         id: conda-env-cache
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
         with:
-          key: conda|${{runner.os}}-${{runner.arch}}|${{hashFiles('requirements/locks/py312-lock-linux-64.txt')}}
+          key: conda|${{runner.os}}-${{runner.arch}}|${{hashFiles('requirements/locks/py313-lock-linux-64.txt')}}
           path: |
             ~/conda-env
             ~/.local/share/cartopy
@@ -26,7 +26,7 @@ jobs:
         run: |
           # Check cache hasn't pulled a partial key match.
           test ! -e "${HOME}/conda-env"
-          conda create --prefix="${HOME}/conda-env" --file=requirements/locks/py312-lock-linux-64.txt
+          conda create --prefix="${HOME}/conda-env" --file=requirements/locks/py313-lock-linux-64.txt
 
       - name: Add conda environment to PATH
         run: echo "${HOME}/conda-env/bin" >> $GITHUB_PATH

--- a/cset-workflow/app/build_conda/bin/build_conda_env.sh
+++ b/cset-workflow/app/build_conda/bin/build_conda_env.sh
@@ -23,7 +23,7 @@ should_build_conda_env() {
   fi
 
   # Find environment definition file, abort if not found.
-  env_lock_file="${CYLC_WORKFLOW_RUN_DIR}/requirements/locks/py312-lock-linux-64.txt"
+  env_lock_file="${CYLC_WORKFLOW_RUN_DIR}/requirements/locks/py313-lock-linux-64.txt"
   if [[ -f "$env_lock_file" ]]
   then
     echo "Using environment file $env_lock_file"

--- a/docs/source/contributing/getting-started.rst
+++ b/docs/source/contributing/getting-started.rst
@@ -69,7 +69,7 @@ environment for you to use.
 .. code-block:: bash
 
     # Creates a conda environment named "cset-dev".
-    conda create -n cset-dev --file requirements/locks/py312-lock-linux-64.txt
+    conda create -n cset-dev --file requirements/locks/py313-lock-linux-64.txt
     # Activates the conda environment.
     conda activate cset-dev
     # Adds extra checks when you commit something with git.


### PR DESCRIPTION
<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

Use the most recent python version throughout CSET. We are still supported back to 3.10, but aside from the tests for each python version everything should now be using 3.13.

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
