### PR TITLE
Avoid accessing non-captured output in MASS fetch script

### DIFF
--- a/cset-workflow/app/fetch_fcst/bin/fetch-data-mass.py
+++ b/cset-workflow/app/fetch_fcst/bin/fetch-data-mass.py
@@ -4,7 +4,6 @@
 
 import logging
 import subprocess
-import sys
 
 from CSET._workflow_utils.fetch_data import FileRetrieverABC, fetch_data
 
@@ -32,12 +31,7 @@ class MASSFileRetriever(FileRetrieverABC):
         logging.debug(f"Fetching from MASS with:\n{' '.join(moo_command)}")
         p = subprocess.run(moo_command)
         if p.returncode > 0:
-            logging.info(
-                "moo get exited with non-zero code %s.\nstdout: %s\nstderr: %s",
-                p.returncode,
-                p.stdout.decode(sys.stdout.encoding),
-                p.stderr.decode(sys.stderr.encoding),
-            )
+            logging.info("moo get exited with non-zero code %s.", p.returncode)
             return False
         return True
 


### PR DESCRIPTION
It was failing when trying to decode the output stream, as we were not capturing the stream so there was nothing to decode.

As we don't need to capture it we can just remove the decoding attempt and all will be well.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
