### PR TITLE
1337 fix implementation of grid latitude grid longitude callback for non rotated pole inputs

### DIFF
--- a/src/CSET/operators/_utils.py
+++ b/src/CSET/operators/_utils.py
@@ -55,17 +55,22 @@ def get_cube_yxcoordname(cube: iris.cube.Cube) -> tuple[str, str]:
     Y_COORD_NAMES = ["latitude", "grid_latitude", "projection_y_coordinate", "y"]
 
     # Get a list of dimension coordinate names for the cube
-    coord_names = [coord.name() for coord in cube.coords(dim_coords=True)]
+    dim_coord_names = [coord.name() for coord in cube.coords(dim_coords=True)]
+    coord_names = [coord.name() for coord in cube.coords()]
 
     # Check which x-coordinate we have, if any
     x_coords = [coord for coord in coord_names if coord in X_COORD_NAMES]
     if len(x_coords) != 1:
-        raise ValueError("Could not identify a unique x-coordinate in cube")
+        x_coords = [coord for coord in dim_coord_names if coord in X_COORD_NAMES]
+        if len(x_coords) != 1:
+            raise ValueError("Could not identify a unique x-coordinate in cube")
 
     # Check which y-coordinate we have, if any
     y_coords = [coord for coord in coord_names if coord in Y_COORD_NAMES]
     if len(y_coords) != 1:
-        raise ValueError("Could not identify a unique y-coordinate in cube")
+        y_coords = [coord for coord in dim_coord_names if coord in Y_COORD_NAMES]
+        if len(y_coords) != 1:
+            raise ValueError("Could not identify a unique y-coordinate in cube")
 
     return (y_coords[0], x_coords[0])
 

