### PR TITLE
Add colorbar ranges for different pressure levels

### DIFF
--- a/src/CSET/operators/_colorbar_definition.json
+++ b/src/CSET/operators/_colorbar_definition.json
@@ -322,8 +322,8 @@
   },
   "potential_vorticity_at_pressure_levels_difference": {
     "cmap": "bwr",
-    "max": 2e-06,
-    "min": -2e-06
+    "max": 1e-05,
+    "min": -1e-05
   },
   "radar_reflectivity_at_1km_above_the_surface": {
     "cmap": "cubehelix_r",
@@ -346,7 +346,7 @@
     "min": -30
   },
   "relative_humidity_wrt_ice_at_pressure_levels": {
-    "cmap": "viridis",
+    "cmap": "Blues",
     "max": 110,
     "min": 0
   },
@@ -619,8 +619,8 @@
         "min": -80
       },
       "250": {
-        "max": 55,
-        "min": -55
+        "max": 70,
+        "min": -70
       },
       "300": {
         "max": 55,

--- a/src/CSET/operators/_colorbar_definition.json
+++ b/src/CSET/operators/_colorbar_definition.json
@@ -573,8 +573,8 @@
   },
   "vertical_wind_at_pressure_levels": {
     "cmap": "bwr",
-    "max": 5,
-    "min": -5
+    "max": 2,
+    "min": -2
   },
   "vertical_wind_at_pressure_levels_difference": {
     "cmap": "bwr",

--- a/src/CSET/operators/_colorbar_definition.json
+++ b/src/CSET/operators/_colorbar_definition.json
@@ -135,9 +135,27 @@
     "min": -1
   },
   "geopotential_height_at_pressure_levels": {
-    "cmap": "viridis",
-    "max": 10000,
-    "min": 0
+    "cmap": "bwr",
+    "max": 15000,
+    "min": -250,
+    "pressure_levels": {
+      "1000": {
+        "max": 250,
+        "min": -250
+      },
+      "250": {
+        "max": 10200,
+        "min": 9500
+      },
+      "500": {
+        "max": 5600,
+        "min": 4800
+      },
+      "850": {
+        "max": 2000,
+        "min": 1000
+      }
+    }
   },
   "geopotential_height_at_pressure_levels_differences": {
     "cmap": "bwr",
@@ -226,8 +244,46 @@
   },
   "meridional_wind_at_pressure_levels": {
     "cmap": "bwr",
-    "max": 35,
-    "min": -35
+    "max": 50,
+    "min": -50,
+    "pressure_levels": {
+      "100": {
+        "max": 100,
+        "min": -100
+      },
+      "1000": {
+        "max": 35,
+        "min": -35
+      },
+      "200": {
+        "max": 80,
+        "min": -80
+      },
+      "250": {
+        "max": 55,
+        "min": -55
+      },
+      "300": {
+        "max": 55,
+        "min": -55
+      },
+      "500": {
+        "max": 45,
+        "min": -45
+      },
+      "700": {
+        "max": 35,
+        "min": -35
+      },
+      "850": {
+        "max": 35,
+        "min": -35
+      },
+      "950": {
+        "max": 35,
+        "min": -35
+      }
+    }
   },
   "meridional_wind_at_pressure_levels_difference": {
     "cmap": "bwr",
@@ -371,8 +427,8 @@
   },
   "temperature_at_pressure_levels": {
     "cmap": "RdYlBu_r",
-    "max": 330,
-    "min": 200,
+    "max": 320,
+    "min": 240,
     "pressure_levels": {
       "100": {
         "max": 240,
@@ -392,11 +448,11 @@
       },
       "300": {
         "max": 250,
-        "min": 210
+        "min": 200
       },
       "500": {
         "max": 280,
-        "min": 240
+        "min": 220
       },
       "700": {
         "max": 300,
@@ -468,9 +524,47 @@
     "min": -5000
   },
   "vapour_specific_humidity_at_pressure_levels_for_climate_averaging": {
-    "cmap": "viridis",
+    "cmap": "Blues",
     "max": 0.01,
-    "min": 0
+    "min": 0,
+    "pressure_levels": {
+      "100": {
+        "max": 5e-05,
+        "min": 0
+      },
+      "1000": {
+        "max": 0.01,
+        "min": 0
+      },
+      "200": {
+        "max": 5e-05,
+        "min": 0
+      },
+      "250": {
+        "max": 5e-05,
+        "min": 0
+      },
+      "300": {
+        "max": 0.0001,
+        "min": 0
+      },
+      "500": {
+        "max": 0.003,
+        "min": 0
+      },
+      "700": {
+        "max": 0.003,
+        "min": 0
+      },
+      "850": {
+        "max": 0.005,
+        "min": 0
+      },
+      "950": {
+        "max": 0.01,
+        "min": 0
+      }
+    }
   },
   "vapour_specific_humidity_at_pressure_levels_for_climate_averaging_differences": {
     "cmap": "bwr",
@@ -479,8 +573,8 @@
   },
   "vertical_wind_at_pressure_levels": {
     "cmap": "bwr",
-    "max": -1,
-    "min": -1
+    "max": 5,
+    "min": -5
   },
   "vertical_wind_at_pressure_levels_difference": {
     "cmap": "bwr",
@@ -509,8 +603,46 @@
   },
   "zonal_wind_at_pressure_levels": {
     "cmap": "bwr",
-    "max": 35,
-    "min": -35
+    "max": 50,
+    "min": -50,
+    "pressure_levels": {
+      "100": {
+        "max": 100,
+        "min": -100
+      },
+      "1000": {
+        "max": 35,
+        "min": -35
+      },
+      "200": {
+        "max": 80,
+        "min": -80
+      },
+      "250": {
+        "max": 55,
+        "min": -55
+      },
+      "300": {
+        "max": 55,
+        "min": -55
+      },
+      "500": {
+        "max": 45,
+        "min": -45
+      },
+      "700": {
+        "max": 35,
+        "min": -35
+      },
+      "850": {
+        "max": 35,
+        "min": -35
+      },
+      "950": {
+        "max": 35,
+        "min": -35
+      }
+    }
   },
   "zonal_wind_at_pressure_levels_difference": {
     "cmap": "bwr",


### PR DESCRIPTION
Amends a selection of pressure level color bars to vary with pressure to provide appropriate color bars.

Fixes #1179 

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [ ] All tests and CI checks pass.
- [ ] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [ ] Marked the PR as ready to review.
