### PR TITLE
Support equalising hour coordinate in difference operator

### DIFF
--- a/src/CSET/operators/aggregate.py
+++ b/src/CSET/operators/aggregate.py
@@ -20,8 +20,6 @@ import iris
 import iris.analysis
 import iris.coord_categorisation
 import iris.cube
-import iris.exceptions
-import iris.util
 import isodate
 
 from CSET._common import iter_maybe


### PR DESCRIPTION
It will now equalise any time coordinate, rather than just one called "time". Notably this means it now supports the "hours" coordinate creating by aggregate_by_hour_of_day.

Fixes #1244

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [x] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
