### PR TITLE
Remove recipe

### DIFF
--- a/src/CSET/__init__.py
+++ b/src/CSET/__init__.py
@@ -168,16 +168,6 @@ def setup_argument_parser() -> argparse.ArgumentParser:
     )
     parser_cookbook.set_defaults(func=_cookbook_command)
 
-    parser_recipe_id = subparsers.add_parser("recipe-id", help="get the ID of a recipe")
-    parser_recipe_id.add_argument(
-        "-r",
-        "--recipe",
-        type=Path,
-        required=True,
-        help="recipe file to read",
-    )
-    parser_recipe_id.set_defaults(func=_recipe_id_command)
-
     return parser
 
 
@@ -273,18 +263,3 @@ def _cookbook_command(args, unparsed_args):
                 sys.exit(1)
     else:
         list_available_recipes()
-
-
-def _recipe_id_command(args, unparsed_args):
-    from uuid import uuid4
-
-    from CSET._common import parse_recipe, parse_variable_options, slugify
-
-    recipe_variables = parse_variable_options(unparsed_args)
-    recipe = parse_recipe(args.recipe, recipe_variables)
-    try:
-        recipe_id = slugify(recipe["title"])
-    except KeyError:
-        logging.warning("Recipe has no title; Falling back to random recipe_id.")
-        recipe_id = str(uuid4())
-    print(recipe_id)

--- a/src/CSET/_workflow_utils/run_cset_recipe.py
+++ b/src/CSET/_workflow_utils/run_cset_recipe.py
@@ -2,22 +2,10 @@
 
 """Run a recipe with the CSET CLI."""
 
-import logging
 import os
 import shlex
 import subprocess
 import sys
-from pathlib import Path
-
-logging.basicConfig(
-    level=os.getenv("LOGLEVEL", "INFO"), format="%(asctime)s %(levelname)s %(message)s"
-)
-
-
-def subprocess_env():
-    """Create a dictionary of amended environment variables for subprocess."""
-    env_mapping = dict(os.environ)
-    return env_mapping
 
 
 def recipe_file() -> str:
@@ -25,52 +13,16 @@ def recipe_file() -> str:
     # Ready recipe file to disk.
     cset_recipe = os.environ["CSET_RECIPE_NAME"]
     subprocess.run(("cset", "-v", "cookbook", cset_recipe), check=True)
-    # Debug check that recipe has been retrieved.
-    assert Path(cset_recipe).is_file()
     return cset_recipe
-
-
-def recipe_id():
-    """Get the ID for the recipe."""
-    file = recipe_file()
-    env = subprocess_env()
-    try:
-        p = subprocess.run(
-            ("cset", "recipe-id", "--recipe", file),
-            capture_output=True,
-            check=True,
-            env=env,
-        )
-    except subprocess.CalledProcessError as err:
-        logging.critical(
-            "cset recipe-id exited with non-zero code %s.\nstdout: %s\nstderr: %s",
-            err.returncode,
-            # Presume that subprocesses have the same IO encoding as this one.
-            # Honestly, on all our supported platforms this will be "utf-8".
-            err.stdout.decode(sys.stdout.encoding),
-            err.stderr.decode(sys.stderr.encoding),
-        )
-        raise
-    recipe_id = p.stdout.decode(sys.stdout.encoding).strip()
-    model_identifiers = sorted(os.environ["MODEL_IDENTIFIERS"].split())
-    return f"m{'_m'.join(model_identifiers)}_{recipe_id}"
-
-
-def output_directory():
-    """Get the plot output directory for the recipe."""
-    share_directory = os.environ["CYLC_WORKFLOW_SHARE_DIR"]
-    cycle_point = os.environ["CYLC_TASK_CYCLE_POINT"]
-    return f"{share_directory}/web/plots/{recipe_id()}_{cycle_point}"
 
 
 def data_directories() -> list[str]:
     """Get the input data directories for the cycle."""
     model_identifiers = sorted(os.environ["MODEL_IDENTIFIERS"].split())
     if os.getenv("DO_CASE_AGGREGATION"):
