### PR TITLE
Correct for instances where longitude plot bounds caused set_extent to

### DIFF
--- a/src/CSET/operators/plot.py
+++ b/src/CSET/operators/plot.py
@@ -321,7 +321,7 @@ def _plot_and_save_spatial_plot(
         x2 = np.max(cube.coord(lon_axis).points)
         y1 = np.min(cube.coord(lat_axis).points)
         y2 = np.max(cube.coord(lat_axis).points)
-        # Adjust bounds within +/- 180.0 if x dimension extends beyond half-globe
+        # Adjust bounds within +/- 180.0 if x dimension extends beyond half-globe.
         if (x2 - x1) > 180.0:
             x1 = x1 - 180.0
             x2 = x2 - 180.0

--- a/src/CSET/operators/plot.py
+++ b/src/CSET/operators/plot.py
@@ -317,14 +317,15 @@ def _plot_and_save_spatial_plot(
     try:
         lat_axis, lon_axis = get_cube_yxcoordname(cube)
         axes.coastlines(resolution="10m")
-        axes.set_extent(
-            [
-                np.min(cube.coord(lon_axis).points),
-                np.max(cube.coord(lon_axis).points),
-                np.min(cube.coord(lat_axis).points),
-                np.max(cube.coord(lat_axis).points),
-            ]
-        )
+        x1 = np.min(cube.coord(lon_axis).points)
+        x2 = np.max(cube.coord(lon_axis).points)
+        y1 = np.min(cube.coord(lat_axis).points)
+        y2 = np.max(cube.coord(lat_axis).points)
+        # Adjust bounds within +/- 180.0 if x dimension extends beyond half-globe
+        if (x2 - x1) > 180.0:
+            x1 = x1 - 180.0
+            x2 = x2 - 180.0
+        axes.set_extent([x1, x2, y1, y2])
     except ValueError:
         # Skip if no x and y map coordinates.
         pass
@@ -442,14 +443,15 @@ def _plot_and_save_postage_stamp_spatial_plot(
         try:
             lat_axis, lon_axis = get_cube_yxcoordname(cube)
             ax.coastlines(resolution="10m")
-            ax.set_extent(
-                [
-                    np.min(cube.coord(lon_axis).points),
-                    np.max(cube.coord(lon_axis).points),
-                    np.min(cube.coord(lat_axis).points),
-                    np.max(cube.coord(lat_axis).points),
-                ]
-            )
+            x1 = np.min(cube.coord(lon_axis).points)
+            x2 = np.max(cube.coord(lon_axis).points)
+            y1 = np.min(cube.coord(lat_axis).points)
+            y2 = np.max(cube.coord(lat_axis).points)
+            # Adjust bounds within +/- 180.0 if x dimension extends beyond half-globe
+            if (x2 - x1) > 180.0:
+                x1 = x1 - 180.0
+                x2 = x2 - 180.0
+            ax.set_extent([x1, x2, y1, y2])
         except ValueError:
             # Skip if no x and y map coordinates.
             pass

--- a/src/CSET/operators/plot.py
+++ b/src/CSET/operators/plot.py
@@ -447,7 +447,7 @@ def _plot_and_save_postage_stamp_spatial_plot(
             x2 = np.max(cube.coord(lon_axis).points)
             y1 = np.min(cube.coord(lat_axis).points)
             y2 = np.max(cube.coord(lat_axis).points)
-            # Adjust bounds within +/- 180.0 if x dimension extends beyond half-globe
+            # Adjust bounds within +/- 180.0 if x dimension extends beyond half-globe.
             if (x2 - x1) > 180.0:
                 x1 = x1 - 180.0
                 x2 = x2 - 180.0


### PR DESCRIPTION
collapse output plot to vertical line (e.g. for global model)

Fixes #1252. 
Wraps min and max longitudes for instances where plotting > 1/2 globe (e.g. global model or CTC), enabling ongoing use of set_extents logic. Have also defined x1, x2, y1, y2 rather than compute bounds within set_extents calls.

Example output plots with global, cyclic tropical channel and LAM outputs: https://wwwspice/~huw.lewis/CSET/CSET_KScaleFirst/

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [x] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
