### PR TITLE
Remove environment section from bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,17 +1,19 @@
 ---
 name: Bug report
-about: Create a report to help us fix something
+about: Create a report to help us fix something.
 title: ''
 labels: bug
 assignees: ''
 ---
 
 ### Describe the bug
-<!-- Description of what the bug is. -->
+<!-- Description of what the bug is. If applicable, add screenshots or logs to help explain your problem. -->
 
 
 
 ### How to reproduce
+<!-- How to trigger the bug, including any information about your local setup. -->
+
 Steps to reproduce the behaviour:
 
 1.
@@ -19,11 +21,4 @@ Steps to reproduce the behaviour:
 3.
 
 ### Expected behaviour
-<!-- Description of what you expected to happen. If applicable, add screenshots or logs to help explain your problem. -->
-
-
-
-### Environment
-
-- Version: [e.g. from `cset --version`]
-- Browser (if UI issue): [e.g. Chrome, Firefox]
+<!-- Description of what you expected to happen. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
 name: Feature request
-about: Suggest an idea for this project
+about: Suggest an idea for this project.
 title: ''
 labels: enhancement
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/other.md
+++ b/.github/ISSUE_TEMPLATE/other.md
@@ -1,6 +1,6 @@
 ---
 name: Something else
-about: Neither a bug report or a feature request
+about: Neither a bug report or a feature request.
 title: ''
 labels: ''
 assignees: ''


### PR DESCRIPTION
No one has ever really filled it in usefully, and it is covered in the reproducing section.

Also fixes some inconsistencies in the issue type descriptions.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