-        cylc_workflow_share_dir = os.environ["CYLC_WORKFLOW_SHARE_DIR"]
+        share_dir = os.environ["CYLC_WORKFLOW_SHARE_DIR"]
         return [
-            f"{cylc_workflow_share_dir}/cycle/*/data/{model_id}"
-            for model_id in model_identifiers
+            f"{share_dir}/cycle/*/data/{model_id}" for model_id in model_identifiers
         ]
     else:
         rose_datac = os.environ["ROSE_DATAC"]
@@ -79,11 +31,14 @@ def data_directories() -> list[str]:
 
 def run_recipe_steps():
     """Process data and produce output plots."""
-    output_dir = output_directory()
+    recipe = recipe_file()
+    data_dirs = data_directories()
+    # Construct the plot output directory for the recipe.
+    output_dir = f"{os.environ['CYLC_WORKFLOW_SHARE_DIR']}/web/plots/{os.environ['CYLC_TASK_ID']}"
 
     command = (
-        ["cset", "bake", "--recipe", recipe_file(), "--input-dir"]
-        + data_directories()
+        ["cset", "bake", "--recipe", recipe, "--input-dir"]
+        + data_dirs
         + ["--output-dir", output_dir]
     )
 
@@ -99,11 +54,11 @@ def run_recipe_steps():
     if skip_write:
         command.append("--skip-write")
 
-    logging.info("Running %s", shlex.join(command))
+    print("Running %s", shlex.join(command))
     try:
-        subprocess.run(command, check=True, env=subprocess_env())
+        subprocess.run(command, check=True)
     except subprocess.CalledProcessError as err:
-        logging.critical("cset bake exited with non-zero code %s.", err.returncode)
+        print("cset bake exited with non-zero code %s.", err.returncode, sys.stderr)
         raise
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -40,15 +40,15 @@ def test_command_line_invocation():
 
 # Every other test should not use the command line interface, but rather stay
 # within python to ensure coverage measurement.
-def test_argument_parser():
+def test_argument_parser(tmp_path):
     """Tests the argument parser behaves appropriately."""
     parser = CSET.setup_argument_parser()
     # Test verbose flag.
-    args = parser.parse_args(["recipe-id", "-r", "recipe.yaml"])
+    args = parser.parse_args(["graph", "-r", "recipe.yaml", "-o", str(tmp_path)])
     assert args.verbose == 0
-    args = parser.parse_args(["-v", "recipe-id", "-r", "recipe.yaml"])
+    args = parser.parse_args(["-v", "graph", "-r", "recipe.yaml", "-o", str(tmp_path)])
     assert args.verbose == 1
-    args = parser.parse_args(["-vv", "recipe-id", "-r", "recipe.yaml"])
+    args = parser.parse_args(["-vv", "graph", "-r", "recipe.yaml", "-o", str(tmp_path)])
     assert args.verbose == 2
 
 
@@ -165,16 +165,6 @@ def test_bake_invalid_args(capsys):
     assert capsys.readouterr().err == "Unknown argument: --not-a-real-option\n"
 
 
-def test_bake_invalid_args_input_dir(capsys):
-    """Missing required input-dir argument for bake."""
-    with pytest.raises(SystemExit) as sysexit:
-        CSET.main(["cset", "bake", "--recipe=foo", "--output-dir=/tmp"])
-    assert sysexit.value.code == 2
-    assert capsys.readouterr().err.endswith(
-        "cset bake: error: the following arguments are required: -i/--input-dir\n"
-    )
-
-
 def test_graph_creation(tmp_path: Path):
     """Generates a graph with the command line interface."""
     # We can't easily test running without the output specified from the CLI, as
@@ -249,23 +239,3 @@ def test_cookbook_non_existent_recipe(tmp_path):
             ["cset", "cookbook", "--output-dir", str(tmp_path), "non-existent.yaml"]
         )
     assert sysexit.value.code == 1
-
-
-def test_recipe_id(capsys):
-    """Get recipe ID for a recipe."""
-    CSET.main(["cset", "recipe-id", "-r", "tests/test_data/noop_recipe.yaml"])
-    assert capsys.readouterr().out == "noop\n"
-
-
-def test_recipe_id_no_title(capsys):
-    """Get recipe id for recipe without a title."""
-    CSET.main(["cset", "recipe-id", "-r", "tests/test_data/ensemble_air_temp.yaml"])
-    # UUID output + newline.
-    assert len(capsys.readouterr().out) == 37
-
-
-def test_cset_addopts(capsys, monkeypatch):
-    """Lists in CSET_ADDOPTS environment variable don't crash the parser."""
-    monkeypatch.setenv("CSET_ADDOPTS", "--LIST='[1, 2, 3]'")
-    CSET.main(["cset", "recipe-id", "-r", "tests/test_data/addopts_test_recipe.yaml"])
-    assert capsys.readouterr().out == "list_1_2_3\n"

