### PR TITLE
Nicer output on crash from run_cset_recipe

### DIFF
--- a/tests/workflow_utils/test_run_cset_recipe.py
+++ b/tests/workflow_utils/test_run_cset_recipe.py
@@ -129,6 +129,18 @@ def test_entrypoint(monkeypatch):
     assert function_ran, "Function did not run!"
 
 
+def test_entrypoint_exit_on_subprocess_exception(monkeypatch):
+    """Check that run_cset_recipe.run() exits non-zero."""
+
+    def subprocess_error():
+        raise subprocess.CalledProcessError(1, "foo")
+
+    monkeypatch.setattr(run_cset_recipe, "run_recipe_steps", subprocess_error)
+    with pytest.raises(SystemExit) as exc_info:
+        run_cset_recipe.run()
+        assert exc_info.value.code == 1
+
+
 def test_run_recipe_steps(monkeypatch, tmp_working_dir):
     """Test run recipe steps correctly runs CSET and creates an archive."""
 


### PR DESCRIPTION
<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

This removes the large (double) traceback when CSET crashes. These
tracebacks don't contain anything useful as the subprocess already logs
its own crash output.

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [x] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
