### PR TITLE
Avoid calling `os.sync()`

### DIFF
--- a/src/CSET/operators/__init__.py
+++ b/src/CSET/operators/__init__.py
@@ -109,15 +109,11 @@ def get_operator(name: str):
 
 def _write_metadata(recipe: dict):
     """Write a meta.json file in the CWD."""
-    # TODO: Investigate whether we might be better served by an SQLite database.
     metadata = recipe.copy()
     # Remove steps, as not needed, and might contain non-serialisable types.
     metadata.pop("steps", None)
     with open("meta.json", "wt", encoding="UTF-8") as fp:
         json.dump(metadata, fp, indent=2)
-    os.sync()
-    # Stat directory to force NFS to synchronise metadata.
-    os.stat(Path.cwd())
 
 
 def _step_parser(step: dict, step_input: any) -> str:


### PR DESCRIPTION
This prevents hanging on multi-user systems, where there might be several hundred GiBs in various caches.

This synchronisation is no longer needed as we don't write to this file from multiple processes any more. Given that we don't, an SQLite database is also no longer needed.

Fixes #1275

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [ ] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
