### PR TITLE
Add option to skip writing output

### DIFF
--- a/cset-workflow/flow.cylc
+++ b/cset-workflow/flow.cylc
@@ -96,6 +96,7 @@ URL = https://metoffice.github.io/CSET
         LOGLEVEL = {{LOGLEVEL}}
         COLORBAR_FILE = {{COLORBAR_FILE}}
         PLOT_RESOLUTION = {{PLOT_RESOLUTION|default(100)}}
+        SKIP_WRITE = {{SKIP_WRITE}}
 
     [[PROCESS]]
     script = rose task-run -v --app-key=run_cset_recipe

--- a/cset-workflow/meta/rose-meta.conf
+++ b/cset-workflow/meta/rose-meta.conf
@@ -43,6 +43,15 @@ help=This will be a JSON file with a colorbar definition inside. See
 type=quoted
 compulsory=true
 
+[template variables=SKIP_WRITE]
+ns=Setup
+title=Skip writing processed data
+description=Skip saving the processed data used for the plots to save disk space.
+help=This skips writing the processed data that is plotted to minimise disk usage
+    and IO throughput. It is recommended for large CSET runs.
+type=python_boolean
+compulsory=true
+
 [template variables=PLOT_RESOLUTION]
 ns=Setup
 title=Plot resolution

--- a/cset-workflow/meta/rose-meta.conf.jinja2
+++ b/cset-workflow/meta/rose-meta.conf.jinja2
@@ -43,6 +43,15 @@ help=This will be a JSON file with a colorbar definition inside. See
 type=quoted
 compulsory=true
 
+[template variables=SKIP_WRITE]
+ns=Setup
+title=Skip writing processed data
+description=Skip saving the processed data used for the plots to save disk space.
+help=This skips writing the processed data that is plotted to minimise disk usage
+    and IO throughput. It is recommended for large CSET runs.
+type=python_boolean
+compulsory=true
+
 [template variables=PLOT_RESOLUTION]
 ns=Setup
 title=Plot resolution

--- a/src/CSET/__init__.py
+++ b/src/CSET/__init__.py
@@ -115,6 +115,9 @@ def setup_argument_parser() -> argparse.ArgumentParser:
     parser_bake.add_argument(
         "--plot-resolution", type=int, help="plotting resolution in dpi"
     )
+    parser_bake.add_argument(
+        "--skip-write", action="store_true", help="Skip saving processed output"
+    )
     parser_bake.set_defaults(func=_bake_command)
 
     parser_graph = subparsers.add_parser("graph", help="visualise a recipe file")
@@ -238,6 +241,7 @@ def _bake_command(args, unparsed_args):
         recipe_variables,
         args.style_file,
         args.plot_resolution,
+        args.skip_write,
     )
 
 

--- a/src/CSET/_workflow_utils/run_cset_recipe.py
+++ b/src/CSET/_workflow_utils/run_cset_recipe.py
@@ -109,6 +109,10 @@ def run_recipe_steps():
     if plot_resolution:
         command.append(f"--plot-resolution={plot_resolution}")
 
+    skip_write = bool(os.getenv("SKIP_WRITE"))
+    if skip_write:
+        command.append("--skip-write")
+
     logging.info("Running %s", shlex.join(command))
     try:
         subprocess.run(command, check=True, env=subprocess_env())

--- a/src/CSET/operators/__init__.py
+++ b/src/CSET/operators/__init__.py
@@ -150,6 +150,7 @@ def _run_steps(
     output_directory: Path,
     style_file: Path = None,
     plot_resolution: int = None,
+    skip_write: bool = None,
 ) -> None:
     """Execute the steps in a recipe."""
     original_working_directory = Path.cwd()
@@ -173,6 +174,8 @@ def _run_steps(
             recipe["style_file_path"] = str(style_file)
         if plot_resolution:
             recipe["plot_resolution"] = plot_resolution
+        if skip_write:
+            recipe["skip_write"] = skip_write
         _write_metadata(recipe)
         # Execute the recipe.
         for step in steps:
@@ -189,6 +192,7 @@ def execute_recipe(
     recipe_variables: dict = None,
     style_file: Path = None,
     plot_resolution: int = None,
+    skip_write: bool = None,
 ) -> None:
     """Parse and executes the steps from a recipe file.
 
@@ -209,6 +213,8 @@ def execute_recipe(
         Path to a style file.
     plot_resolution: int, optional
         Resolution of plots in dpi.
+    skip_write: bool, optional
+        Skip saving processed output alongside plots.
 
     Raises
     ------
@@ -230,5 +236,11 @@ def execute_recipe(
         raise err
     steps = recipe["steps"]
     _run_steps(
-        recipe, steps, input_directories, output_directory, style_file, plot_resolution
+        recipe,
+        steps,
+        input_directories,
+        output_directory,
+        style_file,
+        plot_resolution,
+        skip_write,
     )

--- a/src/CSET/operators/write.py
+++ b/src/CSET/operators/write.py
@@ -48,6 +48,11 @@ def write_cube_to_nc(
     Cube | CubeList
         The inputted cube(list) (so further operations can be applied)
     """
+    # Allow writing to be disabled without changing the recipe. This improves
+    # runtime and avoids using excessive disk space for large runs.
+    if get_recipe_metadata().get("skip_write"):
+        return cube
+
     if filename is None:
         filename = slugify(get_recipe_metadata().get("title", "Untitled"))
 

--- a/tests/operators/test_write.py
+++ b/tests/operators/test_write.py
@@ -31,3 +31,11 @@ def test_write_cube_default_filename(cube, tmp_working_dir):
     Path("meta.json").write_text("{}", encoding="UTF-8")
     write.write_cube_to_nc(cube, overwrite=True)
     assert Path.cwd().joinpath("untitled.nc").is_file()
+
+
+def test_write_cube_skip_write(cube, tmp_working_dir):
+    """Cube is not written when skip_write is configured."""
+    Path("meta.json").write_text('{"skip_write": true}', encoding="UTF-8")
+    returned = write.write_cube_to_nc(cube, "output.nc", overwrite=True)
+    assert returned == cube
+    assert not Path.cwd().joinpath("output.nc").is_file()

--- a/tests/test_execute_recipe.py
+++ b/tests/test_execute_recipe.py
@@ -85,3 +85,11 @@ def test_run_steps_plot_resolution_metadata_written(tmp_path: Path):
     with open(tmp_path / "meta.json", "rb") as fp:
         metadata = json.load(fp)
     assert metadata["plot_resolution"] == 72
+
+
+def test_run_steps_skip_write_metadata_written(tmp_path: Path):
+    """Skip write metadata written out."""
+    CSET.operators._run_steps({}, [], "", tmp_path, skip_write=True)
+    with open(tmp_path / "meta.json", "rb") as fp:
+        metadata = json.load(fp)
+    assert metadata["skip_write"]


### PR DESCRIPTION
This can be used to avoid writing the output for large runs, where the processed data might take up many terabytes and significantly slow processing.

I also sneaked in a minor improvement to the command logging in run_cset_recipe, so you can just take the logged command and run it directly, without having to worry about quoting things.

Fixes #1271

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [x] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
