### PR TITLE
Error build_conda when local CSET path not set

### DIFF
--- a/cset-workflow/app/build_conda/bin/install-local-cset.sh
+++ b/cset-workflow/app/build_conda/bin/install-local-cset.sh
@@ -5,8 +5,13 @@
 set -euo pipefail
 
 if [[ $CSET_ENV_USE_LOCAL_CSET = "True" ]]; then
-  cset_source_path="${CSET_LOCAL_CSET_PATH}"
-  echo "Using local CSET from ${cset_source_path}"
+  if [[ -e $CSET_LOCAL_CSET_PATH ]]; then
+    cset_source_path="${CSET_LOCAL_CSET_PATH}"
+    echo "Using local CSET from ${cset_source_path}"
+  else
+    echo "${CSET_LOCAL_CSET_PATH:-''}" does not exist. Make sure CSET_LOCAL_CSET_PATH is set correctly.
+    exit 1
+  fi
 
   # Directly install wheel files or copy, build, and install source folder.
   if [[ $cset_source_path == *.whl ]]; then


### PR DESCRIPTION
We now check that the value of `CSET_LOCAL_CSET_PATH` points to a file or directory that exists before using it.

Fixes #1202

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
