### PR TITLE
Revert to python 3.12 for workflow environment

### DIFF
--- a/cset-workflow/app/build_conda/bin/build_conda_env.sh
+++ b/cset-workflow/app/build_conda/bin/build_conda_env.sh
@@ -5,7 +5,7 @@
 set -euo pipefail
 
 # Find environment definition file, abort if not found.
-env_lock_file="${CYLC_WORKFLOW_RUN_DIR}/requirements/workflow-locks/py313-lock-linux-64.txt"
+env_lock_file="${CYLC_WORKFLOW_RUN_DIR}/requirements/workflow-locks/py312-lock-linux-64.txt"
 if [[ -f "$env_lock_file" ]]; then
   echo "Using environment file $env_lock_file"
 else


### PR DESCRIPTION
Python 3.13 still has issues with the Met Office web proxy. It is going to be May when the certificate is replaced to fix this, so until then we will need to stick with python 3.12 for the workflow, as it needs to fetch the coastline information for cartopy.

Fixes #1167

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
