### PR TITLE
Update pyproject.toml metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,12 +4,11 @@ dynamic = ["version"]
 description = "Toolkit for evaluation and investigation of numerical models for weather and climate applications."
 authors = [{ name = "Met Office" }, { name = "NIWA" }]
 readme = "README.md"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
 requires-python = ">=3.11"
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: Apache Software License",
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.11",
@@ -23,7 +22,7 @@ classifiers = [
 ]
 dependencies = [
     "numpy",
-    "scitools-iris >= 3.6",
+    "scitools-iris >= 3.12.2",
     "ruamel.yaml >= 0.17",
     "pygraphviz >= 1.11",
     "mo_pack >= 0.3.0",
@@ -41,7 +40,7 @@ Source = "https://github.com/MetOffice/CSET"
 cset = "CSET:main"
 
 [build-system]
-requires = ["setuptools>=64", "setuptools_scm>=8"]
+requires = ["setuptools>=80", "setuptools_scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]


### PR DESCRIPTION
The change in licence format comes from an upstream packaging change (hence the setuptools bump).

The iris update was missed in 7e12d834 as we mainly use conda for dependency management.

Finally the Development Status change reflects CSET maturing.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [ ] All tests and CI checks pass.
- [ ] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [ ] Marked the PR as ready to review.
