### PR TITLE
Symbolic link to raw filesystem data to avoid slow copy

### DIFF
--- a/src/CSET/_workflow_utils/fetch_data.py
+++ b/src/CSET/_workflow_utils/fetch_data.py
@@ -7,12 +7,12 @@ import glob
 import itertools
 import logging
 import os
-import shutil
 import ssl
 import urllib.parse
 import urllib.request
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta
+from pathlib import Path
 from typing import Literal
 
 import isodate
@@ -93,9 +93,11 @@ class FilesystemFileRetriever(FileRetrieverABC):
         if not file_paths:
             logging.warning("file_path does not match any files: %s", file_path)
         any_files_copied = False
-        for file in file_paths:
+        for f in file_paths:
+            file = Path(f)
             try:
-                shutil.copy(file, output_dir)
+                # We know file exists from glob.
+                os.symlink(file.absolute(), f"{output_dir}/{file.name}")
                 any_files_copied = True
             except OSError as err:
                 logging.warning("Failed to copy %s, error: %s", file, err)

--- a/tests/workflow_utils/test_fetch_data.py
+++ b/tests/workflow_utils/test_fetch_data.py
@@ -207,9 +207,17 @@ def test_FilesystemFileRetriever(tmp_path):
     """Test retrieving a file from the filesystem."""
     with fetch_data.FilesystemFileRetriever() as ffr:
         files_found = ffr.get_file("tests/test_data/exeter_em*.nc", str(tmp_path))
-    assert (tmp_path / "exeter_em01.nc").is_file()
-    assert (tmp_path / "exeter_em02.nc").is_file()
+    # Correct return value.
     assert files_found
+    # Symlinks created. Technically this checks that the files the symlink
+    # points to exists, but that is good enough here, and the follow_symlinks
+    # argument requires python 3.12.
+    assert (tmp_path / "exeter_em01.nc").exists()
+    assert (tmp_path / "exeter_em02.nc").exists()
+    # Check symlink points to correct file.
+    with open((tmp_path / "exeter_em01.nc"), "rb") as fp:
+        digest = hashlib.file_digest(fp, "sha256").hexdigest()
+    assert digest == "67899970eeca75b9378f0275ce86db3d1d613f2bc7a178540912848dc8a69ca7"
 
 
 def test_FilesystemFileRetriever_no_files(tmp_path, caplog):


### PR DESCRIPTION
This is *much* faster than copying. As we rewrite the data in the pre-processing step this doesn't meaningfully change our external dependence on the data.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [x] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
