### PR TITLE
Improve customisability of x/y ranges using json

### DIFF
--- a/src/CSET/operators/plot.py
+++ b/src/CSET/operators/plot.py
@@ -216,7 +216,7 @@ def _get_model_colors_map(cubes: iris.cube.CubeList | iris.cube.Cube) -> dict:
     return {mname: color for mname, color in zip(model_names, color_list, strict=False)}
 
 
-def _colorbar_map_levels(cube: iris.cube.Cube):
+def _colorbar_map_levels(cube: iris.cube.Cube, axis=None):
     """Get an appropriate colorbar for the given cube.
 
     For the given variable the appropriate colorbar is looked up from a
@@ -229,6 +229,8 @@ def _colorbar_map_levels(cube: iris.cube.Cube):
     ----------
     cube: Cube
         Cube of variable for which the colorbar information is desired.
+    axis: str
+        If specified, x or y-axis for setting vmin and vmax bounds
 
     Returns
     -------
@@ -293,10 +295,24 @@ def _colorbar_map_levels(cube: iris.cube.Cube):
             except KeyError:
                 # Get the range for this variable.
                 vmin, vmax = var_colorbar["min"], var_colorbar["max"]
+                print(vmin, vmax)
+                if axis:
+                    print(axis)
+                    if axis == "x":
+                        try:
+                            vmin, vmax = var_colorbar["xmin"], var_colorbar["xmax"]
+                        except:
+                            pass
+                    if axis == "y":
+                        try:
+                            vmin, vmax = var_colorbar["ymin"], var_colorbar["ymax"]
+                        except:
+                            pass
                 logging.debug("Using min and max for %s colorbar.", varname)
                 # Calculate levels from range.
                 levels = np.linspace(vmin, vmax, 51)
-                norm = None
+                # norm = None
+                norm = mpl.colors.BoundaryNorm(levels, ncolors=cmap.N)
                 cmap, levels, norm = _custom_colourmap_precipitation(
                     cube, cmap, levels, norm
                 )


### PR DESCRIPTION
Allows more flexibility for the user to specify xmin/xmax or similar on y axis to allow more control on plotting ranges. At the moment if levels is present, then this overrides the presence of x/y ranges in the json, so some logic is needed to query what exists for that variable.

Initially drafted by @ukmo-huw-lewis 

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [ ] All tests and CI checks pass.
- [ ] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [ ] Marked the PR as ready to review.
