### PR TITLE
Add fixes for vertical line xlim and PDF xlim

### DIFF
--- a/src/CSET/operators/plot.py
+++ b/src/CSET/operators/plot.py
@@ -1159,6 +1159,9 @@ def plot_vertical_line_series(
     # Initialise empty list to hold all data from all cubes in a CubeList
     all_data = []
 
+    # Store min/max ranges for x range
+    x_levels = []
+
     # Iterate over all cubes in cube or CubeList and plot.
     for cube_iter in iter_maybe(cubes):
         # Ensure we've got a single cube.
@@ -1180,18 +1183,26 @@ def plot_vertical_line_series(
                 f"Cube must have a {sequence_coordinate} coordinate or be 1D."
             ) from err
 
-        # Append cube data to the list to calculate vmin and vmax across entire
-        # cubelist.
-        all_data.append(cube_iter.data)
+        # Get minimum and maximum from levels information.
+        _, levels, _ = _colorbar_map_levels(cube_iter)
+        if levels is not None:
+            x_levels.append(min(levels))
+            x_levels.append(max(levels))
+        else:
+            all_data.append(cube_iter.data)
 
-    # Combine all data into a single NumPy array
-    combined_data = np.concatenate(all_data)
+    if len(x_levels) == 0:
+        # Combine all data into a single NumPy array
+        combined_data = np.concatenate(all_data)
 
-    # Set the lower and upper limit for the x-axis to ensure all plots have same
-    # range. This needs to read the whole cube over the range of the sequence
-    # and if applicable postage stamp coordinate.
-    vmin = np.floor(combined_data.min())
-    vmax = np.ceil(combined_data.max())
+        # Set the lower and upper limit for the x-axis to ensure all plots have same
+        # range. This needs to read the whole cube over the range of the sequence
+        # and if applicable postage stamp coordinate.
+        vmin = np.floor(combined_data.min())
+        vmax = np.ceil(combined_data.max())
+    else:
+        vmin = min(x_levels)
+        vmax = max(x_levels)
 
     # Create a plot for each value of the sequence coordinate.
     # Allowing for multiple cubes in a CubeList to be plotted in the same plot for

--- a/src/CSET/operators/plot.py
+++ b/src/CSET/operators/plot.py
@@ -1160,7 +1160,7 @@ def plot_vertical_line_series(
     # Initialise empty list to hold all data from all cubes in a CubeList
     all_data = []
 
-    # Store min/max ranges for x range
+    # Store min/max ranges for x range.
     x_levels = []
 
     # Iterate over all cubes in cube or CubeList and plot.


### PR DESCRIPTION
Also removes obslete references to the type of histogram (step filled, etc.) as this is no longer specified in the GUI and does not pass through into the recipes.

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [ ] All tests and CI checks pass.
- [ ] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [ ] Marked the PR as ready to review.
