### PR TITLE
Update logic for reading SKIP_WRITE environment variable when running cset-workflow

### DIFF
--- a/src/CSET/_workflow_utils/run_cset_recipe.py
+++ b/src/CSET/_workflow_utils/run_cset_recipe.py
@@ -50,9 +50,10 @@ def run_recipe_steps():
     if plot_resolution:
         command.append(f"--plot-resolution={plot_resolution}")
 
-    skip_write = bool(os.getenv("SKIP_WRITE"))
+    skip_write = os.getenv("SKIP_WRITE")
     if skip_write:
-        command.append("--skip-write")
+        if skip_write == "True":
+            command.append("--skip-write")
 
     print("Running %s", shlex.join(command))
     try:


### PR DESCRIPTION
<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->
Fixes #1338. The internal logic for reading cset-workflow environment variable SKIP_WRITE was not operating as expected. This change to run_cset_recipe.py ensures that setting environment variable to T/F has the desired impact on cset bake commands.

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [ ] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
