### PR TITLE
Add non-aggregated cell_methods contraint to all histogram plotting recipes for surface and level variables

### DIFF
--- a/src/CSET/recipes/generic_level_histogram_series_case_aggregation.yaml
+++ b/src/CSET/recipes/generic_level_histogram_series_case_aggregation.yaml
@@ -20,6 +20,9 @@ steps:
       variable_constraint:
         operator: constraints.generate_var_constraint
         varname: $VARNAME
+      cell_methods_constraint:
+        operator: constraints.generate_cell_methods_constraint
+        cell_methods: []
       level_constraint:
         operator: constraints.generate_level_constraint
         coordinate: $LEVELTYPE

--- a/src/CSET/recipes/generic_level_histogram_series_case_aggregation_hour_of_day.yaml
+++ b/src/CSET/recipes/generic_level_histogram_series_case_aggregation_hour_of_day.yaml
@@ -20,6 +20,9 @@ steps:
       variable_constraint:
         operator: constraints.generate_var_constraint
         varname: $VARNAME
+      cell_methods_constraint:
+        operator: constraints.generate_cell_methods_constraint
+        cell_methods: []
       level_constraint:
         operator: constraints.generate_level_constraint
         coordinate: $LEVELTYPE

--- a/src/CSET/recipes/generic_level_histogram_series_case_aggregation_lead_time.yaml
+++ b/src/CSET/recipes/generic_level_histogram_series_case_aggregation_lead_time.yaml
@@ -20,6 +20,9 @@ steps:
       variable_constraint:
         operator: constraints.generate_var_constraint
         varname: $VARNAME
+      cell_methods_constraint:
+        operator: constraints.generate_cell_methods_constraint
+        cell_methods: []
       level_constraint:
         operator: constraints.generate_level_constraint
         coordinate: $LEVELTYPE

--- a/src/CSET/recipes/generic_level_histogram_series_case_aggregation_validity_time.yaml
+++ b/src/CSET/recipes/generic_level_histogram_series_case_aggregation_validity_time.yaml
@@ -20,6 +20,9 @@ steps:
       variable_constraint:
         operator: constraints.generate_var_constraint
         varname: $VARNAME
+      cell_methods_constraint:
+        operator: constraints.generate_cell_methods_constraint
+        cell_methods: []
       level_constraint:
         operator: constraints.generate_level_constraint
         coordinate: $LEVELTYPE

--- a/src/CSET/recipes/generic_surface_histogram_series_case_aggregation.yaml
+++ b/src/CSET/recipes/generic_surface_histogram_series_case_aggregation.yaml
@@ -17,6 +17,9 @@ steps:
       variable_constraint:
         operator: constraints.generate_var_constraint
         varname: $VARNAME
+      cell_methods_constraint:
+        operator: constraints.generate_cell_methods_constraint
+        cell_methods: []
       pressure_level_constraint:
         operator: constraints.generate_level_constraint
         coordinate: pressure

--- a/src/CSET/recipes/generic_surface_histogram_series_case_aggregation_hour_of_day.yaml
+++ b/src/CSET/recipes/generic_surface_histogram_series_case_aggregation_hour_of_day.yaml
@@ -17,6 +17,9 @@ steps:
       variable_constraint:
         operator: constraints.generate_var_constraint
         varname: $VARNAME
+      cell_methods_constraint:
+        operator: constraints.generate_cell_methods_constraint
+        cell_methods: []
       pressure_level_constraint:
         operator: constraints.generate_level_constraint
         coordinate: pressure

--- a/src/CSET/recipes/generic_surface_histogram_series_case_aggregation_lead_time.yaml
+++ b/src/CSET/recipes/generic_surface_histogram_series_case_aggregation_lead_time.yaml
@@ -17,6 +17,9 @@ steps:
       variable_constraint:
         operator: constraints.generate_var_constraint
         varname: $VARNAME
+      cell_methods_constraint:
+        operator: constraints.generate_cell_methods_constraint
+        cell_methods: []
       pressure_level_constraint:
         operator: constraints.generate_level_constraint
         coordinate: pressure

--- a/src/CSET/recipes/generic_surface_histogram_series_case_aggregation_validity_time.yaml
+++ b/src/CSET/recipes/generic_surface_histogram_series_case_aggregation_validity_time.yaml
@@ -17,6 +17,9 @@ steps:
       variable_constraint:
         operator: constraints.generate_var_constraint
         varname: $VARNAME
+      cell_methods_constraint:
+        operator: constraints.generate_cell_methods_constraint
+        cell_methods: []
       pressure_level_constraint:
         operator: constraints.generate_level_constraint
         coordinate: pressure

--- a/src/CSET/recipes/generic_surface_single_point_time_series.yaml
+++ b/src/CSET/recipes/generic_surface_single_point_time_series.yaml
@@ -11,6 +11,9 @@ steps:
       varname_constraint:
         operator: constraints.generate_var_constraint
         varname: $VARNAME
+      cell_methods_constraint:
+        operator: constraints.generate_cell_methods_constraint
+        cell_methods: []
       pressure_level_constraint:
         operator: constraints.generate_level_constraint
         levels: []


### PR DESCRIPTION
<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->
Addresses #1402. Implements plotting of instantaneous outputs as default CSET behaviour across all plot types, where multiple input variables exist in input diagnostics. 

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
