### PR TITLE
Fully sort website index

### DIFF
--- a/src/CSET/_common.py
+++ b/src/CSET/_common.py
@@ -329,6 +329,24 @@ def iter_maybe(thing) -> Iterable:
     return (thing,)
 
 
+def human_sorted(iterable: Iterable, reverse: bool = False) -> list:
+    """Sort such numbers within strings are sorted correctly."""
+    # Adapted from https://nedbatchelder.com/blog/200712/human_sorting.html
+
+    def alphanum_key(s):
+        """Turn a string into a list of string and number chunks.
+
+        >>> alphanum_key("z23a")
+        ["z", 23, "a"]
+        """
+        try:
+            return [int(c) if c.isdecimal() else c for c in re.split(r"(\d+)", s)]
+        except TypeError:
+            return s
+
+    return sorted(iterable, key=alphanum_key, reverse=reverse)
+
+
 def combine_dicts(d1: dict, d2: dict) -> dict:
     """Recursively combines two dictionaries.
 
@@ -344,3 +362,12 @@ def combine_dicts(d1: dict, d2: dict) -> dict:
     for key in d2.keys() - d1.keys():
         d1[key] = d2[key]
     return d1
+
+
+def sort_dict(d: dict) -> dict:
+    """Recursively sort a dictionary."""
+    # Thank you to https://stackoverflow.com/a/47882384
+    return {
+        k: sort_dict(v) if isinstance(v, dict) else v
+        for k, v in human_sorted(d.items())
+    }

--- a/src/CSET/_workflow_utils/finish_website.py
+++ b/src/CSET/_workflow_utils/finish_website.py
@@ -11,7 +11,7 @@ import logging
 import os
 from pathlib import Path
 
-from CSET._common import combine_dicts
+from CSET._common import combine_dicts, sort_dict
 
 logging.basicConfig(
     level=os.getenv("LOGLEVEL", "INFO"), format="%(asctime)s %(levelname)s %(message)s"
@@ -51,15 +51,9 @@ def construct_index():
         index = combine_dicts(index, record)
 
     # Sort index of diagnostics.
-    index = dict(sorted(index.items()))
-    for category in index:
-        for case_date in index[category]:
-            diagnostics = index[category][case_date]
-            index[category][case_date] = dict(
-                # Sort by display name.
-                sorted(diagnostics.items(), key=lambda x: x[1])
-            )
+    index = sort_dict(index)
 
+    # Write out website index.
     with open(plots_dir / "index.json", "wt", encoding="UTF-8") as fp:
         json.dump(index, fp, indent=2)
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -282,9 +282,24 @@ def test_iter_maybe_string():
         assert value is atom
 
 
+def test_human_sort():
+    """Strings are sorted by value of contained numbers."""
+    strings = ["a9", "a100", "a20", "a"]
+    assert common.human_sorted(strings) == ["a", "a9", "a20", "a100"]
+    # Check it is also fine with non-string data types.
+    other_types = [[4, 5, 6], [1, 2, 3]]
+    assert common.human_sorted(other_types) == [[1, 2, 3], [4, 5, 6]]
+
+
 def test_combine_dicts():
     """Test combine_dicts function."""
     d1 = {"a": 1, "b": 2, "c": {"d": 3, "e": 4}}
     d2 = {"b": 3, "c": {"d": 5, "f": 6}}
     expected = {"a": 1, "b": 3, "c": {"d": 5, "e": 4, "f": 6}}
     assert common.combine_dicts(d1, d2) == expected
+
+
+def test_sort_dicts():
+    """Test recursively sorting a dictionary."""
+    d = {"b": {"ba": 1, "bb": 2}, "a": {"ab": 2, "aa": 1}}
+    assert common.sort_dict(d) == {"a": {"aa": 1, "ab": 2}, "b": {"ba": 1, "bb": 2}}


### PR DESCRIPTION
This uses a newly added human sort function, which ensures that strings containing numbers are sorted by value, rather than just character by character. This ensures that 9 sorts before 10, for example.

Fixes #1230

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [x] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
