### PR TITLE
Rename difference cube with long name

### DIFF
--- a/src/CSET/operators/misc.py
+++ b/src/CSET/operators/misc.py
@@ -347,6 +347,6 @@ def difference(cubes: CubeList):
 
     # This currently relies on the cubes having the same underlying data layout.
     difference = base.copy()
-    difference.rename(base.longname() + "_difference")
+    difference.rename(base.long_name() + "_difference")
     difference.data = base.data - other.data
     return difference

--- a/src/CSET/operators/misc.py
+++ b/src/CSET/operators/misc.py
@@ -347,6 +347,6 @@ def difference(cubes: CubeList):
 
     # This currently relies on the cubes having the same underlying data layout.
     difference = base.copy()
-    difference.rename(base.name() + "_difference")
+    difference.rename(base.longname() + "_difference")
     difference.data = base.data - other.data
     return difference

--- a/src/CSET/operators/misc.py
+++ b/src/CSET/operators/misc.py
@@ -347,6 +347,6 @@ def difference(cubes: CubeList):
 
     # This currently relies on the cubes having the same underlying data layout.
     difference = base.copy()
-    difference.rename(base.long_name() + "_difference")
+    difference.rename(base.long_name + "_difference")
     difference.data = base.data - other.data
     return difference


### PR DESCRIPTION
Difference cubes are currently renamed with name, this is potentially causing issues with the color bar and so trying a rename on the long name.

Fixes #1187

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [ ] All tests and CI checks pass.
- [ ] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [ ] Marked the PR as ready to review.
