### PR TITLE
Add model names to spatial_difference recipes

### DIFF
--- a/src/CSET/recipes/surface_spatial_difference.yaml
+++ b/src/CSET/recipes/surface_spatial_difference.yaml
@@ -5,6 +5,7 @@ description: Extracts and plot the difference in $VARNAME for all times.
 steps:
   - operator: read.read_cubes
     file_paths: $INPUT_PATHS
+    model_names: [$BASE_MODEL, $OTHER_MODEL]
     constraint:
       operator: constraints.combine_constraints
       varname_constraint:

--- a/src/CSET/recipes/surface_spatial_difference_case_aggregation_mean_hour_of_day.yaml
+++ b/src/CSET/recipes/surface_spatial_difference_case_aggregation_mean_hour_of_day.yaml
@@ -7,6 +7,7 @@ description: |
 steps:
   - operator: read.read_cubes
     file_paths: $INPUT_PATHS
+    model_names: [$BASE_MODEL, $OTHER_MODEL]
     constraint:
       operator: constraints.combine_constraints
       varname_constraint:

--- a/src/CSET/recipes/surface_spatial_difference_case_aggregation_mean_lead_time.yaml
+++ b/src/CSET/recipes/surface_spatial_difference_case_aggregation_mean_lead_time.yaml
@@ -7,6 +7,7 @@ description: |
 steps:
   - operator: read.read_cubes
     file_paths: $INPUT_PATHS
+    model_names: [$BASE_MODEL, $OTHER_MODEL]
     constraint:
       operator: constraints.combine_constraints
       varname_constraint:

--- a/src/CSET/recipes/surface_spatial_difference_case_aggregation_mean_validity_time.yaml
+++ b/src/CSET/recipes/surface_spatial_difference_case_aggregation_mean_validity_time.yaml
@@ -7,6 +7,7 @@ description: |
 steps:
   - operator: read.read_cubes
     file_paths: $INPUT_PATHS
+    model_names: [$BASE_MODEL, $OTHER_MODEL]
     constraint:
       operator: constraints.combine_constraints
       varname_constraint:


### PR DESCRIPTION
<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->
Addresses #1438 
Ensures model_name can be assigned to all cubes when using read.read_cubes in recipes.
Otherwise, differences are only created if for example cube names differ.

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [ ] All tests and CI checks pass.
- [ ] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [ ] Marked the PR as ready to review.