--- a/tests/test_execute_recipe.py
+++ b/tests/test_execute_recipe.py
@@ -49,26 +49,26 @@ def test_get_operator_exception_not_callable():
 
 def test_execute_recipe(tmp_path: Path):
     """Execute recipe to test happy case (this is really an integration test)."""
-    input_file = "tests/test_data/air_temp.nc"
+    variables = {"INPUT_PATHS": str(Path.cwd() / "tests/test_data/air_temp.nc")}
     recipe = Path("tests/test_data/plot_instant_air_temp.yaml")
-    CSET.operators.execute_recipe(recipe, input_file, tmp_path)
+    CSET.operators.execute_recipe(recipe, tmp_path, recipe_variables=variables)
 
 
 def test_execute_recipe_edge_cases(tmp_path: Path):
     """Test weird edge cases. Also tests data paths not being pathlib Paths."""
-    input_file = "tests/test_data/air_temp.nc"
+    variables = {"INPUT_PATHS": str(Path.cwd() / "tests/test_data/air_temp.nc")}
     recipe = Path("tests/test_data/noop_recipe.yaml")
-    CSET.operators.execute_recipe(recipe, input_file, tmp_path)
+    CSET.operators.execute_recipe(recipe, tmp_path, recipe_variables=variables)
 
 
 def test_execute_recipe_invalid_output_dir(tmp_path: Path):
     """Exception raised if output directory can't be created."""
+    variables = {"INPUT_PATHS": str(Path.cwd() / "tests/test_data/air_temp.nc")}
     recipe = '{"steps":[{"operator": misc.noop}]}'
-    input_file = Path("tests/test_data/air_temp.nc")
     output_dir = tmp_path / "actually_a_file"
     output_dir.touch()
     with pytest.raises((FileExistsError, NotADirectoryError)):
-        CSET.operators.execute_recipe(recipe, input_file, output_dir)
+        CSET.operators.execute_recipe(recipe, output_dir, recipe_variables=variables)
 
 
 def test_execute_recipe_style_file_metadata_written(tmp_path: Path):
@@ -76,7 +76,6 @@ def test_execute_recipe_style_file_metadata_written(tmp_path: Path):
     style_file_path = "/test/style_file_path.json"
     CSET.operators.execute_recipe(
         '{"steps":[{"operator": misc.noop}]}',
-        [],
         tmp_path,
         style_file=Path(style_file_path),
     )
@@ -88,7 +87,7 @@ def test_execute_recipe_style_file_metadata_written(tmp_path: Path):
 def test_execute_recipe_plot_resolution_metadata_written(tmp_path: Path):
     """Style file path metadata written out."""
     CSET.operators.execute_recipe(
-        '{"steps":[{"operator": misc.noop}]}', [], tmp_path, plot_resolution=72
+        '{"steps":[{"operator": misc.noop}]}', tmp_path, plot_resolution=72
     )
     with open(tmp_path / "meta.json", "rb") as fp:
         metadata = json.load(fp)
@@ -98,7 +97,7 @@ def test_execute_recipe_plot_resolution_metadata_written(tmp_path: Path):
 def test_execute_recipe_skip_write_metadata_written(tmp_path: Path):
     """Skip write metadata written out."""
     CSET.operators.execute_recipe(
-        '{"steps":[{"operator": misc.noop}]}', [], tmp_path, skip_write=True
+        '{"steps":[{"operator": misc.noop}]}', tmp_path, skip_write=True
     )
     with open(tmp_path / "meta.json", "rb") as fp:
         metadata = json.load(fp)


### PR DESCRIPTION
<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

Simplify the cset bake runner script, and remove the `cset recipe-id` command that is only used within that script.

This is a precursor cleanup PR for separating the interpretation of the recipes from their execution, which should allow much faster performance, and eventually lead to reusing of processing steps.

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [ ] All tests and CI checks pass.
- [ ] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [ ] Marked the PR as ready to review.
