### PR TITLE
Improve testing of get_cube_coordindex

### DIFF
--- a/src/CSET/operators/_utils.py
+++ b/src/CSET/operators/_utils.py
@@ -104,10 +104,7 @@ def get_cube_coordindex(cube: iris.cube.Cube, coord_name) -> int:
     coord_names = [coord.name() for coord in cube.coords(dim_coords=True)]
 
     # Check which index the requested dimension is found in, if any
-    try:
-        coord_index = coord_names.index(coord_name)
-    except iris.exceptions.CoordinateNotFoundError:
-        pass
+    coord_index = coord_names.index(coord_name)
 
     return coord_index
 

--- a/tests/operators/test_utils.py
+++ b/tests/operators/test_utils.py
@@ -60,6 +60,9 @@ def test_get_cube_coordindex(regrid_rectilinear_cube):
     assert (
         operator_utils.get_cube_coordindex(regrid_rectilinear_cube, "longitude")
     ) == 1
+    # Error when coord name isn't in cube.
+    with pytest.raises(ValueError):
+        operator_utils.get_cube_coordindex(regrid_rectilinear_cube, "no-existent")
 
 
 def test_is_transect_multiple_spatial_coords(regrid_rectilinear_cube):


### PR DESCRIPTION
This tests the error from get_cube_coordindex when a coordinate doesn't exist, and removes an unreachable except clause.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [x] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
