### PR TITLE
Removes check to ensure cubes can be aggregated by hour in recipes

### DIFF
--- a/src/CSET/recipes/generic_level_domain_mean_time_series_case_aggregation_hour_of_day.yaml
+++ b/src/CSET/recipes/generic_level_domain_mean_time_series_case_aggregation_hour_of_day.yaml
@@ -20,8 +20,6 @@ steps:
     coordinate: [grid_latitude, grid_longitude]
     method: MEAN
 
-  - operator: aggregate.ensure_aggregatable_across_cases
-
   - operator: collapse.collapse_by_hour_of_day
     method: MEAN
 

--- a/src/CSET/recipes/generic_level_domain_mean_vertical_profile_series_case_aggregation_hour_of_day.yaml
+++ b/src/CSET/recipes/generic_level_domain_mean_vertical_profile_series_case_aggregation_hour_of_day.yaml
@@ -25,8 +25,6 @@ steps:
     coordinate: [grid_latitude, grid_longitude]
     method: MEAN
 
-  - operator: aggregate.ensure_aggregatable_across_cases
-
   - operator: collapse.collapse_by_hour_of_day
     method: MEAN
 

--- a/src/CSET/recipes/generic_level_histogram_series_case_aggregation_hour_of_day.yaml
+++ b/src/CSET/recipes/generic_level_histogram_series_case_aggregation_hour_of_day.yaml
@@ -28,8 +28,6 @@ steps:
         coordinate: $LEVELTYPE
         levels: $LEVEL
 
-  - operator: aggregate.ensure_aggregatable_across_cases
-
   - operator: collapse.collapse_by_hour_of_day
     method: MEAN
 

--- a/src/CSET/recipes/generic_level_spatial_plot_sequence_case_aggregation_mean_hour_of_day.yaml
+++ b/src/CSET/recipes/generic_level_spatial_plot_sequence_case_aggregation_mean_hour_of_day.yaml
@@ -19,8 +19,6 @@ steps:
     subarea_type: $SUBAREA_TYPE
     subarea_extent: $SUBAREA_EXTENT
 
-  - operator: aggregate.ensure_aggregatable_across_cases
-
   - operator: collapse.collapse_by_hour_of_day
     method: MEAN
 

--- a/src/CSET/recipes/generic_surface_domain_mean_time_series_case_aggregation_hour_of_day.yaml
+++ b/src/CSET/recipes/generic_surface_domain_mean_time_series_case_aggregation_hour_of_day.yaml
@@ -27,8 +27,6 @@ steps:
     coordinate: [grid_latitude, grid_longitude]
     method: MEAN
 
-  - operator: aggregate.ensure_aggregatable_across_cases
-
   - operator: collapse.collapse_by_hour_of_day
     method: MEAN
 

--- a/src/CSET/recipes/generic_surface_histogram_series_case_aggregation_hour_of_day.yaml
+++ b/src/CSET/recipes/generic_surface_histogram_series_case_aggregation_hour_of_day.yaml
@@ -25,8 +25,6 @@ steps:
         coordinate: pressure
         levels: []
 
-  - operator: aggregate.ensure_aggregatable_across_cases
-
   - operator: collapse.collapse_by_hour_of_day
     method: MEAN
 

--- a/src/CSET/recipes/generic_surface_spatial_plot_sequence_case_aggregation_mean_hour_of_day.yaml
+++ b/src/CSET/recipes/generic_surface_spatial_plot_sequence_case_aggregation_mean_hour_of_day.yaml
@@ -22,8 +22,6 @@ steps:
     subarea_type: $SUBAREA_TYPE
     subarea_extent: $SUBAREA_EXTENT
 
-  - operator: aggregate.ensure_aggregatable_across_cases
-
   - operator: collapse.collapse_by_hour_of_day
     method: MEAN
 

--- a/src/CSET/recipes/level_spatial_difference_case_aggregation_mean_hour_of_day.yaml
+++ b/src/CSET/recipes/level_spatial_difference_case_aggregation_mean_hour_of_day.yaml
@@ -20,8 +20,6 @@ steps:
         coordinate: $LEVELTYPE
         levels: $LEVEL
 
-  - operator: aggregate.ensure_aggregatable_across_cases
-
   - operator: collapse.collapse_by_hour_of_day
     method: MEAN
 

--- a/src/CSET/recipes/surface_spatial_difference_case_aggregation_mean_hour_of_day.yaml
+++ b/src/CSET/recipes/surface_spatial_difference_case_aggregation_mean_hour_of_day.yaml
@@ -22,8 +22,6 @@ steps:
     subarea_type: $SUBAREA_TYPE
     subarea_extent: $SUBAREA_EXTENT
 
-  - operator: aggregate.ensure_aggregatable_across_cases
-
   - operator: collapse.collapse_by_hour_of_day
     method: MEAN
 


### PR DESCRIPTION
Removal the checking cubes to ensure they can be aggregated step in the recipes. This removal allows longer runs (such as climate simulations) to be aggregated by day to create diurnal cycles.

Fixes #1442

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [ ] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
