### PR TITLE
Avoid writing meta.json outside tempdir during test

### DIFF
--- a/tests/operators/test_write.py
+++ b/tests/operators/test_write.py
@@ -19,9 +19,9 @@ from pathlib import Path
 from CSET.operators import write
 
 
-def test_write_cube(tmp_path: Path, cube):
+def test_write_cube(cube, tmp_working_dir: Path):
     """Write cube and verify it was written."""
-    file_path = tmp_path / "cube.nc"
+    file_path = tmp_working_dir / "cube.nc"
     write.write_cube_to_nc(cube, file_path, overwrite=True)
     assert file_path.is_file()
 


### PR DESCRIPTION
The call to get_metadata would prompt for the creation of a meta.json file, but this test was running outside of a temporary directory, so the meta.json was left in your current working directory after the test had run. The test now runs in a temporary directory, avoiding this issue.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [x] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
