### PR TITLE
Add Makefile providing useful commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,36 @@
+# Makefile providing useful commands to assist with CSET development.
+# See the make manual for more information:
+# https://www.gnu.org/software/make/manual/html_node/
+
+# To make a command appear in the help, provide a line of documentation after
+# the target/prerequisites with ##.
+
+help: ## Display this help message.
+	@echo "Please provide a target from:"
+	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
+	| sed -n 's/^\(.*:\) \(.*\)##\(.*\)/  \1\3/p'
+
+conda:
+	conda create -n cset-dev --file requirements/locks/py313-lock-linux-64.txt
+	@echo "Run 'conda activate cset-dev' to use conda environment."
+
+.git/hooks/pre-commit: conda
+	conda run -n cset-dev pre-commit install
+
+setup: conda .git/hooks/pre-commit ## Setup development environment.
+	conda run -n cset-dev pip install --no-deps -e .
+
+docs: ## Build documentation.
+	cd docs && make html
+
+pre-commit:
+	pre-commit run --all-files
+
+pytest:
+	pytest -vv
+
+test: pre-commit pytest ## Run linting and unit tests.
+
+# Mark targets as 'phony' to indicate they don't actually produce a file with
+# the same name as their target. Basically for actions rather than files.
+.PHONY: help setup docs test

--- a/docs/source/contributing/getting-started.rst
+++ b/docs/source/contributing/getting-started.rst
@@ -6,7 +6,7 @@ Contributing
 
 Contributions are readily welcome! In addition to reading the `working
 practices`_, the key recommendation is early communication. Open an issue on
-Github with your proposed change or addition in the design phase, and then
+GitHub with your proposed change or addition in the design phase, and then
 others can provide guidance early. To create an issue:
 
 - Go to the `issue tracker on GitHub`_,
@@ -77,10 +77,18 @@ environment for you to use.
     # Make CSET runnable for manual testing
     pip install --no-deps -e .
 
+Alternatively, if you have make_ installed you can use a single command
+to setup the development environment (equivalent to the above commands).
+
+.. code-block:: bash
+
+    make setup
+
 When subsequently returning to the code after closing your terminal, you will
 need to rerun the ``conda activate cset-dev`` command.
 
 .. _conda: https://docs.conda.io/en/latest/
+.. _make: https://www.gnu.org/software/make
 
 Updating tooling
 ------------------


### PR DESCRIPTION
<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

Add a makefile with some basic useful commands. The most useful is
probably `make setup`, which will create the development conda
environment, install the pre-commit hooks, and install the CSET package
all in one go.

Fixes https://github.com/MetOffice/CSET/issues/1417

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [ ] All tests and CI checks pass.
- [ ] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [ ] Marked the PR as ready to review.
