### PR TITLE
Improve colorbar formatting to reduce whitespace

### DIFF
--- a/src/CSET/operators/plot.py
+++ b/src/CSET/operators/plot.py
@@ -371,8 +371,8 @@ def _plot_and_save_spatial_plot(
     )
 
     # Add colour bar.
-    cbar = fig.colorbar(plot, orientation="horizontal")
-    cbar.set_label(label=f"{cube.name()} ({cube.units})", size=20)
+    cbar = fig.colorbar(plot, orientation="horizontal", pad=0.08, shrink=0.75)
+    cbar.set_label(label=f"{cube.name()} ({cube.units})", size=16)
 
     # Save plot.
     fig.savefig(filename, bbox_inches="tight", dpi=_get_plot_resolution())
@@ -458,8 +458,10 @@ def _plot_and_save_postage_stamp_spatial_plot(
 
     # Put the shared colorbar in its own axes.
     colorbar_axes = fig.add_axes([0.15, 0.07, 0.7, 0.03])
-    colorbar = fig.colorbar(plot, colorbar_axes, orientation="horizontal")
-    colorbar.set_label(f"{cube.name()} / {cube.units}")
+    colorbar = fig.colorbar(
+        plot, colorbar_axes, orientation="horizontal", pad=0.08, shrink=0.75
+    )
+    colorbar.set_label(f"{cube.name()} / {cube.units}", fontsize=16)
 
     # Overall figure title.
     fig.suptitle(title)


### PR DESCRIPTION
Update formatting settings for horizontal colorbar in spatial maps, to reduce width in figure, reducing whitespace.

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [ ] All tests and CI checks pass.
- [ ] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [ ] Marked the PR as ready to review.
