### PR TITLE
Create needed parent directories when writing the website

### DIFF
--- a/cset-workflow/app/install_website_skeleton/bin/install-website.sh
+++ b/cset-workflow/app/install_website_skeleton/bin/install-website.sh
@@ -23,6 +23,10 @@ mkdir -v "${CYLC_WORKFLOW_SHARE_DIR}/web"
 cp -rv html/* "${CYLC_WORKFLOW_SHARE_DIR}/web"
 # Create directory for plots.
 mkdir -p "${CYLC_WORKFLOW_SHARE_DIR}/web/plots"
+
+# Ensure parent directories of WEB_DIR exist.
+mkdir -p "$(dirname "$WEB_DIR")"
+
 # Create symbolic link to web directory.
 # NOTE: While good for space, it means `cylc clean` removes output.
 ln -s "${CYLC_WORKFLOW_SHARE_DIR}/web" "$WEB_DIR"

--- a/cset-workflow/meta/rose-meta.conf
+++ b/cset-workflow/meta/rose-meta.conf
@@ -78,7 +78,7 @@ help=This will probably be under $HOME/public_html or similar. You will want to
 
     This is where the output of the workflow will be accessible from, through a
     symlink to the workflow shared directory. Anything existing at the path will
-    be removed.
+    be removed. Missing intermediate directories will be created.
 
     E.g: $HOME/public_html/CSET
 type=quoted

--- a/cset-workflow/meta/rose-meta.conf.jinja2
+++ b/cset-workflow/meta/rose-meta.conf.jinja2
@@ -78,7 +78,7 @@ help=This will probably be under $HOME/public_html or similar. You will want to
 
     This is where the output of the workflow will be accessible from, through a
     symlink to the workflow shared directory. Anything existing at the path will
-    be removed.
+    be removed. Missing intermediate directories will be created.
 
     E.g: $HOME/public_html/CSET
 type=quoted


### PR DESCRIPTION
<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

This prevents errors such as:

```
WEB_DIR="$HOME/public_html/CSET/300m_UM_vs_LFRic_test" but the install_website_skeleton task failed with:
ln: failed to create symbolic link '/home/users/example.person/public_html/CSET/300m_UM_vs_LFRic_test': No such file or directory
```

Due to the intermediate CSET directory not already existing. These intermediate directories will now be created as needed.

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [x] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