--- a/src/CSET/operators/_utils.py
+++ b/src/CSET/operators/_utils.py
@@ -29,7 +29,7 @@ import iris.util
 
 def get_cube_yxcoordname(cube: iris.cube.Cube) -> tuple[str, str]:
     """
-    Return horizontal coordinate name(s) from a given cube.
+    Return horizontal dimension coordinate name(s) from a given cube.
 
     Arguments
     ---------
@@ -37,7 +37,7 @@ def get_cube_yxcoordname(cube: iris.cube.Cube) -> tuple[str, str]:
     cube: iris.cube.Cube
         An iris cube which will be checked to see if it contains coordinate
         names that match a pre-defined list of acceptable horizontal
-        coordinate names.
+        dimension coordinate names.
 
     Returns
     -------
@@ -54,8 +54,8 @@ def get_cube_yxcoordname(cube: iris.cube.Cube) -> tuple[str, str]:
     X_COORD_NAMES = ["longitude", "grid_longitude", "projection_x_coordinate", "x"]
     Y_COORD_NAMES = ["latitude", "grid_latitude", "projection_y_coordinate", "y"]
 
-    # Get a list of coordinate names for the cube
-    coord_names = [coord.name() for coord in cube.coords()]
+    # Get a list of dimension coordinate names for the cube
+    coord_names = [coord.name() for coord in cube.coords(dim_coords=True)]
 
     # Check which x-coordinate we have, if any
     x_coords = [coord for coord in coord_names if coord in X_COORD_NAMES]
@@ -68,6 +68,43 @@ def get_cube_yxcoordname(cube: iris.cube.Cube) -> tuple[str, str]:
         raise ValueError("Could not identify a unique y-coordinate in cube")
 
     return (y_coords[0], x_coords[0])
+
+
+def get_cube_coordindex(cube: iris.cube.Cube, coord_name) -> int:
+    """
+    Return coordinate dimension for a named coordinate from a given cube.
+
+    Arguments
+    ---------
+
+    cube: iris.cube.Cube
+        An iris cube which will be checked to see if it contains coordinate
+        names that match a pre-defined list of acceptable horizontal
+        coordinate names.
+
+    coord_name: str
+        A cube dimension name
+
+    Returns
+    -------
+    coord_index
+        An integer specifying where in the cube dimension list a specified coordinate name is found.
+
+    Raises
+    ------
+    ValueError
+        If a specified dimension coordinate cannot be found.
+    """
+    # Get a list of dimension coordinate names for the cube
+    coord_names = [coord.name() for coord in cube.coords(dim_coords=True)]
+
+    # Check which index the requested dimension is found in, if any
+    try:
+        coord_index = coord_names.index(coord_name)
+    except iris.exceptions.CoordinateNotFoundError:
+        pass
+
+    return coord_index
 
 
 def is_spatialdim(cube: iris.cube.Cube) -> bool:

--- a/src/CSET/operators/read.py
+++ b/src/CSET/operators/read.py
@@ -391,21 +391,39 @@ def _fix_spatial_coord_name_callback(cube: iris.cube.Cube):
         # Don't modify non-spatial cubes.
         return cube
 
-    # Get spatial coords.
+    # Get spatial coords and dimension index.
     y_name, x_name = utils.get_cube_yxcoordname(cube)
+    ny = utils.get_cube_coordindex(cube, y_name)
+    nx = utils.get_cube_coordindex(cube, x_name)
 
     if y_name in ["latitude"] and cube.coord(y_name).units in [
         "degrees",
         "degrees_north",
         "degrees_south",
     ]:
-        cube.coord(y_name).rename("grid_latitude")
+        if "grid_latitude" not in [
+            coord.name() for coord in cube.coords(dim_coords=False)
+        ]:
+            cube.add_aux_coord(
+                iris.coords.AuxCoord(
+                    cube.coord(y_name).points, long_name="grid_latitude"
+                ),
+                ny,
+            )
     if x_name in ["longitude"] and cube.coord(x_name).units in [
         "degrees",
         "degrees_west",
         "degrees_east",
     ]:
-        cube.coord(x_name).rename("grid_longitude")
+        if "grid_longitude" not in [
+            coord.name() for coord in cube.coords(dim_coords=False)
+        ]:
+            cube.add_aux_coord(
+                iris.coords.AuxCoord(
+                    cube.coord(x_name).points, long_name="grid_longitude"
+                ),
+                nx,
+            )
 
 
 def _fix_pressure_coord_callback(cube: iris.cube.Cube):

--- a/src/CSET/operators/transect.py
+++ b/src/CSET/operators/transect.py
@@ -136,8 +136,12 @@ def calc_transect(cube: iris.cube.Cube, startcoords: tuple, endcoords: tuple):
         )
 
         # Remove existing coordinates ready to add one single map coordinate
-        cube_slice.remove_coord(lon_name)
-        cube_slice.remove_coord(lat_name)
+        # Note latitude/longitude cubes may have additional AuxCoord to remove
+        for coord_name in ["latitude", "longitude", "grid_latitude", "grid_longitude"]:
+            try:
+                cube_slice.remove_coord(coord_name)
+            except iris.exceptions.CoordinateNotFoundError:
+                pass
 
         if transect_coord == "latitude":
             dist_coord = iris.coords.DimCoord(

--- a/tests/operators/test_read.py
+++ b/tests/operators/test_read.py
@@ -462,14 +462,14 @@ def test_fix_um_lightning_skip_no_offset(cube):
         assert ft == t
 
 
-def test_spatial_coord_rename_callback():
-    """Check that spatial coord gets renamed if it is not grid_latitude."""
+def test_spatial_coord_auxcoord_callback():
+    """Check that additional spatial aux coord grid_latitude gets added."""
     # This cube contains 'latitude' and 'longitude'
     cube = iris.load_cube("tests/test_data/transect_test_umpl.nc")
     read._fix_spatial_coord_name_callback(cube)
     assert (
         repr(cube.coords())
-        == "[<DimCoord: time / (hours since 1970-01-01 00:00:00)  [...]  shape(2,)>, <DimCoord: pressure / (hPa)  [ 100., 150., ..., 950., 1000.]  shape(16,)>, <DimCoord: grid_latitude / (degrees)  [-10.98, -10.94, ..., -10.82, -10.78]  shape(6,)>, <DimCoord: grid_longitude / (degrees)  [19.02, 19.06, ..., 19.18, 19.22]  shape(6,)>, <DimCoord: forecast_reference_time / (hours since 1970-01-01 00:00:00)  [...]>, <AuxCoord: forecast_period / (hours)  [15., 18.]  shape(2,)>]"
+        == "[<DimCoord: time / (hours since 1970-01-01 00:00:00)  [...]  shape(2,)>, <DimCoord: pressure / (hPa)  [ 100., 150., ..., 950., 1000.]  shape(16,)>, <DimCoord: latitude / (degrees)  [-10.98, -10.94, ..., -10.82, -10.78]  shape(6,)>, <DimCoord: longitude / (degrees)  [19.02, 19.06, ..., 19.18, 19.22]  shape(6,)>, <DimCoord: forecast_reference_time / (hours since 1970-01-01 00:00:00)  [...]>, <AuxCoord: forecast_period / (hours)  [15., 18.]  shape(2,)>, <AuxCoord: grid_latitude / (unknown)  [-10.98, -10.94, ..., -10.82, -10.78]  shape(6,)>, <AuxCoord: grid_longitude / (unknown)  [19.02, 19.06, ..., 19.18, 19.22]  shape(6,)>]"
     )
 
 

--- a/tests/operators/test_utils.py
+++ b/tests/operators/test_utils.py
@@ -25,13 +25,15 @@ import CSET.operators._utils as operator_utils
 def test_missing_coord_get_cube_yxcoordname_x(regrid_rectilinear_cube):
     """Missing X coordinate raises error."""
     regrid_rectilinear_cube.remove_coord("longitude")
+    regrid_rectilinear_cube.remove_coord("grid_longitude")
     with pytest.raises(ValueError):
         operator_utils.get_cube_yxcoordname(regrid_rectilinear_cube)
 
 
 def test_missing_coord_get_cube_yxcoordname_y(regrid_rectilinear_cube):
     """Missing Y coordinate raises error."""
-    regrid_rectilinear_cube.remove_coord("longitude")
+    regrid_rectilinear_cube.remove_coord("latitude")
+    regrid_rectilinear_cube.remove_coord("grid_latitude")
     with pytest.raises(ValueError):
         operator_utils.get_cube_yxcoordname(regrid_rectilinear_cube)
 

--- a/tests/operators/test_utils.py
+++ b/tests/operators/test_utils.py
@@ -24,14 +24,14 @@ import CSET.operators._utils as operator_utils
 
 def test_missing_coord_get_cube_yxcoordname_x(regrid_rectilinear_cube):
     """Missing X coordinate raises error."""
-    regrid_rectilinear_cube.remove_coord("grid_longitude")
+    regrid_rectilinear_cube.remove_coord("longitude")
     with pytest.raises(ValueError):
         operator_utils.get_cube_yxcoordname(regrid_rectilinear_cube)
 
 
 def test_missing_coord_get_cube_yxcoordname_y(regrid_rectilinear_cube):
     """Missing Y coordinate raises error."""
-    regrid_rectilinear_cube.remove_coord("grid_longitude")
+    regrid_rectilinear_cube.remove_coord("longitude")
     with pytest.raises(ValueError):
         operator_utils.get_cube_yxcoordname(regrid_rectilinear_cube)
 
@@ -39,8 +39,8 @@ def test_missing_coord_get_cube_yxcoordname_y(regrid_rectilinear_cube):
 def test_get_cube_yxcoordname(regrid_rectilinear_cube):
     """Check that function returns tuple containing horizontal dimension names."""
     assert (operator_utils.get_cube_yxcoordname(regrid_rectilinear_cube)) == (
-        "grid_latitude",
-        "grid_longitude",
+        "latitude",
+        "longitude",
     )
 
 
@@ -51,7 +51,7 @@ def test_missing_coord_get_cube_coordindex(regrid_rectilinear_cube):
 
 
 def test_get_cube_coordindex(regrid_rectilinear_cube):
-    """Check that function returns correct dimension index for grid_latitude."""
+    """Check that function returns correct dimension index for latitude and longitude."""
     assert (
         operator_utils.get_cube_coordindex(regrid_rectilinear_cube, "latitude")
     ) == 0

--- a/tests/operators/test_utils.py
+++ b/tests/operators/test_utils.py
@@ -44,6 +44,22 @@ def test_get_cube_yxcoordname(regrid_rectilinear_cube):
     )
 
 
+def test_missing_coord_get_cube_coordindex(regrid_rectilinear_cube):
+    """Missing coordinate name raises error."""
+    with pytest.raises(ValueError):
+        operator_utils.get_cube_coordindex(regrid_rectilinear_cube, "gridded_latitude")
+
+
+def test_get_cube_coordindex(regrid_rectilinear_cube):
+    """Check that function returns correct dimension index for grid_latitude."""
+    assert (
+        operator_utils.get_cube_coordindex(regrid_rectilinear_cube, "latitude")
+    ) == 0
+    assert (
+        operator_utils.get_cube_coordindex(regrid_rectilinear_cube, "longitude")
+    ) == 1
+
+
 def test_is_transect_multiple_spatial_coords(regrid_rectilinear_cube):
     """Check that function returns False as more than one spatial map coord."""
     assert not operator_utils.is_transect(regrid_rectilinear_cube)


### PR DESCRIPTION
<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->
Fixes #1337. Updated approach to add grid_latitude and grid_longitude as additional aux variables with read.py callback to ensure cube attributes are preserved when reading/writing intermediate files when processing latitude and longitude cubes (e.g. non-rotated grids). This preserves functionality of collapsing on [grid_latitude, grid_longitude] for all use cases. 

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [x] Documentation has been updated to reflect change.
- [x] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
