### PR TITLE
1-line change to move default position of map colorbars to horizontal

### DIFF
--- a/src/CSET/operators/plot.py
+++ b/src/CSET/operators/plot.py
@@ -370,7 +370,7 @@ def _plot_and_save_spatial_plot(
     )
 
     # Add colour bar.
-    cbar = fig.colorbar(plot)
+    cbar = fig.colorbar(plot, orientation="horizontal")
     cbar.set_label(label=f"{cube.name()} ({cube.units})", size=20)
 
     # Save plot.


### PR DESCRIPTION
Fixes #1280 
Switches default colorbar location to horizontal below map plots.

See issue for example of sample LAM output (have not demonstrated use with global given dependencies on #1252 

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
