### PR TITLE
Increase aggregation wallclock to 3 hours

### DIFF
--- a/cset-workflow/flow.cylc
+++ b/cset-workflow/flow.cylc
@@ -105,7 +105,7 @@ URL = https://metoffice.github.io/CSET
 
     [[PROCESS_CASE_AGGREGATION]]
     script = rose task-run -v --app-key=run_cset_recipe
-    execution time limit = PT2H
+    execution time limit = PT3H
         [[[directives]]]
         --mem=100000
         [[[environment]]]


### PR DESCRIPTION
This should help with tasks occasionally timing out. Three hours is the practical limit for most compute systems without going into special long job queues.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
