### PR TITLE
Ensure all lead time in common units (hours) between models

### DIFF
--- a/src/CSET/operators/read.py
+++ b/src/CSET/operators/read.py
@@ -731,8 +731,10 @@ def _lfric_time_callback(cube: iris.cube.Cube):
                 lead_times = tcoord.points - init_time_points_in_tcoord_units
 
                 # Get unit for lead time from time coordinate's unit.
+                # Convert all lead time to hours for consistency between models.
                 if "seconds" in str(tcoord.units):
-                    units = "seconds"
+                    lead_times = lead_times / 3600.0
+                    units = "hours"
                 elif "hours" in str(tcoord.units):
                     units = "hours"
                 else:

--- a/tests/operators/test_read.py
+++ b/tests/operators/test_read.py
@@ -531,8 +531,8 @@ def test_lfric_time_callback_forecast_period(slammed_lfric_cube):
     assert fc_period_coord.standard_name == "forecast_period"
     assert fc_period_coord.long_name == "forecast_period"
     assert fc_period_coord.var_name is None
-    assert str(fc_period_coord.units) == "seconds"
-    assert all(fc_period_coord.points == [3600, 7200, 10800, 14400, 18000, 21600])
+    assert str(fc_period_coord.units) == "hours"
+    assert all(fc_period_coord.points == [1, 2, 3, 4, 5, 6])
 
 
 def test_lfric_time_callback_hours(slammed_lfric_cube):


### PR DESCRIPTION
<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->
Default unit to lead time set to hours for all models.

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [x] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
