### PR TITLE
Set website display date at plot creation

### DIFF
--- a/src/CSET/_workflow_utils/finish_website.py
+++ b/src/CSET/_workflow_utils/finish_website.py
@@ -34,7 +34,7 @@ def construct_index():
                 plot_metadata = json.load(fp)
             record = {
                 plot_metadata["category"]: {
-                    directory.name: f"{plot_metadata['title']} {os.getenv('CYLC_TASK_CYCLE_POINT', '')}".strip()
+                    directory.name: f"{plot_metadata['title']} {plot_metadata.get('case_date', '')}".strip()
                 }
             }
         except FileNotFoundError:

--- a/src/CSET/operators/plot.py
+++ b/src/CSET/operators/plot.py
@@ -20,6 +20,7 @@ import importlib.resources
 import json
 import logging
 import math
+import os
 import sys
 from typing import Literal
 
@@ -59,6 +60,17 @@ def _append_to_plot_index(plot_index: list) -> list:
         complete_plot_index = meta.get("plots", [])
         complete_plot_index = complete_plot_index + plot_index
         meta["plots"] = complete_plot_index
+        logging.debug(
+            "Cylc task namespace hierarchy: %s",
+            os.getenv(
+                "CYLC_TASK_NAMESPACE_HIERARCHY",
+                "$CYLC_TASK_NAMESPACE_HIERARCHY not set.",
+            ),
+        )
+        if "PROCESS_CASE_AGGREGATION" not in os.getenv(
+            "CYLC_TASK_NAMESPACE_HIERARCHY", ""
+        ):
+            meta["case_date"] = os.getenv("CYLC_TASK_CYCLE_POINT", "")
         fp.seek(0)
         fp.truncate()
         json.dump(meta, fp, indent=2)

--- a/tests/operators/test_plots.py
+++ b/tests/operators/test_plots.py
@@ -414,3 +414,37 @@ def test_invalid_plotting_method_postage_stamp_spatial_plot(cube, tmp_working_di
         plot._plot_and_save_postage_stamp_spatial_plot(
             cube, "filename", "realization", "title", "invalid"
         )
+
+
+def test_append_to_plot_index(monkeypatch, tmp_working_dir):
+    """Ensure the datetime is written along with the plot index."""
+    # Setup environment and required file.
+    monkeypatch.setenv("CYLC_TASK_CYCLE_POINT", "20000101T0000Z")
+    with open("meta.json", "wt") as fp:
+        fp.write('{"plots":["plot_1"]}\n')
+
+    plot._append_to_plot_index(["plot_2"])
+
+    with open("meta.json", "rt") as fp:
+        meta = json.load(fp)
+    assert meta == {"plots": ["plot_1", "plot_2"], "case_date": "20000101T0000Z"}
+    assert "datetime" not in meta
+
+
+def test_append_to_plot_index_case_aggregation_no_datetime(
+    monkeypatch, tmp_working_dir
+):
+    """Ensure the datetime is not written for aggregation plots."""
+    # Setup environment and required file.
+    monkeypatch.setenv("CYLC_TASK_CYCLE_POINT", "20000101T0000Z")
+    monkeypatch.setenv(
+        "CYLC_TASK_NAMESPACE_HIERARCHY", "root PROCESS_CASE_AGGREGATION task_name"
+    )
+    with open("meta.json", "wt") as fp:
+        fp.write("{}\n")
+
+    plot._append_to_plot_index(["plot_1"])
+
+    with open("meta.json", "rt") as fp:
+        meta = json.load(fp)
+    assert "case_date" not in meta


### PR DESCRIPTION
This ensures the correct cycle point datetime is picked up. The date is not set for case study aggregation plots as there isn't a sensible date to pick.

Fixes #940

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [x] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
