### PR TITLE
Updated vertical line series pressure maximum y limit to 100hPa.

### DIFF
--- a/src/CSET/operators/plot.py
+++ b/src/CSET/operators/plot.py
@@ -581,12 +581,8 @@ def _plot_and_save_vertical_line_series(
             "300",
             "200",
             "100",
-            "50",
-            "30",
-            "20",
-            "10",
         ]
-        y_ticks = [1000, 850, 700, 500, 300, 200, 100, 50, 30, 20, 10]
+        y_ticks = [1000, 850, 700, 500, 300, 200, 100]
 
         # Set y-axis limits and ticks.
         ax.set_ylim(1100, 100)


### PR DESCRIPTION
I have changed the vertical line series y limit maximum from 10 hPa to 100 hPa and checked that the plots are correct by running the cset-workflow. This change is associated with #1210.

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
