### PR TITLE
Updated default colorbar definition for radiation

### DIFF
--- a/src/CSET/operators/_colorbar_definition.json
+++ b/src/CSET/operators/_colorbar_definition.json
@@ -502,7 +502,7 @@
     "min": -10
   },
   "toa_direct_shortwave_flux": {
-    "cmap": "viridis",
+    "cmap": "Greys",
     "max": 1400.0,
     "min": 0.0
   },
@@ -512,7 +512,7 @@
     "min": -2.0
   },
   "toa_upward_longwave_flux_radiative_timestep": {
-    "cmap": "viridis",
+    "cmap": "Greys",
     "max": 350.0,
     "min": 0.0
   },
@@ -523,7 +523,7 @@
   },
   "toa_upward_shortwave_flux": {
     "cmap": "Greys",
-    "max": 500,
+    "max": 500.0,
     "min": 0
   },
   "toa_upward_shortwave_flux_difference": {


### PR DESCRIPTION
Updated toa radiation variables to use greyscale in default colorbar file

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
