### PR TITLE
Add preprocessing task to speed up workflow

### DIFF
--- a/cset-workflow/app/preprocess_data/bin/preprocess.py
+++ b/cset-workflow/app/preprocess_data/bin/preprocess.py
@@ -1,0 +1,7 @@
+#! /usr/bin/env python3
+
+"""Preprocess forecast data into a single file per model."""
+
+import CSET._workflow_utils.preprocess
+
+CSET._workflow_utils.preprocess.run()

--- a/cset-workflow/app/preprocess_data/rose-app.conf
+++ b/cset-workflow/app/preprocess_data/rose-app.conf
@@ -1,0 +1,2 @@
+[command]
+default=app_env_wrapper preprocess.py

--- a/cset-workflow/flow.cylc
+++ b/cset-workflow/flow.cylc
@@ -40,7 +40,7 @@ URL = https://metoffice.github.io/CSET
             R1/{{date}} = """
             setup_complete[^] =>
             FETCH_DATA:succeed-all =>
-            fetch_complete
+            PREPROCESS_DATA:succeed-all =>
             fetch_complete =>
             PROCESS:{% if LOGLEVEL == "DEBUG" %}succeed-all{% else %}finish-all{% endif %} =>
             cycle_complete
@@ -51,6 +51,7 @@ URL = https://metoffice.github.io/CSET
         {{CSET_TRIAL_CYCLE_PERIOD}} = """
         setup_complete[^] =>
         FETCH_DATA:succeed-all =>
+        PREPROCESS_DATA:succeed-all =>
         fetch_complete =>
         PROCESS:{% if LOGLEVEL == "DEBUG" %}succeed-all{% else %}finish-all{% endif %} =>
         cycle_complete
@@ -122,6 +123,13 @@ URL = https://metoffice.github.io/CSET
         [[[environment]]]
         ANALYSIS_LENGTH = {{ANALYSIS_LENGTH}}
 
+    [[PREPROCESS_DATA]]
+    script = rose task-run -v --app-key=preprocess_data
+    execution time limit = PT15M
+    execution retry delays = PT1M, PT15M, PT1H
+        [[[directives]]]
+        --mem = 30000
+
     [[METPLUS]]
         [[[environment]]]
         {% if METPLUS_GRID_STAT|default(False) %}
@@ -179,6 +187,12 @@ URL = https://metoffice.github.io/CSET
         DATE_TYPE = {{model["date_type"]}}
         DATA_PERIOD = {{model["data_period"]}}
         ANALYSIS_OFFSET = {{model["analysis_offset"]}}
+
+    [[preprocess_m{{model["id"]}}]]
+    # Preprocess data to fix up metadata and speed up future loads.
+    inherit = PREPROCESS_DATA
+        [[[environment]]]
+        MODEL_IDENTIFIER = {{model["id"]}}
     {% endfor %}
 
     [[housekeeping]]

--- a/src/CSET/_workflow_utils/preprocess.py
+++ b/src/CSET/_workflow_utils/preprocess.py
@@ -1,0 +1,53 @@
+# © Crown copyright, Met Office (2022-2025) and CSET contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Preprocess forecast data into a single file per model."""
+
+import os
+import shutil
+
+import iris
+
+from CSET.operators import read
+
+
+def preprocess_data(data_location: str):
+    """Rewrite data into a single file. This also fixes all the metadata."""
+    # Load up all the data.
+    cubes = read.read_cubes(data_location)
+
+    # Remove added comparison base; we don't know if this is the base model yet.
+    for cube in cubes:
+        del cube.attributes["cset_comparison_base"]
+
+    # Use iris directly to save uncompressed for faster reading.
+    iris.save(cubes, "forecast.nc")
+
+    # Remove raw forecast data.
+    shutil.rmtree(data_location)
+    os.mkdir(data_location)
+
+    # Move forecast data back into place.
+    shutil.move("forecast.nc", str(data_location) + "/forecast.nc")
+
+
+def run():
+    """Run workflow script."""
+    data_location = (
+        f"{os.environ['CYLC_WORKFLOW_SHARE_DIR']}/cycle/"
+        f"{os.environ['CYLC_TASK_CYCLE_POINT']}/data/"
+        f"{os.environ['MODEL_IDENTIFIER']}"
+    )
+    print(f"Preprocessing {data_location}")
+    preprocess_data(data_location)

--- a/tests/workflow_utils/test_preprocess.py
+++ b/tests/workflow_utils/test_preprocess.py
@@ -1,0 +1,60 @@
+# © Crown copyright, Met Office (2022-2025) and CSET contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for run_cset_recipe workflow utility."""
+
+import glob
+import shutil
+
+import iris
+
+from CSET._workflow_utils import preprocess
+
+
+def test_preprocess(monkeypatch):
+    """Test preprocess run."""
+    preprocess_run = False
+    monkeypatch.setenv("CYLC_WORKFLOW_SHARE_DIR", "/data")
+    monkeypatch.setenv("CYLC_TASK_CYCLE_POINT", "20250101T0000Z")
+    monkeypatch.setenv("MODEL_IDENTIFIER", "1")
+
+    def mock_preprocess_data(data_location: str):
+        nonlocal preprocess_run
+        preprocess_run = True
+        assert data_location == "/data/cycle/20250101T0000Z/data/1"
+
+    monkeypatch.setattr(preprocess, "preprocess_data", mock_preprocess_data)
+    preprocess.run()
+    assert preprocess_run
+
+
+def test_preprocess_data(tmp_path):
+    """Combine model files into one."""
+    # Prepare some model data in the data_location.
+    for file in glob.glob("tests/test_data/long_forecast_air_temp_fcst_*.nc"):
+        shutil.copy(file, tmp_path)
+
+    # Preprocess data.
+    preprocess.preprocess_data(tmp_path)
+
+    # Check file has been created.
+    output = tmp_path / "forecast.nc"
+    assert output.is_file()
+
+    # Check cubes have been transferred correctly. We use iris here to avoid
+    # re-processing the data.
+    cubes = iris.load(output)
+    assert len(cubes) == 4
+    for cube in cubes:
+        assert "cset_comparison_base" not in cube.attributes


### PR DESCRIPTION
By putting the whole forecast into one file we only have to fix the metadata once, and it is much faster to load.

This takes most PROCESS tasks from 1 minute 30 seconds down to about 15 seconds.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
