### PR TITLE
More robustly test command line argument parser

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -30,7 +30,9 @@ import CSET
 def test_command_line_invocation():
     """Check invocation via different entrypoints.
 
-    Uses subprocess to validate the external interface.
+    Uses subprocess to validate the external interface. Every other test should
+    not use the command line interface, but rather stay within python to ensure
+    coverage measurement.
     """
     # Invoke via cset command
     subprocess.run(["cset", "--version"], check=True)
@@ -38,18 +40,64 @@ def test_command_line_invocation():
     subprocess.run(["python3", "-m", "CSET", "--version"], check=True)
 
 
-# Every other test should not use the command line interface, but rather stay
-# within python to ensure coverage measurement.
-def test_argument_parser(tmp_path):
-    """Tests the argument parser behaves appropriately."""
+def test_argument_parser_graph(tmp_path):
+    """Tests the cset graph argument parser behaves appropriately."""
     parser = CSET.setup_argument_parser()
-    # Test verbose flag.
     args = parser.parse_args(["graph", "-r", "recipe.yaml", "-o", str(tmp_path)])
+    assert args.recipe == Path("recipe.yaml")
+    assert args.output_path == tmp_path
     assert args.verbose == 0
+    # Test verbose flag.
     args = parser.parse_args(["-v", "graph", "-r", "recipe.yaml", "-o", str(tmp_path)])
     assert args.verbose == 1
     args = parser.parse_args(["-vv", "graph", "-r", "recipe.yaml", "-o", str(tmp_path)])
     assert args.verbose == 2
+
+
+def test_argument_parser_bake(tmp_path):
+    """Tests the cset bake argument parser behaves appropriately."""
+    parser = CSET.setup_argument_parser()
+    # Check required arguments.
+    args = parser.parse_args(
+        ["bake", "--recipe", "recipe.yaml", "--output-dir", str(tmp_path)]
+    )
+    assert args.recipe == Path("recipe.yaml")
+    assert args.output_dir == tmp_path
+    # Check optional arguments.
+    args = parser.parse_args(
+        [
+            "bake",
+            "-r",
+            "recipe.yaml",
+            "-o",
+            str(tmp_path),
+            "-i",
+            str(tmp_path),
+            "-s",
+            str(tmp_path / "style.json"),
+            "--plot-resolution",
+            "72",
+            "--skip-write",
+        ]
+    )
+    assert args.input_dir == [str(tmp_path)]
+    assert args.style_file == tmp_path / "style.json"
+    assert args.plot_resolution == 72
+    assert args.skip_write is True
+
+
+def test_argument_parser_cookbook(tmp_path):
+    """Tests the cset cookbook argument parser behaves appropriately."""
+    parser = CSET.setup_argument_parser()
+    # Check default values.
+    args = parser.parse_args(["cookbook"])
+    assert args.recipe == ""
+    assert args.output_dir == Path.cwd()
+    # Check optional arguments.
+    args = parser.parse_args(["cookbook", "-d", "-o", str(tmp_path), "recipe.yaml"])
+    assert args.details is True
+    assert args.output_dir == tmp_path
+    assert args.recipe == "recipe.yaml"
 
 
 def test_setup_logging():


### PR DESCRIPTION
This now actually checks each of the subparsers work.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [x] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
