### PR TITLE
Remove tox

### DIFF
--- a/docs/source/contributing/documentation.rst
+++ b/docs/source/contributing/documentation.rst
@@ -13,13 +13,16 @@ documentation.
 The documentation is organised into sections following the `Diátaxis
 documentation system`_.
 
-You can build the documentation of CSET with the following command:
+You can build the documentation of CSET with the following commands:
 
 .. code-block:: bash
 
-    tox -e docs
+    # Ensure you are in the docs directory.
+    cd docs
+    # Build the HTML documentation.
+    make html
 
-The documentation will be output to the docs/build directory.
+The documentation will be output to the docs/build/html directory.
 
 .. _Diátaxis documentation system: https://diataxis.fr/
 

--- a/docs/source/contributing/testing.rst
+++ b/docs/source/contributing/testing.rst
@@ -15,20 +15,21 @@ of the project.
 Having tooling to aid in comparing output to KGO is useful, especially if we
 want to get into automated functional testing.
 
-You can run the tests of CSET simply with the following command:
+You can run the tests of CSET with the following command:
 
 .. code-block:: bash
 
-    tox
+    pytest
 
 .. note::
 
-    You might need to load the conda environment beforehand with the
-    following command:
+    You will need to make sure you have the conda environment activated, and that
+    CSET is installed into it with:
 
     .. code-block:: bash
 
         conda activate cset-dev
+        pip install -e .
 
 Quick testing of individual components during development
 ---------------------------------------------------------
@@ -38,7 +39,7 @@ Fortunately individual tests can be run on the command line with:
 
 .. code-block:: bash
 
-    pytest -k file_name_of_test
+    pytest -k name_of_test
 
 
 You can also run all of the tests in a file, by giving the name of the file. For
@@ -47,14 +48,6 @@ example, the following command will run all of the plotting tests.
 .. code-block:: bash
 
     pytest -k test_plots
-
-
-You will need to make sure you have the conda environment activated, and that
-CSET is installed into it with:
-
-.. code-block:: bash
-
-    pip install -e .
 
 Unit Testing
 ------------
@@ -120,14 +113,15 @@ some good points on writing docstrings for unit tests.
 Pre-commit Checks
 -----------------
 
-Some very quick checks to catch any very obvious mistakes. They are usually
-setup to run automatically when you make a commit. The checks are installed from
-.pre-commit-config.yaml, and currently involve formatting python code, linting,
-and checking all files are well formed (no trailing whitespace, etc.).
+Pre-commit checks are very quick checks to catch any obvious mistakes. They are
+usually setup to run automatically when you make a commit. The checks are
+installed from .pre-commit-config.yaml, and currently involve formatting python
+code, linting, and checking all files are well formed (no trailing whitespace,
+etc.).
 
 .. code-block:: bash
 
-    # Install the pre-commit helper.
-    pip install pre-commit
+    # Ensure your conda environment is activated.
+    conda activate cset-dev
     # Install the checks into git
     pre-commit install

--- a/docs/source/usage/add-diagnostic.rst
+++ b/docs/source/usage/add-diagnostic.rst
@@ -130,12 +130,12 @@ once in the ``src/CSET/recipes`` directory. This way we can run recipes with the
 Test your code
 --------------
 
-Tests can be run by invoking the ``tox`` command and are also run on ``git
-commit``. To run the tests:
+Tests can be run by invoking the ``pytest`` command. Some additional checks are
+also run on ``git commit`` via ``pre-commit``. To run the tests:
 
 .. code-block:: bash
 
-    tox
+    pytest
 
 Committing code
 ---------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,41 +65,6 @@ relative_files = true
 source = ["src"]
 omit = ["__main__.py"]
 
-[tool.tox]
-legacy_tox_ini = '''
-[tox]
-requires = tox-conda
-isolated_build = True
-envlist =
-    coverage-clean
-    py312-linux-tests
-    py312-linux-docs
-
-[testenv:py{310,311,312}-{linux,osx,win}-tests]
-description = Run unit and integration tests with PyTest.
-conda_spec =
-    py310-linux: {toxinidir}{/}requirements{/}locks{/}py310-lock-linux-64.txt
-    py311-linux: {toxinidir}{/}requirements{/}locks{/}py311-lock-linux-64.txt
-    py312-linux: {toxinidir}{/}requirements{/}locks{/}py312-lock-linux-64.txt
-usedevelop = true
-depends = coverage-clean
-commands = pytest {posargs}
-
-[testenv:py{310,311,312}-{linux,osx,win}-docs]
-description = Invoke sphinx-build to build the HTML docs.
-conda_spec =
-    py310-linux: {toxinidir}{/}requirements{/}locks{/}py310-lock-linux-64.txt
-    py311-linux: {toxinidir}{/}requirements{/}locks{/}py311-lock-linux-64.txt
-    py312-linux: {toxinidir}{/}requirements{/}locks{/}py312-lock-linux-64.txt
-usedevelop = true
-commands = sphinx-build -d "docs/build/doctree" docs/source "docs/build/html" --color -W -bhtml {posargs}
-
-[testenv:coverage-clean]
-deps = coverage
-skip_install = true
-commands = coverage erase
-'''
-
 [tool.codespell]
 ignore-words-list = "lazyness,meaned"
 skip = "build,*.css,*.ipynb,*.js,*.html,*.svg,*.xml,.git"

--- a/requirements/environment.yml
+++ b/requirements/environment.yml
@@ -23,8 +23,6 @@ dependencies:
   - ruff
 
   # Testing dependencies
-  - tox < 4.0
-  - tox-conda
   - pytest >= 7.0
   - pytest-cov
   - pytest-xdist


### PR DESCRIPTION
<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

We have stopped using tox for our development, as it doesn't offer enough over just using the cset-dev conda environment and the tools directly. It is also very slow on the networked filesystems our development environment uses. In addition we are pinned to an old, unmaintained version of tox to retain support for conda environments.

Given all of that this PR removes all references to tox from the documentation, removes the tox configuration, and removes the tox package from the cset-dev environment.

I've intentionally left it in the environment lock files, as actively removing it has a high chance of messy merge conflicts. It will get removed on the next weekly lockfile update after this PR is merged.

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [x] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
