### PR TITLE
Conditionally fix times in callbacks to avoid corrupting dates by double fixing

### DIFF
--- a/src/CSET/operators/read.py
+++ b/src/CSET/operators/read.py
@@ -457,6 +457,10 @@ def _fix_um_radtime_posthour(cube: iris.cube.Cube):
             time_unit = time_coord.units
             time_points = time_unit.num2date(time_coord.points)
 
+            # Skip if times don't need fixing.
+            if time_points[0].minute != 1:
+                return
+
             # Subtract 1 minute from each time point
             new_time_points = np.array(
                 [t - datetime.timedelta(minutes=1) for t in time_points]
@@ -480,6 +484,10 @@ def _fix_um_radtime_prehour(cube: iris.cube.Cube):
             # Convert time points to datetime objects
             time_unit = time_coord.units
             time_points = time_unit.num2date(time_coord.points)
+
+            # Skip if times don't need fixing.
+            if time_points[0].minute != 59:
+                return
 
             # Add 1 minute from each time point
             new_time_points = np.array(
@@ -515,6 +523,7 @@ def _fix_um_lightning(cube: iris.cube.Cube):
     """
     try:
         if cube.attributes["STASH"] == "m01s21i104":
+            # Remove aggregation cell method.
             cube.cell_methods = []
 
             time_coord = cube.coord("time")
@@ -522,6 +531,10 @@ def _fix_um_lightning(cube: iris.cube.Cube):
             # Convert time points to datetime objects
             time_unit = time_coord.units
             time_points = time_unit.num2date(time_coord.points)
+
+            # Skip if times don't need fixing.
+            if time_points[0].minute == 0:
+                return
 
             # Subtract 1 minute from each time point
             new_time_points = np.array(

--- a/src/CSET/operators/read.py
+++ b/src/CSET/operators/read.py
@@ -519,33 +519,28 @@ def _fix_um_lightning(cube: iris.cube.Cube):
     as variables are ignored with cell methods for surface plots currently),
     and also adjust the time so that the value is at the end of each hour.
     """
-    try:
-        if cube.attributes["STASH"] == "m01s21i104":
-            # Remove aggregation cell method.
-            cube.cell_methods = []
+    if cube.attributes.get("STASH") == "m01s21i104":
+        # Remove aggregation cell method.
+        cube.cell_methods = ()
 
-            time_coord = cube.coord("time")
+        time_coord = cube.coord("time")
 
-            # Convert time points to datetime objects
-            time_unit = time_coord.units
-            time_points = time_unit.num2date(time_coord.points)
+        # Convert time points to datetime objects.
+        time_unit = time_coord.units
+        time_points = time_unit.num2date(time_coord.points)
 
-            # Skip if times don't need fixing.
-            if time_points[0].minute == 0:
-                return
+        # Skip if times don't need fixing.
+        if time_points[0].minute == 0:
+            return
 
-            # Subtract 1 minute from each time point
-            new_time_points = np.array(
-                [t + datetime.timedelta(minutes=30) for t in time_points]
-            )
+        # Add 30 minutes to each time point.
+        new_time_points = time_points + datetime.timedelta(minutes=30)
 
-            # Convert back to numeric values using the original time unit
-            new_time_values = time_unit.date2num(new_time_points)
+        # Convert back to numeric values using the original time unit.
+        new_time_values = time_unit.date2num(new_time_points)
 
-            # Replace the time coordinate with corrected values
-            time_coord.points = new_time_values
-    except KeyError:
-        pass
+        # Replace the time coordinate with corrected values.
+        time_coord.points = new_time_values
 
 
 def _lfric_normalise_varname(cube: iris.cube.Cube):

--- a/src/CSET/operators/read.py
+++ b/src/CSET/operators/read.py
@@ -462,9 +462,7 @@ def _fix_um_radtime_posthour(cube: iris.cube.Cube):
                 return
 
             # Subtract 1 minute from each time point
-            new_time_points = np.array(
-                [t - datetime.timedelta(minutes=1) for t in time_points]
-            )
+            new_time_points = time_points - datetime.timedelta(minutes=1)
 
             # Convert back to numeric values using the original time unit
             new_time_values = time_unit.date2num(new_time_points)

--- a/tests/operators/test_read.py
+++ b/tests/operators/test_read.py
@@ -345,6 +345,88 @@ def test_fix_um_radtime_posthour_no_time_coordinate():
     assert cube == iris.cube.Cube([0], var_name="data")
 
 
+def test_fix_um_radtime_prehour(cube):
+    """Check times that are 1 minute passed are rounded to the whole hour."""
+    # Offset times by one minute.
+    time_coord = cube.coord("time")
+    times = time_coord.units.num2pydate(time_coord.points) - datetime.timedelta(
+        minutes=1
+    )
+    time_coord.points = time_coord.units.date2num(times)
+    # Check all times are offset.
+    for time in times:
+        assert time.minute == 59
+
+    # Give cube a radiation STASH code.
+    cube.attributes["STASH"] = "m01s01i207"
+
+    # Apply fix.
+    read._fix_um_radtime_prehour(cube)
+
+    # Ensure radiation times are fixed.
+    rad_time_coord = cube.coord("time")
+    rad_times = rad_time_coord.units.num2pydate(rad_time_coord.points)
+    # Check all times are fixed.
+    assert rad_times[0] == datetime.datetime(2022, 9, 21, 3, 0)
+    for time in rad_times:
+        assert time.minute == 0
+
+
+def test_fix_um_radtime_prehour_skip_non_radiation(cube):
+    """Check non-radiation times are NOT fixed."""
+    # Offset times by one minute.
+    time_coord = cube.coord("time")
+    times = time_coord.units.num2pydate(time_coord.points) - datetime.timedelta(
+        minutes=1
+    )
+    time_coord.points = time_coord.units.date2num(times)
+    # Check all times are offset.
+    for time in times:
+        assert time.minute == 59
+
+    # Apply fix.
+    read._fix_um_radtime_prehour(cube)
+
+    # Ensure that non-radiation cubes are unchanged.
+    non_rad_time_coord = cube.coord("time")
+    non_rad_times = non_rad_time_coord.units.num2pydate(non_rad_time_coord.points)
+    for nrt, t in zip(non_rad_times, times, strict=True):
+        assert nrt == t
+
+
+def test_fix_um_radtime_prehour_skip_non_offset(cube):
+    """Check radiation times NOT offset by 1 minute are not fixed."""
+    time_coord = cube.coord("time")
+    times = time_coord.units.num2pydate(time_coord.points)
+    # Check all times are not offset.
+    for time in times:
+        assert time.minute == 0
+
+    # Give cube a radiation STASH code.
+    cube.attributes["STASH"] = "m01s01i207"
+
+    # Apply fix.
+    read._fix_um_radtime_prehour(cube)
+
+    # Ensure that non-offset cubes are unchanged.
+    non_offset_time_coord = cube.coord("time")
+    non_offset_times = non_offset_time_coord.units.num2pydate(
+        non_offset_time_coord.points
+    )
+    for nt, t in zip(non_offset_times, times, strict=True):
+        assert nt == t
+
+
+def test_fix_um_radtime_prehour_no_time_coordinate():
+    """Check cubes without time coordinates are skipped without error."""
+    # Create a cube with no time coordinate.
+    cube = iris.cube.Cube([0], var_name="data")
+    # Apply fix.
+    read._fix_um_radtime_prehour(cube)
+    # Check unchanged.
+    assert cube == iris.cube.Cube([0], var_name="data")
+
+
 def test_spatial_coord_rename_callback():
     """Check that spatial coord gets renamed if it is not grid_latitude."""
     # This cube contains 'latitude' and 'longitude'


### PR DESCRIPTION
<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

This prevents the callbacks from being applied multiple times to the same data, corrupting it. Additionally tests were added for these callbacks, which were previously untested.

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [x] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
