### PR TITLE
Retry failed processing tasks

### DIFF
--- a/cset-workflow/flow.cylc
+++ b/cset-workflow/flow.cylc
@@ -74,6 +74,8 @@ URL = https://metoffice.github.io/CSET
     [[root]]
     script = rose task-run -v
     execution time limit = PT15M
+    # Retry submit-failed tasks after a minute.
+    submission retry delays = PT1M
         [[[environment]]]
         # As these variables are used in the environment script, they must be
         # defined.
@@ -100,7 +102,8 @@ URL = https://metoffice.github.io/CSET
 
     [[PROCESS]]
     script = rose task-run -v --app-key=run_cset_recipe
-    execution time limit = PT15M
+    execution time limit = PT5M
+    execution retry delays = PT1M, PT15M, PT1H
     [[[directives]]]
         --mem=5000
 


### PR DESCRIPTION
Retry failed tasks to improve workflow reliability against transient failures.

We can also reduce the wallclock, as it was higher than needed to reduce the chance of a failure, but if we are going to retry anyway we can get through quicker anyway.

Fixes #1312

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
