### PR TITLE
include precipitation specific colorbar and unit conversion

### DIFF
--- a/src/CSET/operators/_colorbar_definition.json
+++ b/src/CSET/operators/_colorbar_definition.json
@@ -392,18 +392,8 @@
   },
   "surface_microphysical_rainfall_rate": {
     "cmap": "cividis",
-    "levels": [
-      0.125,
-      0.25,
-      0.5,
-      1,
-      2,
-      4,
-      8,
-      16,
-      32,
-      64
-    ]
+    "max": 256.0,
+    "min": 0.0
   },
   "surface_microphysical_rainfall_rate_difference": {
     "cmap": "bwr",

--- a/src/CSET/operators/_colorbar_definition.json
+++ b/src/CSET/operators/_colorbar_definition.json
@@ -392,7 +392,7 @@
   },
   "surface_microphysical_rainfall_rate": {
     "cmap": "cividis",
-    "max": 0.001,
+    "max": 256.0,
     "min": 0
   },
   "surface_microphysical_rainfall_rate_difference": {

--- a/src/CSET/operators/_colorbar_definition.json
+++ b/src/CSET/operators/_colorbar_definition.json
@@ -392,8 +392,21 @@
   },
   "surface_microphysical_rainfall_rate": {
     "cmap": "cividis",
-    "max": 256.0,
-    "min": 0.0
+    "levels": [
+      0,
+      0.125,
+      0.25,
+      0.5,
+      1,
+      2,
+      4,
+      8,
+      16,
+      32,
+      64,
+      128,
+      256
+    ]
   },
   "surface_microphysical_rainfall_rate_difference": {
     "cmap": "bwr",

--- a/src/CSET/operators/_colorbar_definition.json
+++ b/src/CSET/operators/_colorbar_definition.json
@@ -392,8 +392,18 @@
   },
   "surface_microphysical_rainfall_rate": {
     "cmap": "cividis",
-    "max": 256.0,
-    "min": 0
+    "levels": [
+      0.125,
+      0.25,
+      0.5,
+      1,
+      2,
+      4,
+      8,
+      16,
+      32,
+      64
+    ]
   },
   "surface_microphysical_rainfall_rate_difference": {
     "cmap": "bwr",

--- a/src/CSET/operators/plot.py
+++ b/src/CSET/operators/plot.py
@@ -959,11 +959,11 @@ def _convert_precipitation_units_callback(cube: iris.cube.Cube):
     if cube.long_name == "surface_microphysical_rainfall_rate":
         if cube.units == "kg m-2 s-1":
             logging.info("Converting precipitation units from kg m-2 s-1 to mm hr-1")
-            # manually convert from kg m-2 s-1 to mm hr-1 assuming 1kg water = 1l water = 1dm^3 water
-            cube.data = cube.data * 3600.0
-
-            # update the units
-            cube.units = "mm hr-1"
+            # Convert from kg m-2 s-1 to mm s-1 assuming 1kg water = 1l water = 1dm^3 water.
+            # This is a 1:1 conversion, so we just change the units.
+            cube.units = "mm s-1"
+            # Convert the units to per hour.
+            cube.convert_units("mm hr-1")
         else:
             logging.warning(
                 "Precipitation units are not in 'kg m-2 s-1', skipping conversion"

--- a/src/CSET/operators/plot.py
+++ b/src/CSET/operators/plot.py
@@ -1495,7 +1495,6 @@ def _convert_precipitation_units_callback(cube: iris.cube.Cube):
 
     Some precipitation diagnostics are output with unit kg m-2 s-1 and are converted to mm hr-1.
     """
-    try:
         # if cube.attributes["STASH"] == "m01s04i203" or cube.long_name == "surface_microphysical_rainfall_rate":
         if cube.long_name == "surface_microphysical_rainfall_rate":
             if cube.units == "kg m-2 s-1":

--- a/src/CSET/operators/plot.py
+++ b/src/CSET/operators/plot.py
@@ -1511,10 +1511,4 @@ def _convert_precipitation_units_callback(cube: iris.cube.Cube):
                 logging.warning(
                     "Precipitation units are not in 'kg m-2 s-1', skipping conversion"
                 )
-    except iris.exceptions.CoordinateNotFoundError:
-        logging.warning(
-            "Precipitation cube does not contain the required coordinate, skipping conversion"
-        )
-    except KeyError:
-        logging.warning("STASH attribute not found in cube, cannot convert units")
     return cube

--- a/src/CSET/operators/plot.py
+++ b/src/CSET/operators/plot.py
@@ -977,8 +977,9 @@ def _custom_colourmap_precipitation(cube: iris.cube.Cube, cmap, levels, norm):
         or cube.var_name == "surface_microphysical_rainfall_rate"
     ):
         # Define the levels and colors
-        levels = [0.125, 0.25, 0.5, 1, 2, 4, 8, 16, 32, 64, 128]
+        levels = [0, 0.125, 0.25, 0.5, 1, 2, 4, 8, 16, 32, 64, 128, 256]
         colors = [
+            "w",
             (0, 0, 0.6),
             "b",
             "c",
@@ -986,9 +987,11 @@ def _custom_colourmap_precipitation(cube: iris.cube.Cube, cmap, levels, norm):
             "y",
             (1, 0.5, 0),
             "r",
+            "pink",
             "m",
-            (0.6, 0.6, 0.6),
-            "k",
+            "purple",
+            "maroon",
+            "gray",
         ]
         # Create a custom colormap
         cmap = mcolors.ListedColormap(colors)

--- a/src/CSET/operators/plot.py
+++ b/src/CSET/operators/plot.py
@@ -313,7 +313,7 @@ def _plot_and_save_spatial_plot(
             vmax = max(levels)
         except TypeError:
             vmin, vmax = None, None
-        # pcolormesh plot of the field and ensure not to use norm and not vmin/vmax if levels are defined.
+        # pcolormesh plot of the field and ensure to use norm and not vmin/vmax if levels are defined.
         if norm is not None:
             vmin = None
             vmax = None
@@ -385,6 +385,10 @@ def _plot_and_save_spatial_plot(
     # Add colour bar.
     cbar = fig.colorbar(plot, orientation="horizontal")
     cbar.set_label(label=f"{cube.name()} ({cube.units})", size=20)
+    # add ticks and tick_labels for every levels if less than 20 levels exist
+    if levels is not None and len(levels) < 20:
+        cbar.set_ticks(levels)
+        cbar.set_ticklabels([f"{level:.1f}" for level in levels])
 
     # Save plot.
     fig.savefig(filename, bbox_inches="tight", dpi=_get_plot_resolution())

--- a/src/CSET/operators/plot.py
+++ b/src/CSET/operators/plot.py
@@ -1495,19 +1495,17 @@ def _convert_precipitation_units_callback(cube: iris.cube.Cube):
 
     Some precipitation diagnostics are output with unit kg m-2 s-1 and are converted to mm hr-1.
     """
-        # if cube.attributes["STASH"] == "m01s04i203" or cube.long_name == "surface_microphysical_rainfall_rate":
-        if cube.long_name == "surface_microphysical_rainfall_rate":
-            if cube.units == "kg m-2 s-1":
-                logging.info(
-                    "Converting precipitation units from kg m-2 s-1 to mm hr-1"
-                )
-                # manually convert from kg m-2 s-1 to mm hr-1 assuming 1kg water = 1l water = 1dm^3 water
-                cube.data = cube.data * 3600.0
+    # if cube.attributes["STASH"] == "m01s04i203" or cube.long_name == "surface_microphysical_rainfall_rate":
+    if cube.long_name == "surface_microphysical_rainfall_rate":
+        if cube.units == "kg m-2 s-1":
+            logging.info("Converting precipitation units from kg m-2 s-1 to mm hr-1")
+            # manually convert from kg m-2 s-1 to mm hr-1 assuming 1kg water = 1l water = 1dm^3 water
+            cube.data = cube.data * 3600.0
 
-                # update the units
-                cube.units = "mm hr-1"
-            else:
-                logging.warning(
-                    "Precipitation units are not in 'kg m-2 s-1', skipping conversion"
-                )
+            # update the units
+            cube.units = "mm hr-1"
+        else:
+            logging.warning(
+                "Precipitation units are not in 'kg m-2 s-1', skipping conversion"
+            )
     return cube

--- a/src/CSET/operators/plot.py
+++ b/src/CSET/operators/plot.py
@@ -891,6 +891,9 @@ def _spatial_plot(
     # Ensure we've got a single cube.
     cube = _check_single_cube(cube)
 
+    # Convert precipitation units if necessary
+    _convert_precipitation_units_callback(cube)
+
     # Make postage stamp plots if stamp_coordinate exists and has more than a
     # single point.
     plotting_func = _plot_and_save_spatial_plot
@@ -978,9 +981,6 @@ def spatial_contour_plot(
     TypeError
         If the cube isn't a single cube.
     """
-    # Convert precipitation units if necessary
-    _convert_precipitation_units_callback(cube)
-
     _spatial_plot("contourf", cube, filename, sequence_coordinate, stamp_coordinate)
     return cube
 

--- a/src/CSET/operators/plot.py
+++ b/src/CSET/operators/plot.py
@@ -245,6 +245,7 @@ def _colorbar_map_levels(cube: iris.cube.Cube):
                 # smooth range.
                 norm = mpl.colors.BoundaryNorm(levels, ncolors=cmap.N)
                 logging.debug("Using levels for %s colorbar.", varname)
+                logging.info("Using levels: %s", levels)
             except KeyError:
                 # Get the range for this variable.
                 vmin, vmax = var_colorbar["min"], var_colorbar["max"]
@@ -299,13 +300,13 @@ def _plot_and_save_spatial_plot(
         # Filled contour plot of the field.
         plot = iplt.contourf(cube, cmap=cmap, levels=levels, norm=norm)
     elif method == "pcolormesh":
-        try:
-            vmin = min(levels)
-            vmax = max(levels)
-        except TypeError:
-            vmin, vmax = None, None
+        # try:
+        #    vmin = min(levels)
+        #    vmax = max(levels)
+        # except TypeError:
+        # vmin, vmax = None, None
         # pcolormesh plot of the field.
-        plot = iplt.pcolormesh(cube, cmap=cmap, norm=norm, vmin=vmin, vmax=vmax)
+        plot = iplt.pcolormesh(cube, cmap=cmap, norm=norm)
     else:
         raise ValueError(f"Unknown plotting method: {method}")
 

--- a/src/CSET/operators/plot.py
+++ b/src/CSET/operators/plot.py
@@ -935,6 +935,27 @@ def _spatial_plot(
     _make_plot_html_page(complete_plot_index)
 
 
+def _convert_precipitation_units_callback(cube: iris.cube.Cube):
+    """To convert the unit of precipitation from kg m-2 s-1 to mm hr-1.
+
+    Some precipitation diagnostics are output with unit kg m-2 s-1 and are converted to mm hr-1.
+    """
+    # if cube.attributes["STASH"] == "m01s04i203" or cube.long_name == "surface_microphysical_rainfall_rate":
+    if cube.long_name == "surface_microphysical_rainfall_rate":
+        if cube.units == "kg m-2 s-1":
+            logging.info("Converting precipitation units from kg m-2 s-1 to mm hr-1")
+            # manually convert from kg m-2 s-1 to mm hr-1 assuming 1kg water = 1l water = 1dm^3 water
+            cube.data = cube.data * 3600.0
+
+            # update the units
+            cube.units = "mm hr-1"
+        else:
+            logging.warning(
+                "Precipitation units are not in 'kg m-2 s-1', skipping conversion"
+            )
+    return cube
+
+
 ####################
 # Public functions #
 ####################
@@ -1488,24 +1509,3 @@ def plot_histogram_series(
     _make_plot_html_page(complete_plot_index)
 
     return cubes
-
-
-def _convert_precipitation_units_callback(cube: iris.cube.Cube):
-    """To convert the unit of precipitation from kg m-2 s-1 to mm hr-1.
-
-    Some precipitation diagnostics are output with unit kg m-2 s-1 and are converted to mm hr-1.
-    """
-    # if cube.attributes["STASH"] == "m01s04i203" or cube.long_name == "surface_microphysical_rainfall_rate":
-    if cube.long_name == "surface_microphysical_rainfall_rate":
-        if cube.units == "kg m-2 s-1":
-            logging.info("Converting precipitation units from kg m-2 s-1 to mm hr-1")
-            # manually convert from kg m-2 s-1 to mm hr-1 assuming 1kg water = 1l water = 1dm^3 water
-            cube.data = cube.data * 3600.0
-
-            # update the units
-            cube.units = "mm hr-1"
-        else:
-            logging.warning(
-                "Precipitation units are not in 'kg m-2 s-1', skipping conversion"
-            )
-    return cube

--- a/src/CSET/operators/read.py
+++ b/src/CSET/operators/read.py
@@ -240,7 +240,6 @@ def _create_callback(is_ensemble: bool, is_base: bool) -> callable:
         _fix_lfric_longnames(cube)
         _fix_um_lightning(cube)
         _lfric_time_callback(cube)
-        _convert_precipitation_units(cube)
 
     return callback
 
@@ -666,33 +665,3 @@ def _check_input_files(input_paths: list[str], filename_pattern: str) -> list[Pa
     if len(files) == 0:
         raise FileNotFoundError(f"No files found for {input_paths}")
     return files
-
-
-def _convert_precipitation_units(cube: iris.cube.Cube):
-    """To convert the unit of precipitation from kg m-2 s-1 to mm hr-1.
-
-    Some precipitation diagnostics are output with unit kg m-2 s-1 and are converted to mm hr-1.
-    """
-    try:
-        # if cube.attributes["STASH"] == "m01s04i203" or cube.long_name == "surface_microphysical_rainfall_rate":
-        if cube.long_name == "surface_microphysical_rainfall_rate":
-            if cube.units == "kg m-2 s-1":
-                logging.info(
-                    "Converting precipitation units from kg m-2 s-1 to mm hr-1"
-                )
-                # manually convert from kg m-2 s-1 to mm hr-1 assuming 1kg water = 1l water = 1dm^3 water
-                cube.data = cube.data * 3600.0
-
-                # update the units
-                cube.units = "mm hr-1"
-            else:
-                logging.warning(
-                    "Precipitation units are not in 'kg m-2 s-1', skipping conversion"
-                )
-    except iris.exceptions.CoordinateNotFoundError:
-        logging.warning(
-            "Precipitation cube does not contain the required coordinate, skipping conversion"
-        )
-    except KeyError:
-        logging.warning("STASH attribute not found in cube, cannot convert units")
-    return cube

--- a/src/CSET/operators/read.py
+++ b/src/CSET/operators/read.py
@@ -240,6 +240,7 @@ def _create_callback(is_ensemble: bool, is_base: bool) -> callable:
         _fix_lfric_longnames(cube)
         _fix_um_lightning(cube)
         _lfric_time_callback(cube)
+        _convert_precipitation_units(cube)
 
     return callback
 
@@ -665,3 +666,33 @@ def _check_input_files(input_paths: list[str], filename_pattern: str) -> list[Pa
     if len(files) == 0:
         raise FileNotFoundError(f"No files found for {input_paths}")
     return files
+
+
+def _convert_precipitation_units(cube: iris.cube.Cube):
+    """To convert the unit of precipitation from kg m-2 s-1 to mm hr-1.
+
+    Some precipitation diagnostics are output with unit kg m-2 s-1 and are converted to mm hr-1.
+    """
+    try:
+        # if cube.attributes["STASH"] == "m01s04i203" or cube.long_name == "surface_microphysical_rainfall_rate":
+        if cube.long_name == "surface_microphysical_rainfall_rate":
+            if cube.units == "kg m-2 s-1":
+                logging.info(
+                    "Converting precipitation units from kg m-2 s-1 to mm hr-1"
+                )
+                # manually convert from kg m-2 s-1 to mm hr-1 assuming 1kg water = 1l water = 1dm^3 water
+                cube.data = cube.data * 3600.0
+
+                # update the units
+                cube.units = "mm hr-1"
+            else:
+                logging.warning(
+                    "Precipitation units are not in 'kg m-2 s-1', skipping conversion"
+                )
+    except iris.exceptions.CoordinateNotFoundError:
+        logging.warning(
+            "Precipitation cube does not contain the required coordinate, skipping conversion"
+        )
+    except KeyError:
+        logging.warning("STASH attribute not found in cube, cannot convert units")
+    return cube


### PR DESCRIPTION
convert precipitation units to mm hr--1 and colourbar scale changed accordingly for surface_microphysical_rainfall_rate. Still requires change to colourbar

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [x] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [x] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [ ] Marked the PR as ready to review.
