### PR TITLE
Check for staggered grid with name rather than STASH in difference operator

### DIFF
--- a/src/CSET/operators/misc.py
+++ b/src/CSET/operators/misc.py
@@ -303,13 +303,13 @@ def difference(cubes: CubeList):
         base.coord(base_lat_name).shape != other.coord(other_lat_name).shape
         or base.coord(base_lon_name).shape != other.coord(other_lon_name).shape
     ):
-        if base.attributes.get("STASH", None) in [
-            "m01s03i225",
-            "m01s03i226",
-            "m01s15i201",
-            "m01s15i202",
-            "m01s15i229",
-            "m01s30i205",
+        if base.long_name in [
+            "eastward_wind_at_10m",
+            "northward_wind_at_10m",
+            "zonal_wind_at_pressure_levels",
+            "meridional_wind_at_pressure_levels",
+            "potential_vorticity_at_pressure_levels",
+            "vapour_specific_humidity_at_pressure_levels_for_climate_averaging",
         ]:
             base = regrid_onto_cube(base, other, method="Linear")
         else:

--- a/tests/operators/test_misc.py
+++ b/tests/operators/test_misc.py
@@ -230,7 +230,7 @@ def test_difference_incorrect_data_shape_regrid(cube):
     """
     rearranged_cube = cube.copy()
     rearranged_cube = rearranged_cube[:, :, 1:]
-    rearranged_cube.attributes["STASH"] = "m01s03i225"
+    rearranged_cube.rename("eastward_wind_at_10m")
     del cube.attributes["cset_comparison_base"]
     cubes = iris.cube.CubeList([rearranged_cube, cube])
     difference = misc.difference(cubes)


### PR DESCRIPTION
Checking for STASH codes only works when the base model is the UM.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [x] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
