### PR TITLE
Provide input paths via recipe variables

### DIFF
--- a/docs/source/getting-started/air_temperature_spatial_plot.yaml
+++ b/docs/source/getting-started/air_temperature_spatial_plot.yaml
@@ -13,7 +13,7 @@ steps:
   # Specify the operator to run in each step.
   - operator: read.read_cubes
     # Specify the name of the argument, and its value.
-    filename_pattern: "*.nc"
+    file_paths: "/data/*.nc"
 
   - operator: filters.filter_cubes
     # Can specify extra keyword arguments as sub-maps.

--- a/docs/source/getting-started/recipe-graph-details.svg
+++ b/docs/source/getting-started/recipe-graph-details.svg
@@ -13,7 +13,7 @@
 <title>61b2e64b&#45;9e35&#45;49ee&#45;9200&#45;2f69705e8485</title>
 <ellipse fill="none" stroke="black" cx="164.91" cy="-432.96" rx="109.96" ry="28.99"/>
 <text text-anchor="middle" x="164.91" y="-436.16" font-family="Times,serif" font-size="14.00">read.read_cubes</text>
-<text text-anchor="middle" x="164.91" y="-419.66" font-family="Times,serif" font-size="14.00">&lt;filename_pattern: *.nc&gt;</text>
+<text text-anchor="middle" x="164.91" y="-419.66" font-family="Times,serif" font-size="14.00">&lt;file_paths: /data/*.nc&gt;</text>
 </g>
 <!-- 409506e4&#45;ebd1&#45;4ba1&#45;bcc1&#45;7aa92d2720c7 -->
 <g id="node3" class="node">

--- a/docs/source/reference/recipe-format.rst
+++ b/docs/source/reference/recipe-format.rst
@@ -27,7 +27,7 @@ Below is a commented example recipe:
     # Specify the operator to run in each step.
     - operator: read.read_cubes
       # Specify the name of the argument, and its value.
-      filename_pattern: "*.nc"
+      file_paths: "/data/*.nc"
 
     - operator: filters.filter_cubes
       # Can specify extra keyword arguments as sub-maps.

--- a/src/CSET/_workflow_utils/preprocess.py
+++ b/src/CSET/_workflow_utils/preprocess.py
@@ -39,7 +39,7 @@ def preprocess_data(data_location: str):
     os.mkdir(data_location)
 
     # Move forecast data back into place.
-    shutil.move("forecast.nc", str(data_location) + "/forecast.nc")
+    shutil.move("forecast.nc", data_location + "/forecast.nc")
 
 
 def run():

--- a/src/CSET/operators/__init__.py
+++ b/src/CSET/operators/__init__.py
@@ -25,7 +25,7 @@ from iris import FUTURE
 
 # Import operators here so they are exported for use by recipes.
 import CSET.operators
-from CSET._common import iter_maybe, parse_recipe
+from CSET._common import parse_recipe
 from CSET.operators import (
     ageofair,
     aggregate,
@@ -158,7 +158,6 @@ def create_diagnostic_archive(output_directory: Path):
 
 def execute_recipe(
     recipe_yaml: Path | str,
-    input_directories: list[str],
     output_directory: Path,
     recipe_variables: dict = None,
     style_file: Path = None,
@@ -173,9 +172,6 @@ def execute_recipe(
         Path to a file containing, or a string of, a recipe's YAML describing
         the operators that need running. If a Path is provided it is opened and
         read.
-    input_directories: list[str]
-        List of pathlike to directories containing input files. Each path is
-        assumed to be to a different model.
     output_directory: Path
         Pathlike indicating desired location of output.
     recipe_variables: dict, optional
@@ -209,11 +205,6 @@ def execute_recipe(
 
     # Execute the steps in a recipe.
     original_working_directory = Path.cwd()
-    # Make paths absolute.
-    step_input = [
-        path if path.startswith("/") else f"{original_working_directory}/{path}"
-        for path in iter_maybe(input_directories)
-    ]
     try:
         os.chdir(output_directory)
         logger = logging.getLogger(__name__)
@@ -234,6 +225,7 @@ def execute_recipe(
         _write_metadata(recipe)
 
         # Execute the recipe.
+        step_input = None
         for step in steps:
             step_input = _step_parser(step, step_input)
         logger.info("Recipe output:\n%s", step_input)

--- a/src/CSET/recipes/CAPE_ratio_plot.yaml
+++ b/src/CSET/recipes/CAPE_ratio_plot.yaml
@@ -5,6 +5,7 @@ description: |
 
 steps:
   - operator: read.read_cubes
+    file_paths: $INPUT_PATHS
 
   - operator: convection.cape_ratio
     SBCAPE:

--- a/src/CSET/recipes/Example_Gaussian_Spatial_Perturbation.yaml
+++ b/src/CSET/recipes/Example_Gaussian_Spatial_Perturbation.yaml
@@ -6,6 +6,7 @@ description: |
 
 steps:
   - operator: read.read_cubes
+    file_paths: $INPUT_PATHS
 
   - operator: mesoscale.spatial_perturbation_field
     original_field:

--- a/src/CSET/recipes/Example_Uniform_Spatial_Perturbation.yaml
+++ b/src/CSET/recipes/Example_Uniform_Spatial_Perturbation.yaml
@@ -6,6 +6,7 @@ description: |
 
 steps:
   - operator: read.read_cubes
+    file_paths: $INPUT_PATHS
 
   - operator: mesoscale.spatial_perturbation_field
     original_field:

--- a/src/CSET/recipes/ageofair.yaml
+++ b/src/CSET/recipes/ageofair.yaml
@@ -12,6 +12,7 @@ description: |
 
 steps:
   - operator: read.read_cubes
+    file_paths: $INPUT_PATHS
 
   - operator: ageofair.compute_ageofair
     XWIND:

--- a/src/CSET/recipes/example_DKE.yaml
+++ b/src/CSET/recipes/example_DKE.yaml
@@ -9,6 +9,7 @@ description: |
 
 steps:
   - operator: read.read_cubes
+    file_paths: $INPUT_PATHS
 
   - operator: ensembles.DKE
     u:

--- a/src/CSET/recipes/example_combined_mask_addition.yaml
+++ b/src/CSET/recipes/example_combined_mask_addition.yaml
@@ -7,6 +7,7 @@ description: |
 
 steps:
   - operator: read.read_cubes
+    file_paths: $INPUT_PATHS
 
   - operator: filters.apply_mask
     original_field:

--- a/src/CSET/recipes/example_combined_mask_multiplication.yaml
+++ b/src/CSET/recipes/example_combined_mask_multiplication.yaml
@@ -7,6 +7,7 @@ description: |
 
 steps:
   - operator: read.read_cubes
+    file_paths: $INPUT_PATHS
 
   - operator: filters.apply_mask
     original_field:

--- a/src/CSET/recipes/example_simple_mask.yaml
+++ b/src/CSET/recipes/example_simple_mask.yaml
@@ -4,6 +4,7 @@ description: Generates and applies a simple mask to a field for stratified analy
 
 steps:
   - operator: read.read_cubes
+    file_paths: $INPUT_PATHS
 
   - operator: filters.apply_mask
     original_field:

--- a/src/CSET/recipes/example_spatial_plot_of_mask.yaml
+++ b/src/CSET/recipes/example_spatial_plot_of_mask.yaml
@@ -5,6 +5,7 @@ description: |
 
 steps:
   - operator: read.read_cubes
+    file_paths: $INPUT_PATHS
 
   - operator: filters.generate_mask
     mask_field:

--- a/src/CSET/recipes/generic_basic_qq_plot.yaml
+++ b/src/CSET/recipes/generic_basic_qq_plot.yaml
@@ -4,6 +4,7 @@ description: Extracts, quantiles, and plots two different variables ($VARNAME_A 
 
 steps:
   - operator: read.read_cubes
+    file_paths: $INPUT_PATHS
 
   - operator: plot.scatter_plot
     cube_y:

--- a/src/CSET/recipes/generic_mlevel_domain_mean_vertical_profile_series.yaml
+++ b/src/CSET/recipes/generic_mlevel_domain_mean_vertical_profile_series.yaml
@@ -4,6 +4,7 @@ description: Plots a time series of vertical profiles for the domain mean $VARNA
 
 steps:
   - operator: read.read_cube
+    file_paths: $INPUT_PATHS
     constraint:
       operator: constraints.combine_constraints
       variable_constraint:

--- a/src/CSET/recipes/generic_mlevel_domain_mean_vertical_profile_series_case_aggregation_hour_of_day.yaml
+++ b/src/CSET/recipes/generic_mlevel_domain_mean_vertical_profile_series_case_aggregation_hour_of_day.yaml
@@ -7,6 +7,7 @@ description: |
 
 steps:
   - operator: read.read_cubes
+    file_paths: $INPUT_PATHS
     constraint:
       operator: constraints.combine_constraints
       variable_constraint:

--- a/src/CSET/recipes/generic_mlevel_domain_mean_vertical_profile_series_case_aggregation_lead_time.yaml
+++ b/src/CSET/recipes/generic_mlevel_domain_mean_vertical_profile_series_case_aggregation_lead_time.yaml
@@ -7,6 +7,7 @@ description: |
 
 steps:
   - operator: read.read_cubes
+    file_paths: $INPUT_PATHS
     constraint:
       operator: constraints.combine_constraints
       variable_constraint:

--- a/src/CSET/recipes/generic_mlevel_domain_mean_vertical_profile_series_case_aggregation_validity_time.yaml
+++ b/src/CSET/recipes/generic_mlevel_domain_mean_vertical_profile_series_case_aggregation_validity_time.yaml
@@ -7,6 +7,7 @@ description: |
 
 steps:
   - operator: read.read_cubes
+    file_paths: $INPUT_PATHS
     constraint:
       operator: constraints.combine_constraints
       variable_constraint:

--- a/src/CSET/recipes/generic_mlevel_domain_vertical_profile_series_case_aggregation_hour_of_day.yaml
+++ b/src/CSET/recipes/generic_mlevel_domain_vertical_profile_series_case_aggregation_hour_of_day.yaml
@@ -7,6 +7,7 @@ description: |
 
 steps:
   - operator: read.read_cubes
+    file_paths: $INPUT_PATHS
     constraint:
       operator: constraints.combine_constraints
       variable_constraint:

--- a/src/CSET/recipes/generic_mlevel_spatial_plot_sequence.yaml
+++ b/src/CSET/recipes/generic_mlevel_spatial_plot_sequence.yaml
@@ -5,6 +5,7 @@ description: |
 
 steps:
   - operator: read.read_cubes
+    file_paths: $INPUT_PATHS
     constraint:
       operator: constraints.combine_constraints
       variable_constraint:

--- a/src/CSET/recipes/generic_mlevel_spatial_plot_sequence_case_aggregation_mean_hour_of_day.yaml
+++ b/src/CSET/recipes/generic_mlevel_spatial_plot_sequence_case_aggregation_mean_hour_of_day.yaml
@@ -6,6 +6,7 @@ description: |
 
 steps:
   - operator: read.read_cubes
+    file_paths: $INPUT_PATHS
     constraint:
       operator: constraints.combine_constraints
       variable_constraint:

--- a/src/CSET/recipes/generic_mlevel_spatial_plot_sequence_case_aggregation_mean_lead_time.yaml
+++ b/src/CSET/recipes/generic_mlevel_spatial_plot_sequence_case_aggregation_mean_lead_time.yaml
@@ -6,6 +6,7 @@ description: |
 
 steps:
   - operator: read.read_cubes
+    file_paths: $INPUT_PATHS
     constraint:
       operator: constraints.combine_constraints
       variable_constraint:

--- a/src/CSET/recipes/generic_mlevel_spatial_plot_sequence_case_aggregation_mean_validity_time.yaml
+++ b/src/CSET/recipes/generic_mlevel_spatial_plot_sequence_case_aggregation_mean_validity_time.yaml
@@ -6,6 +6,7 @@ description: |
 
 steps:
   - operator: read.read_cubes
+    file_paths: $INPUT_PATHS
     constraint:
       operator: constraints.combine_constraints
       variable_constraint:

--- a/src/CSET/recipes/generic_plevel_domain_mean_time_series.yaml
+++ b/src/CSET/recipes/generic_plevel_domain_mean_time_series.yaml
@@ -4,6 +4,7 @@ description: Plots a time series of the domain mean $VARNAME $PLEVEL pressure le
 
 steps:
   - operator: read.read_cube
+    file_paths: $INPUT_PATHS
     constraint:
       operator: constraints.combine_constraints
       varname_constraint:

--- a/src/CSET/recipes/generic_plevel_domain_mean_vertical_profile_series.yaml
+++ b/src/CSET/recipes/generic_plevel_domain_mean_vertical_profile_series.yaml
@@ -4,6 +4,7 @@ description: Plots a time series of vertical profiles for the domain mean $VARNA
 
 steps:
   - operator: read.read_cube
+    file_paths: $INPUT_PATHS
     constraint:
       operator: constraints.combine_constraints
       variable_constraint:

--- a/src/CSET/recipes/generic_plevel_domain_mean_vertical_profile_series_case_aggregation_hour_of_day.yaml
+++ b/src/CSET/recipes/generic_plevel_domain_mean_vertical_profile_series_case_aggregation_hour_of_day.yaml
@@ -7,6 +7,7 @@ description: |
 
 steps:
   - operator: read.read_cubes
+    file_paths: $INPUT_PATHS
     constraint:
       operator: constraints.combine_constraints
       variable_constraint:

--- a/src/CSET/recipes/generic_plevel_domain_mean_vertical_profile_series_case_aggregation_lead_time.yaml
+++ b/src/CSET/recipes/generic_plevel_domain_mean_vertical_profile_series_case_aggregation_lead_time.yaml
@@ -7,6 +7,7 @@ description: |
 
 steps:
   - operator: read.read_cubes
+    file_paths: $INPUT_PATHS
     constraint:
       operator: constraints.combine_constraints
       variable_constraint:

--- a/src/CSET/recipes/generic_plevel_domain_mean_vertical_profile_series_case_aggregation_validity_time.yaml
+++ b/src/CSET/recipes/generic_plevel_domain_mean_vertical_profile_series_case_aggregation_validity_time.yaml
@@ -7,6 +7,7 @@ description: |
 
 steps:
   - operator: read.read_cubes
+    file_paths: $INPUT_PATHS
     constraint:
       operator: constraints.combine_constraints
       variable_constraint:

--- a/src/CSET/recipes/generic_plevel_histogram_series.yaml
+++ b/src/CSET/recipes/generic_plevel_histogram_series.yaml
@@ -11,6 +11,7 @@ description: |
 
 steps:
   - operator: read.read_cube
+    file_paths: $INPUT_PATHS
     constraint:
       operator: constraints.combine_constraints
       variable_constraint:

--- a/src/CSET/recipes/generic_plevel_histogram_series_case_aggregation.yaml
+++ b/src/CSET/recipes/generic_plevel_histogram_series_case_aggregation.yaml
@@ -13,6 +13,7 @@ description: |
 
 steps:
   - operator: read.read_cubes
+    file_paths: $INPUT_PATHS
     constraint:
       operator: constraints.combine_constraints
       variable_constraint:

--- a/src/CSET/recipes/generic_plevel_histogram_series_case_aggregation_lead_time.yaml
+++ b/src/CSET/recipes/generic_plevel_histogram_series_case_aggregation_lead_time.yaml
@@ -13,6 +13,7 @@ description: |
 
 steps:
   - operator: read.read_cubes
+    file_paths: $INPUT_PATHS
     constraint:
       operator: constraints.combine_constraints
       variable_constraint:

--- a/src/CSET/recipes/generic_plevel_spatial_plot_sequence.yaml
+++ b/src/CSET/recipes/generic_plevel_spatial_plot_sequence.yaml
@@ -5,6 +5,7 @@ description: |
 
 steps:
   - operator: read.read_cube
+    file_paths: $INPUT_PATHS
     constraint:
       operator: constraints.combine_constraints
       variable_constraint:

--- a/src/CSET/recipes/generic_plevel_spatial_plot_sequence_case_aggregation_mean_hour_of_day.yaml
+++ b/src/CSET/recipes/generic_plevel_spatial_plot_sequence_case_aggregation_mean_hour_of_day.yaml
@@ -6,6 +6,7 @@ description: |
 
 steps:
   - operator: read.read_cubes
+    file_paths: $INPUT_PATHS
     constraint:
       operator: constraints.combine_constraints
       variable_constraint:

--- a/src/CSET/recipes/generic_plevel_spatial_plot_sequence_case_aggregation_mean_lead_time.yaml
+++ b/src/CSET/recipes/generic_plevel_spatial_plot_sequence_case_aggregation_mean_lead_time.yaml
@@ -6,6 +6,7 @@ description: |
 
 steps:
   - operator: read.read_cubes
+    file_paths: $INPUT_PATHS
     constraint:
       operator: constraints.combine_constraints
       variable_constraint:

--- a/src/CSET/recipes/generic_plevel_spatial_plot_sequence_case_aggregation_mean_validity_time.yaml
+++ b/src/CSET/recipes/generic_plevel_spatial_plot_sequence_case_aggregation_mean_validity_time.yaml
@@ -6,6 +6,7 @@ description: |
 
 steps:
   - operator: read.read_cubes
+    file_paths: $INPUT_PATHS
     constraint:
       operator: constraints.combine_constraints
       variable_constraint:

--- a/src/CSET/recipes/generic_surface_domain_mean_time_series.yaml
+++ b/src/CSET/recipes/generic_surface_domain_mean_time_series.yaml
@@ -4,6 +4,7 @@ description: Plots a time series of the domain mean surface $VARNAME.
 
 steps:
   - operator: read.read_cube
+    file_paths: $INPUT_PATHS
     constraint:
       operator: constraints.combine_constraints
       varname_constraint:

--- a/src/CSET/recipes/generic_surface_domain_mean_time_series_case_aggregation_hour_of_day.yaml
+++ b/src/CSET/recipes/generic_surface_domain_mean_time_series_case_aggregation_hour_of_day.yaml
@@ -6,6 +6,7 @@ description: |
 
 steps:
   - operator: read.read_cubes
+    file_paths: $INPUT_PATHS
     constraint:
       operator: constraints.combine_constraints
       varname_constraint:

--- a/src/CSET/recipes/generic_surface_domain_mean_time_series_case_aggregation_lead_time.yaml
+++ b/src/CSET/recipes/generic_surface_domain_mean_time_series_case_aggregation_lead_time.yaml
@@ -6,6 +6,7 @@ description: |
 
 steps:
   - operator: read.read_cubes
+    file_paths: $INPUT_PATHS
     constraint:
       operator: constraints.combine_constraints
       varname_constraint:

--- a/src/CSET/recipes/generic_surface_domain_mean_time_series_case_aggregation_validity_time.yaml
+++ b/src/CSET/recipes/generic_surface_domain_mean_time_series_case_aggregation_validity_time.yaml
@@ -6,6 +6,7 @@ description: |
 
 steps:
   - operator: read.read_cubes
+    file_paths: $INPUT_PATHS
     constraint:
       operator: constraints.combine_constraints
       varname_constraint:

--- a/src/CSET/recipes/generic_surface_histogram_series.yaml
+++ b/src/CSET/recipes/generic_surface_histogram_series.yaml
@@ -9,6 +9,7 @@ description: |
 
 steps:
   - operator: read.read_cube
+    file_paths: $INPUT_PATHS
     constraint:
       operator: constraints.combine_constraints
       variable_constraint:

--- a/src/CSET/recipes/generic_surface_histogram_series_case_aggregation.yaml
+++ b/src/CSET/recipes/generic_surface_histogram_series_case_aggregation.yaml
@@ -10,6 +10,7 @@ description: |
 
 steps:
   - operator: read.read_cubes
+    file_paths: $INPUT_PATHS
     constraint:
       operator: constraints.combine_constraints
       variable_constraint:

--- a/src/CSET/recipes/generic_surface_histogram_series_case_aggregation_lead_time.yaml
+++ b/src/CSET/recipes/generic_surface_histogram_series_case_aggregation_lead_time.yaml
@@ -10,6 +10,7 @@ description: |
 
 steps:
   - operator: read.read_cubes
+    file_paths: $INPUT_PATHS
     constraint:
       operator: constraints.combine_constraints
       variable_constraint:

--- a/src/CSET/recipes/generic_surface_single_point_time_series.yaml
+++ b/src/CSET/recipes/generic_surface_single_point_time_series.yaml
@@ -4,6 +4,7 @@ description: Plots a time series of the surface $VARNAME at a selected gridpoint
 
 steps:
   - operator: read.read_cube
+    file_paths: $INPUT_PATHS
     constraint:
       operator: constraints.combine_constraints
       varname_constraint:

--- a/src/CSET/recipes/generic_surface_spatial_plot_sequence.yaml
+++ b/src/CSET/recipes/generic_surface_spatial_plot_sequence.yaml
@@ -4,6 +4,7 @@ description: Extracts and plots the surface $VARNAME for all times in $MODEL_NAM
 
 steps:
   - operator: read.read_cube
+    file_paths: $INPUT_PATHS
     constraint:
       operator: constraints.combine_constraints
       varname_constraint:

--- a/src/CSET/recipes/generic_surface_spatial_plot_sequence_case_aggregation_mean_hour_of_day.yaml
+++ b/src/CSET/recipes/generic_surface_spatial_plot_sequence_case_aggregation_mean_hour_of_day.yaml
@@ -6,6 +6,7 @@ description: |
 
 steps:
   - operator: read.read_cubes
+    file_paths: $INPUT_PATHS
     constraint:
       operator: constraints.combine_constraints
       varname_constraint:

--- a/src/CSET/recipes/generic_surface_spatial_plot_sequence_case_aggregation_mean_lead_time.yaml
+++ b/src/CSET/recipes/generic_surface_spatial_plot_sequence_case_aggregation_mean_lead_time.yaml
@@ -6,6 +6,7 @@ description: |
 
 steps:
   - operator: read.read_cubes
+    file_paths: $INPUT_PATHS
     constraint:
       operator: constraints.combine_constraints
       varname_constraint:

--- a/src/CSET/recipes/generic_surface_spatial_plot_sequence_case_aggregation_mean_validity_time.yaml
+++ b/src/CSET/recipes/generic_surface_spatial_plot_sequence_case_aggregation_mean_validity_time.yaml
@@ -6,6 +6,7 @@ description: |
 
 steps:
   - operator: read.read_cubes
+    file_paths: $INPUT_PATHS
     constraint:
       operator: constraints.combine_constraints
       varname_constraint:

--- a/src/CSET/recipes/inflow_layer_properties_plot.yaml
+++ b/src/CSET/recipes/inflow_layer_properties_plot.yaml
@@ -5,6 +5,7 @@ description: |
 
 steps:
   - operator: read.read_cubes
+    file_paths: $INPUT_PATHS
 
   - operator: convection.inflow_layer_properties
     EIB:

--- a/src/CSET/recipes/mlevel_spatial_difference.yaml
+++ b/src/CSET/recipes/mlevel_spatial_difference.yaml
@@ -4,6 +4,7 @@ description: Extracts and plot the difference in surface $VARNAME at level $MLEV
 
 steps:
   - operator: read.read_cubes
+    file_paths: $INPUT_PATHS
     constraint:
       operator: constraints.combine_constraints
       varname_constraint:

--- a/src/CSET/recipes/mlevel_spatial_difference_case_aggregation_mean_hour_of_day.yaml
+++ b/src/CSET/recipes/mlevel_spatial_difference_case_aggregation_mean_hour_of_day.yaml
@@ -6,6 +6,7 @@ description: |
 
 steps:
   - operator: read.read_cubes
+    file_paths: $INPUT_PATHS
     constraint:
       operator: constraints.combine_constraints
       varname_constraint:

--- a/src/CSET/recipes/mlevel_spatial_difference_case_aggregation_mean_lead_time.yaml
+++ b/src/CSET/recipes/mlevel_spatial_difference_case_aggregation_mean_lead_time.yaml
@@ -6,6 +6,7 @@ description: |
 
 steps:
   - operator: read.read_cubes
+    file_paths: $INPUT_PATHS
     constraint:
       operator: constraints.combine_constraints
       varname_constraint:

--- a/src/CSET/recipes/mlevel_spatial_difference_case_aggregation_mean_validity_time.yaml
+++ b/src/CSET/recipes/mlevel_spatial_difference_case_aggregation_mean_validity_time.yaml
@@ -6,6 +6,7 @@ description: |
 
 steps:
   - operator: read.read_cubes
+    file_paths: $INPUT_PATHS
     constraint:
       operator: constraints.combine_constraints
       varname_constraint:

--- a/src/CSET/recipes/pressure_spatial_difference.yaml
+++ b/src/CSET/recipes/pressure_spatial_difference.yaml
@@ -4,6 +4,7 @@ description: Extracts and plot the difference in surface $VARNAME $PLEVEL for al
 
 steps:
   - operator: read.read_cubes
+    file_paths: $INPUT_PATHS
     constraint:
       operator: constraints.combine_constraints
       varname_constraint:

--- a/src/CSET/recipes/surface_spatial_difference.yaml
+++ b/src/CSET/recipes/surface_spatial_difference.yaml
@@ -4,6 +4,7 @@ description: Extracts and plot the difference in surface $VARNAME for all times.
 
 steps:
   - operator: read.read_cubes
+    file_paths: $INPUT_PATHS
     constraint:
       operator: constraints.combine_constraints
       varname_constraint:

--- a/src/CSET/recipes/surface_spatial_difference_case_aggregation_mean_hour_of_day.yaml
+++ b/src/CSET/recipes/surface_spatial_difference_case_aggregation_mean_hour_of_day.yaml
@@ -6,6 +6,7 @@ description: |
 
 steps:
   - operator: read.read_cubes
+    file_paths: $INPUT_PATHS
     constraint:
       operator: constraints.combine_constraints
       varname_constraint:

--- a/src/CSET/recipes/surface_spatial_difference_case_aggregation_mean_lead_time.yaml
+++ b/src/CSET/recipes/surface_spatial_difference_case_aggregation_mean_lead_time.yaml
@@ -6,6 +6,7 @@ description: |
 
 steps:
   - operator: read.read_cubes
+    file_paths: $INPUT_PATHS
     constraint:
       operator: constraints.combine_constraints
       varname_constraint:

--- a/src/CSET/recipes/surface_spatial_difference_case_aggregation_mean_validity_time.yaml
+++ b/src/CSET/recipes/surface_spatial_difference_case_aggregation_mean_validity_time.yaml
@@ -6,6 +6,7 @@ description: |
 
 steps:
   - operator: read.read_cubes
+    file_paths: $INPUT_PATHS
     constraint:
       operator: constraints.combine_constraints
       varname_constraint:

--- a/src/CSET/recipes/transect.yaml
+++ b/src/CSET/recipes/transect.yaml
@@ -8,6 +8,7 @@ description: |
 
 steps:
   - operator: read.read_cube
+    file_paths: $INPUT_PATHS
     constraint:
         operator: constraints.combine_constraints
         cell_method_constraint:

--- a/tests/operators/test_read.py
+++ b/tests/operators/test_read.py
@@ -60,9 +60,8 @@ def test_read_cubes_ensemble_separate_files():
     from CSET.operators import constraints
 
     cubes = read.read_cubes(
-        "tests/test_data/",
+        "tests/test_data/exeter_em*.nc",
         constraint=constraints.generate_stash_constraint("m01s03i236"),
-        filename_pattern="exeter_em*.nc",
     )
     # Check ensemble members have been merged into a single cube.
     assert len(cubes) == 1
@@ -121,7 +120,7 @@ def test_check_input_files_direct_path(tmp_path):
     file_path = tmp_path / "file"
     file_path.touch()
     string_path = str(file_path)
-    actual = read._check_input_files(string_path, "*")
+    actual = read._check_input_files(string_path)
     expected = [file_path]
     assert actual == expected
 
@@ -133,7 +132,7 @@ def test_check_input_files_direct_path_glob(tmp_path):
     file1_path.touch()
     file2_path.touch()
     glob_path = f"{tmp_path}/file*"
-    actual = read._check_input_files(glob_path, "*")
+    actual = read._check_input_files(glob_path)
     expected = [file1_path, file2_path]
     assert actual == expected
 
@@ -144,7 +143,7 @@ def test_check_input_files_direct_path_match_glob_like_file(tmp_path):
     glob_like_path = tmp_path / "file*"
     file1_path.touch()
     glob_like_path.touch()
-    actual = read._check_input_files(str(glob_like_path), "*")
+    actual = read._check_input_files(str(glob_like_path))
     expected = [glob_like_path]
     assert actual == expected
 
@@ -155,19 +154,8 @@ def test_check_input_files_input_directory(tmp_path):
     file2_path = tmp_path / "file2"
     file1_path.touch()
     file2_path.touch()
-    actual = read._check_input_files(str(tmp_path), "*")
+    actual = read._check_input_files(str(tmp_path))
     expected = [file1_path, file2_path]
-    assert actual == expected
-
-
-def test_check_input_files_input_directory_glob(tmp_path):
-    """Get a iterable of files in an input directory with a glob pattern."""
-    file1_path = tmp_path / "file1"
-    file2_path = tmp_path / "file2"
-    file1_path.touch()
-    file2_path.touch()
-    actual = read._check_input_files(str(tmp_path), "*1")
-    expected = [file1_path]
     assert actual == expected
 
 
@@ -175,13 +163,13 @@ def test_check_input_files_invalid_path(tmp_path):
     """Error when path doesn't exist."""
     file_path = str(tmp_path / "file")
     with pytest.raises(FileNotFoundError):
-        read._check_input_files(file_path, "*")
+        read._check_input_files(file_path)
 
 
 def test_check_input_files_no_file_in_directory(tmp_path):
     """Error when input directory doesn't contain any files."""
     with pytest.raises(FileNotFoundError):
-        read._check_input_files(str(tmp_path), "*")
+        read._check_input_files(str(tmp_path))
 
 
 def test_um_normalise_callback_rename_stash(cube):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,7 +25,6 @@ from uuid import uuid4
 import pytest
 
 import CSET
-import CSET.operators
 
 
 def test_command_line_invocation():

--- a/tests/test_data/ensemble_air_temp.yaml
+++ b/tests/test_data/ensemble_air_temp.yaml
@@ -1,6 +1,6 @@
 steps:
   - operator: read.read_cubes
-    filename_pattern: "exeter_em*.nc"
+    file_paths: "tests/test_data/exeter_em*.nc"
     constraint:
       operator: constraints.generate_stash_constraint
       stash: m01s03i236

--- a/tests/test_data/plot_instant_air_temp.yaml
+++ b/tests/test_data/plot_instant_air_temp.yaml
@@ -5,6 +5,7 @@ description: |
 
 steps:
   - operator: read.read_cubes
+    file_paths: $INPUT_PATHS
     constraint:
       operator: constraints.generate_stash_constraint
       stash: m01s03i236

--- a/tests/test_data/plot_instant_air_temp_collapse.yaml
+++ b/tests/test_data/plot_instant_air_temp_collapse.yaml
@@ -4,6 +4,7 @@ description: |
 
 steps:
   - operator: read.read_cubes
+    file_paths: $INPUT_PATHS
     constraint:
       operator: constraints.generate_stash_constraint
       stash: m01s03i236

--- a/tests/workflow_utils/test_preprocess.py
+++ b/tests/workflow_utils/test_preprocess.py
@@ -46,7 +46,7 @@ def test_preprocess_data(tmp_path):
         shutil.copy(file, tmp_path)
 
     # Preprocess data.
-    preprocess.preprocess_data(tmp_path)
+    preprocess.preprocess_data(str(tmp_path))
 
     # Check file has been created.
     output = tmp_path / "forecast.nc"


### PR DESCRIPTION
<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

To facilitate migration the --input-dir command line argument is
reexported into the INPUT_PATHS recipe variable. This provides backwards
compatibility with existing usage of the CLI after the conversion of
recipes.

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [x] New code has tests, and affected old tests have been updated.
- [ ] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [ ] Marked the PR as ready to review.
