### PR TITLE
Align time units and fix diurnal cycle aggregation bug

### DIFF
--- a/src/CSET/operators/aggregate.py
+++ b/src/CSET/operators/aggregate.py
@@ -208,12 +208,6 @@ def add_hour_coordinate(
         # Add a category coordinate of hour into each cube.
         iris.coord_categorisation.add_hour(cube, "time", name="hour")
         cube.coord("hour").units = "hours"
-        # Ensure cube retains hour=24 in sorted hour coordinate
-        time_points = cube.coord("hour").points
-        print(time_points)
-        if time_points[0] > 0:
-            time_points[time_points == 0] = 24
-        print(time_points)
         new_cubelist.append(cube)
 
     if len(new_cubelist) == 1:

--- a/src/CSET/operators/aggregate.py
+++ b/src/CSET/operators/aggregate.py
@@ -208,6 +208,12 @@ def add_hour_coordinate(
         # Add a category coordinate of hour into each cube.
         iris.coord_categorisation.add_hour(cube, "time", name="hour")
         cube.coord("hour").units = "hours"
+        # Ensure cube retains hour=24 in sorted hour coordinate
+        time_points = cube.coord("hour").points
+        print(time_points)
+        if time_points[0] > 0:
+            time_points[time_points == 0] = 24
+        print(time_points)
         new_cubelist.append(cube)
 
     if len(new_cubelist) == 1:

--- a/src/CSET/operators/aggregate.py
+++ b/src/CSET/operators/aggregate.py
@@ -192,6 +192,7 @@ def add_hour_coordinate(
     ---------
     cubes: iris.cube.Cube | iris.cube.CubeList
         Cube of any variable that has a time coordinate.
+        Note input Cube or CubeList items should only have 1 time dimension.
 
     Returns
     -------
@@ -206,6 +207,7 @@ def add_hour_coordinate(
     new_cubelist = iris.cube.CubeList()
     for cube in iter_maybe(cubes):
         # Add a category coordinate of hour into each cube.
+        iris.util.promote_aux_coord_to_dim_coord(cube, "time")
         iris.coord_categorisation.add_hour(cube, "time", name="hour")
         cube.coord("hour").units = "hours"
         new_cubelist.append(cube)

--- a/src/CSET/operators/collapse.py
+++ b/src/CSET/operators/collapse.py
@@ -25,6 +25,7 @@ import iris.coords
 import iris.cube
 import iris.exceptions
 import iris.util
+import numpy as np
 
 from CSET._common import iter_maybe
 from CSET.operators._utils import is_time_aggregatable
@@ -180,12 +181,22 @@ def collapse_by_hour_of_day(
         else:
             collapsed_cube = cube.aggregated_by("hour", getattr(iris.analysis, method))
 
+        print("COLLAPSE: ", collapsed_cube)
+        print("COLLAPSE points: ", collapsed_cube.coord("hour").points)
+        print(collapsed_cube.data[0, 0, 0])
+        if collapsed_cube.coord("hour").points[0] > 0:
+            n1 = collapsed_cube.coord("hour").points[0]
+            collapsed_cube.coord("hour").points.sort()
+            n2 = collapsed_cube.coord("hour").points[0]
+            print(n1, n2)
+            collapsed_cube.data = np.roll(collapsed_cube.data, n2 - n1, axis=0)
+
+        print("COLLAPSE_HR: ", collapsed_cube.coord("hour"))
+        print(collapsed_cube.data[0, 0, 0])
+
         # Remove unnecessary time coordinates.
         collapsed_cube.remove_coord("time")
         collapsed_cube.remove_coord("forecast_period")
-
-        # Sort hour coordinate.
-        collapsed_cube.coord("hour").points.sort()
 
         # Promote "hour" to dim_coord.
         iris.util.promote_aux_coord_to_dim_coord(collapsed_cube, "hour")

--- a/src/CSET/operators/collapse.py
+++ b/src/CSET/operators/collapse.py
@@ -163,11 +163,11 @@ def collapse_by_hour_of_day(
 
     collapsed_cubes = iris.cube.CubeList([])
     for cube in iter_maybe(cubes):
-        # Categorise the time coordinate by hour of the day.
-        cube = add_hour_coordinate(cube)
         # Ensure hour coordinate in each input is sorted, and data adjusted if needed.
         sorted_cube = iris.cube.CubeList()
         for fcst_slice in cube.slices_over(["forecast_reference_time"]):
+            # Categorise the time coordinate by hour of the day.
+            fcst_slide = add_hour_coordinate(fcst_slice)
             if method == "PERCENTILE":
                 by_hour = fcst_slice.aggregated_by(
                     "hour", getattr(iris.analysis, method), percent=additional_percent

--- a/src/CSET/operators/collapse.py
+++ b/src/CSET/operators/collapse.py
@@ -92,7 +92,6 @@ def collapse(
                 collapsed_cubes.append(
                     cube.collapsed(coordinate, getattr(iris.analysis, method))
                 )
-
     if len(collapsed_cubes) == 1:
         return collapsed_cubes[0]
     else:

--- a/src/CSET/operators/collapse.py
+++ b/src/CSET/operators/collapse.py
@@ -167,7 +167,7 @@ def collapse_by_hour_of_day(
         sorted_cube = iris.cube.CubeList()
         for fcst_slice in cube.slices_over(["forecast_reference_time"]):
             # Categorise the time coordinate by hour of the day.
-            fcst_slide = add_hour_coordinate(fcst_slice)
+            fcst_slice = add_hour_coordinate(fcst_slice)
             if method == "PERCENTILE":
                 by_hour = fcst_slice.aggregated_by(
                     "hour", getattr(iris.analysis, method), percent=additional_percent

--- a/src/CSET/operators/collapse.py
+++ b/src/CSET/operators/collapse.py
@@ -154,12 +154,15 @@ def collapse_by_hour_of_day(
             for cube in cubes:
                 cube.coord("forecast_reference_time").bounds = None
                 cube.coord("forecast_period").bounds = None
-            try:
-                cubes = cubes.extract_overlapping(
-                    ["forecast_reference_time", "forecast_period"]
-                )
-            except ValueError:
-                logging.error("No overlapping times detected in cubes: \n%s", cubes)
+            cubes = cubes.extract_overlapping(
+                ["forecast_reference_time", "forecast_period"]
+            )
+            if len(cubes) == 0:
+                raise ValueError("No overlapping times detected in input cubes.")
+        else:
+            logging.debug(
+                "Not extracting common time points as multiple model inputs not detected."
+            )
 
     collapsed_cubes = iris.cube.CubeList([])
     for cube in iter_maybe(cubes):

--- a/src/CSET/operators/collapse.py
+++ b/src/CSET/operators/collapse.py
@@ -28,7 +28,6 @@ import iris.util
 import numpy as np
 
 from CSET._common import iter_maybe
-from CSET.operators._utils import is_time_aggregatable
 from CSET.operators.aggregate import add_hour_coordinate
 
 
@@ -93,6 +92,7 @@ def collapse(
                 collapsed_cubes.append(
                     cube.collapsed(coordinate, getattr(iris.analysis, method))
                 )
+
     if len(collapsed_cubes) == 1:
         return collapsed_cubes[0]
     else:
@@ -149,10 +149,46 @@ def collapse_by_hour_of_day(
     if method == "PERCENTILE" and additional_percent is None:
         raise ValueError("Must specify additional_percent")
 
+    # Retain only common time points between different models if multiple model inputs.
+    if isinstance(cubes, iris.cube.CubeList):
+        if len(cubes) > 1:
+            cubes = cubes.extract_overlapping("time")
+
     collapsed_cubes = iris.cube.CubeList([])
     for cube in iter_maybe(cubes):
-        if is_time_aggregatable(cube):
-            # Collapse by forecast reference time to get a single time dimension.
+        # Categorise the time coordinate by hour of the day.
+        cube = add_hour_coordinate(cube)
+        # Ensure hour coordinate in each input is sorted, and data adjusted if needed.
+        sorted_cube = iris.cube.CubeList()
+        for fcst_slice in cube.slices_over(["forecast_reference_time"]):
+            if method == "PERCENTILE":
+                by_hour = fcst_slice.aggregated_by(
+                    "hour", getattr(iris.analysis, method), percent=additional_percent
+                )
+            else:
+                by_hour = fcst_slice.aggregated_by(
+                    "hour", getattr(iris.analysis, method)
+                )
+            # Compute if data needs sorting to lie in increasing order [0..23].
+            # Note multiple forecasts can sit in same cube spanning different
+            # initialisation times and data ranges.
+            time_points = by_hour.coord("hour").points
+            nroll = time_points[0] / (time_points[1] - time_points[0])
+            # Shift hour coordinate and data cube to be in time of day order.
+            by_hour.coord("hour").points = np.roll(time_points, nroll, 0)
+            by_hour.data = np.roll(by_hour.data, nroll, axis=0)
+
+            # Remove unnecessary time coordinate.
+            by_hour.remove_coord("time")
+
+            sorted_cube.append(by_hour)
+
+        # Recombine cube slices.
+        cube = sorted_cube.merge_cube()
+
+        coord_names = [coord.name() for coord in cube.coords(dim_coords=True)]
+        if "forecast_reference_time" in coord_names:
+            # Collapse by forecast reference time to get a single cube.
             cube = collapse(
                 cube,
                 "forecast_reference_time",
@@ -160,52 +196,18 @@ def collapse_by_hour_of_day(
                 additional_percent=additional_percent,
             )
         else:
-            # Remove forecast_reference_time if a single case, as collapse will
-            # have effectively done this.
+            # Or remove forecast reference time if a single case, as collapse
+            # will have effectively done this.
             cube.remove_coord("forecast_reference_time")
 
-        # Remove time coordinate bounds to enable collapse over time dimension.
-        if cube.coord("time").has_bounds():
-            cube.coord("time").bounds = None
+        # Promote "hour" to dim_coord.
+        iris.util.promote_aux_coord_to_dim_coord(cube, "hour")
         collapsed_cubes.append(cube)
 
-    # Retain only common time points between different models.
-    if len(collapsed_cubes) > 1:
-        collapsed_cubes = collapsed_cubes.extract_overlapping("time")
-
-    final_list = iris.cube.CubeList([])
-    for cube in iter_maybe(collapsed_cubes):
-        # Categorise the time coordinate by hour of the day.
-        cube = add_hour_coordinate(cube)
-        # Aggregate by the new category coordinate.
-        if method == "PERCENTILE":
-            collapsed_cube = cube.aggregated_by(
-                "hour", getattr(iris.analysis, method), percent=additional_percent
-            )
-        else:
-            collapsed_cube = cube.aggregated_by("hour", getattr(iris.analysis, method))
-
-        # Ensure hour_of_day time coordinate is increasing within range
-        # 0h to 23h. Roll collapsed cube data as required.
-        # Compute nroll as the difference from 0 of time0/time_step_of_outputs.
-        # Assume time dimension is on axis 0 of collapsed cubes.
-        time_points = collapsed_cube.coord("hour").points
-        nroll = time_points[0] / (time_points[1] - time_points[0])
-        collapsed_cube.coord("hour").points = np.roll(time_points, nroll, 0)
-        collapsed_cube.data = np.roll(collapsed_cube.data, nroll, axis=0)
-
-        # Remove unnecessary time coordinates.
-        collapsed_cube.remove_coord("time")
-        collapsed_cube.remove_coord("forecast_period")
-
-        # Promote "hour" to dim_coord.
-        iris.util.promote_aux_coord_to_dim_coord(collapsed_cube, "hour")
-        final_list.append(collapsed_cube)
-
-    if len(final_list) == 1:
-        return final_list[0]
+    if len(collapsed_cubes) == 1:
+        return collapsed_cubes[0]
     else:
-        return final_list
+        return collapsed_cubes
 
 
 def collapse_by_validity_time(

--- a/src/CSET/operators/collapse.py
+++ b/src/CSET/operators/collapse.py
@@ -164,6 +164,9 @@ def collapse_by_hour_of_day(
             # have effectively done this.
             cube.remove_coord("forecast_reference_time")
 
+        # Remove time coordinate bounds to enable collapse over time dimension.
+        if cube.coord("time").has_bounds():
+            cube.coord("time").bounds = None
         collapsed_cubes.append(cube)
 
     # Retain only common time points between different models.

--- a/src/CSET/operators/read.py
+++ b/src/CSET/operators/read.py
@@ -702,11 +702,11 @@ def _lfric_time_callback(cube: iris.cube.Cube):
     # Construct forecast_reference time if it doesn't exist.
     try:
         tcoord = cube.coord("time")
-        try:
-            tcoord.calendar = "gregorian"
-            tcoord.convert_units("hours since 1970-01-01 00:00:00")
-        except ValueError:
-            logging.error("Unrecognised base time unit: {tcoord.units}")
+        #        try:
+        #            tcoord.calendar = "gregorian"
+        #            tcoord.convert_units("hours since 1970-01-01 00:00:00")
+        #        except ValueError:
+        #            logging.error("Unrecognised base time unit: {tcoord.units}")
 
         if not cube.coords("forecast_reference_time"):
             try:

--- a/src/CSET/operators/read.py
+++ b/src/CSET/operators/read.py
@@ -702,10 +702,10 @@ def _lfric_time_callback(cube: iris.cube.Cube):
     # Construct forecast_reference time if it doesn't exist.
     try:
         tcoord = cube.coord("time")
-        try:
-            tcoord.convert_units("hours since 1970-01-01 00:00:00")
-        except ValueError:
-            logging.error("Unrecognised base time unit: {tcoord.units}")
+        #        try:
+        #            tcoord.convert_units("hours since 1970-01-01 00:00:00")
+        #        except ValueError:
+        #            logging.error("Unrecognised base time unit: {tcoord.units}")
 
         if not cube.coords("forecast_reference_time"):
             try:

--- a/src/CSET/operators/read.py
+++ b/src/CSET/operators/read.py
@@ -596,7 +596,7 @@ def _fix_um_radtime_posthour(cube: iris.cube.Cube):
 
             # Convert time points to datetime objects
             time_unit = time_coord.units
-            time_points = time_unit.num2date(time_coord.points)
+            time_points = time_unit.num2pydate(time_coord.points)
 
             # Skip if times don't need fixing.
             if time_points[0].minute != 1:
@@ -614,7 +614,7 @@ def _fix_um_radtime_posthour(cube: iris.cube.Cube):
             # Recompute forecast_period with corrected values.
             if cube.coord("forecast_period"):
                 fcst_prd_points = cube.coord("forecast_period").points
-                new_fcst_points = time_unit.num2date(
+                new_fcst_points = time_unit.num2pydate(
                     fcst_prd_points
                 ) - datetime.timedelta(minutes=1)
                 cube.coord("forecast_period").points = time_unit.date2num(
@@ -633,7 +633,7 @@ def _fix_um_radtime_prehour(cube: iris.cube.Cube):
 
             # Convert time points to datetime objects
             time_unit = time_coord.units
-            time_points = time_unit.num2date(time_coord.points)
+            time_points = time_unit.num2pydate(time_coord.points)
 
             # Skip if times don't need fixing.
             if time_points[0].minute != 59:
@@ -651,7 +651,7 @@ def _fix_um_radtime_prehour(cube: iris.cube.Cube):
             # Recompute forecast_period with corrected values.
             if cube.coord("forecast_period"):
                 fcst_prd_points = cube.coord("forecast_period").points
-                new_fcst_points = time_unit.num2date(
+                new_fcst_points = time_unit.num2pydate(
                     fcst_prd_points
                 ) + datetime.timedelta(minutes=1)
                 cube.coord("forecast_period").points = time_unit.date2num(
@@ -679,7 +679,7 @@ def _fix_um_lightning(cube: iris.cube.Cube):
 
         # Convert time points to datetime objects.
         time_unit = time_coord.units
-        time_points = time_unit.num2date(time_coord.points)
+        time_points = time_unit.num2pydate(time_coord.points)
 
         # Skip if times don't need fixing.
         if time_points[0].minute == 0:
@@ -756,7 +756,7 @@ def _lfric_time_callback(cube: iris.cube.Cube):
                 # Create array of forecast lead times.
                 init_coord = cube.coord("forecast_reference_time")
                 init_time_points_in_tcoord_units = tcoord.units.date2num(
-                    init_coord.units.num2date(init_coord.points)
+                    init_coord.units.num2pydate(init_coord.points)
                 )
                 lead_times = tcoord.points - init_time_points_in_tcoord_units
 

--- a/src/CSET/operators/read.py
+++ b/src/CSET/operators/read.py
@@ -719,7 +719,6 @@ def _lfric_time_callback(cube: iris.cube.Cube):
                     units=tcoord.units,
                     standard_name="forecast_reference_time",
                     long_name="forecast_reference_time",
-                    calendar="gregorian",
                 )
                 cube.add_aux_coord(frt_coord)
             except KeyError:

--- a/src/CSET/operators/read.py
+++ b/src/CSET/operators/read.py
@@ -702,10 +702,11 @@ def _lfric_time_callback(cube: iris.cube.Cube):
     # Construct forecast_reference time if it doesn't exist.
     try:
         tcoord = cube.coord("time")
-        #        try:
-        #            tcoord.convert_units("hours since 1970-01-01 00:00:00")
-        #        except ValueError:
-        #            logging.error("Unrecognised base time unit: {tcoord.units}")
+        try:
+            tcoord.calendar = "gregorian"
+            tcoord.convert_units("hours since 1970-01-01 00:00:00")
+        except ValueError:
+            logging.error("Unrecognised base time unit: {tcoord.units}")
 
         if not cube.coords("forecast_reference_time"):
             try:
@@ -718,6 +719,7 @@ def _lfric_time_callback(cube: iris.cube.Cube):
                     units=tcoord.units,
                     standard_name="forecast_reference_time",
                     long_name="forecast_reference_time",
+                    calendar="gregorian",
                 )
                 cube.add_aux_coord(frt_coord)
             except KeyError:

--- a/src/CSET/operators/read.py
+++ b/src/CSET/operators/read.py
@@ -702,11 +702,10 @@ def _lfric_time_callback(cube: iris.cube.Cube):
     # Construct forecast_reference time if it doesn't exist.
     try:
         tcoord = cube.coord("time")
-        #        try:
-        #            tcoord.calendar = "gregorian"
-        #            tcoord.convert_units("hours since 1970-01-01 00:00:00")
-        #        except ValueError:
-        #            logging.error("Unrecognised base time unit: {tcoord.units}")
+        try:
+            tcoord.convert_units("hours since 1970-01-01 00:00:00")
+        except ValueError:
+            logging.error("Unrecognised base time unit: {tcoord.units}")
 
         if not cube.coords("forecast_reference_time"):
             try:

--- a/src/CSET/operators/read.py
+++ b/src/CSET/operators/read.py
@@ -596,7 +596,7 @@ def _fix_um_radtime_posthour(cube: iris.cube.Cube):
 
             # Convert time points to datetime objects
             time_unit = time_coord.units
-            time_points = time_unit.num2pydate(time_coord.points)
+            time_points = time_unit.num2date(time_coord.points)
 
             # Skip if times don't need fixing.
             if time_points[0].minute != 1:
@@ -614,13 +614,12 @@ def _fix_um_radtime_posthour(cube: iris.cube.Cube):
             # Recompute forecast_period with corrected values.
             if cube.coord("forecast_period"):
                 fcst_prd_points = cube.coord("forecast_period").points
-                new_fcst_points = time_unit.num2pydate(
+                new_fcst_points = time_unit.num2date(
                     fcst_prd_points
                 ) - datetime.timedelta(minutes=1)
                 cube.coord("forecast_period").points = time_unit.date2num(
                     new_fcst_points
                 )
-
     except KeyError:
         pass
 
@@ -633,7 +632,7 @@ def _fix_um_radtime_prehour(cube: iris.cube.Cube):
 
             # Convert time points to datetime objects
             time_unit = time_coord.units
-            time_points = time_unit.num2pydate(time_coord.points)
+            time_points = time_unit.num2date(time_coord.points)
 
             # Skip if times don't need fixing.
             if time_points[0].minute != 59:
@@ -651,7 +650,7 @@ def _fix_um_radtime_prehour(cube: iris.cube.Cube):
             # Recompute forecast_period with corrected values.
             if cube.coord("forecast_period"):
                 fcst_prd_points = cube.coord("forecast_period").points
-                new_fcst_points = time_unit.num2pydate(
+                new_fcst_points = time_unit.num2date(
                     fcst_prd_points
                 ) + datetime.timedelta(minutes=1)
                 cube.coord("forecast_period").points = time_unit.date2num(
@@ -679,7 +678,7 @@ def _fix_um_lightning(cube: iris.cube.Cube):
 
         # Convert time points to datetime objects.
         time_unit = time_coord.units
-        time_points = time_unit.num2pydate(time_coord.points)
+        time_points = time_unit.num2date(time_coord.points)
 
         # Skip if times don't need fixing.
         if time_points[0].minute == 0:
@@ -714,7 +713,7 @@ def _lfric_time_callback(cube: iris.cube.Cube):
     expected coordinates, and so we cannot aggregate over case studies without this
     metadata. This callback fixes these issues.
 
-    This callback also ensures all time coordinates are referenced as seconds since
+    This callback also ensures all time coordinates are referenced as hours since
     1970-01-01 00:00:00 for consistency across different model inputs.
 
     Notes
@@ -756,7 +755,7 @@ def _lfric_time_callback(cube: iris.cube.Cube):
                 # Create array of forecast lead times.
                 init_coord = cube.coord("forecast_reference_time")
                 init_time_points_in_tcoord_units = tcoord.units.date2num(
-                    init_coord.units.num2pydate(init_coord.points)
+                    init_coord.units.num2date(init_coord.points)
                 )
                 lead_times = tcoord.points - init_time_points_in_tcoord_units
 

--- a/src/CSET/operators/read.py
+++ b/src/CSET/operators/read.py
@@ -602,14 +602,25 @@ def _fix_um_radtime_posthour(cube: iris.cube.Cube):
             if time_points[0].minute != 1:
                 return
 
-            # Subtract 1 minute from each time point
+            # Subtract 1 minute from each time point.
             new_time_points = time_points - datetime.timedelta(minutes=1)
 
-            # Convert back to numeric values using the original time unit
+            # Convert back to numeric values using the original time unit.
             new_time_values = time_unit.date2num(new_time_points)
 
-            # Replace the time coordinate with corrected values
+            # Replace the time coordinate with corrected values.
             time_coord.points = new_time_values
+
+            # Recompute forecast_period with corrected values.
+            if cube.coord("forecast_period"):
+                fcst_prd_points = cube.coord("forecast_period").points
+                new_fcst_points = time_unit.num2date(
+                    fcst_prd_points
+                ) - datetime.timedelta(minutes=1)
+                cube.coord("forecast_period").points = time_unit.date2num(
+                    new_fcst_points
+                )
+
     except KeyError:
         pass
 
@@ -636,6 +647,17 @@ def _fix_um_radtime_prehour(cube: iris.cube.Cube):
 
             # Replace the time coordinate with corrected values
             time_coord.points = new_time_values
+
+            # Recompute forecast_period with corrected values.
+            if cube.coord("forecast_period"):
+                fcst_prd_points = cube.coord("forecast_period").points
+                new_fcst_points = time_unit.num2date(
+                    fcst_prd_points
+                ) + datetime.timedelta(minutes=1)
+                cube.coord("forecast_period").points = time_unit.date2num(
+                    new_fcst_points
+                )
+
     except KeyError:
         pass
 

--- a/src/CSET/operators/read.py
+++ b/src/CSET/operators/read.py
@@ -712,9 +712,7 @@ def _lfric_time_callback(cube: iris.cube.Cube):
                 init_time = datetime.datetime.fromisoformat(
                     tcoord.attributes["time_origin"]
                 )
-                print(init_time)
                 frt_point = tcoord.units.date2num(init_time)
-                print(frt_point)
                 frt_coord = iris.coords.AuxCoord(
                     frt_point,
                     units=tcoord.units,
@@ -742,7 +740,6 @@ def _lfric_time_callback(cube: iris.cube.Cube):
 
                 # Get unit for lead time from time coordinate's unit.
                 # Convert all lead time to hours for consistency between models.
-                print(tcoord.units)
                 if "seconds" in str(tcoord.units):
                     lead_times = lead_times / 3600.0
                     units = "hours"

--- a/tests/operators/test_collapse.py
+++ b/tests/operators/test_collapse.py
@@ -78,9 +78,25 @@ def test_collapse_percentile(cube):
 
 def test_collapse_by_hour_of_day(long_forecast):
     """Convert and aggregates time dimension by hour of day."""
+    print(long_forecast)
     collapsed_cube = collapse.collapse_by_hour_of_day(long_forecast, "MEAN")
     expected_cube = "<iris 'Cube' of air_temperature / (K) (hour: 24; grid_latitude: 3; grid_longitude: 3)>"
     assert repr(collapsed_cube) == expected_cube
+
+
+def test_collapse_by_hour_of_day_single_day(long_forecast):
+    """Convert and aggregates time dimension by hour of day."""
+    print(long_forecast)
+    collapsed_cube = collapse.collapse_by_hour_of_day(long_forecast[0:24], "MEAN")
+    expected_cube = "<iris 'Cube' of air_temperature / (K) (hour: 24; grid_latitude: 3; grid_longitude: 3)>"
+    assert repr(collapsed_cube) == expected_cube
+    print(collapsed_cube)
+    print(expected_cube)
+
+    # Ensure cube data has changed when averaging 1-day only - input data spans T=15 through to T=14
+    print(collapsed_cube.data[0, 0, 0])
+    print(long_forecast[0, 0, 0])
+    assert collapsed_cube.data[0, 0, 0] != long_forecast.data[0, 0, 0]
 
 
 def test_collapse_by_hour_of_day_cubelist(long_forecast):

--- a/tests/operators/test_collapse.py
+++ b/tests/operators/test_collapse.py
@@ -86,25 +86,26 @@ def test_collapse_by_hour_of_day(long_forecast):
 def test_collapse_by_hour_of_day_single_day(long_forecast):
     """Convert and aggregates time dimension by hour of day."""
     # Read in only first 24h of input data.
-    collapsed_cube = collapse.collapse_by_hour_of_day(long_forecast[0:24], "MEAN")
+    day_long_forecast = long_forecast[0:24]
+    collapsed_cube = collapse.collapse_by_hour_of_day(day_long_forecast, "MEAN")
     expected_cube = "<iris 'Cube' of air_temperature / (K) (hour: 24; grid_latitude: 3; grid_longitude: 3)>"
     assert repr(collapsed_cube) == expected_cube
 
     # Ensure data has changed position in cube (averaging 1-day only).
     # Input data spans T=3 through to T=2.
-    assert collapsed_cube.data[0, 0, 0] == long_forecast.data[21, 0, 0]
-    assert collapsed_cube.data[0, -1, -1] == long_forecast.data[21, -1, -1]
+    assert collapsed_cube.data[0, 0, 0] == day_long_forecast.data[21, 0, 0]
+    assert collapsed_cube.data[0, -1, -1] == day_long_forecast.data[21, -1, -1]
 
     # Select different segment from long_forecast input data.
-    long_forecast_2 = long_forecast[56:80]
-    collapsed_cube = collapse.collapse_by_hour_of_day(long_forecast_2, "MEAN")
+    day_long_forecast_2 = long_forecast[56:80]
+    collapsed_cube = collapse.collapse_by_hour_of_day(day_long_forecast_2, "MEAN")
     expected_cube = "<iris 'Cube' of air_temperature / (K) (hour: 24; grid_latitude: 3; grid_longitude: 3)>"
     assert repr(collapsed_cube) == expected_cube
 
     # Ensure cube data has changed position in cube (averaging 1-day only).
     # Input data spans T=11 through to T=10
-    assert collapsed_cube.data[0, 0, 0] == long_forecast_2.data[13, 0, 0]
-    assert collapsed_cube.data[0, -1, -1] == long_forecast_2.data[13, -1, -1]
+    assert collapsed_cube.data[0, 0, 0] == day_long_forecast_2.data[13, 0, 0]
+    assert collapsed_cube.data[0, -1, -1] == day_long_forecast_2.data[13, -1, -1]
 
 
 def test_collapse_by_hour_of_day_cubelist(long_forecast):

--- a/tests/operators/test_collapse.py
+++ b/tests/operators/test_collapse.py
@@ -90,17 +90,19 @@ def test_collapse_by_hour_of_day_single_day(long_forecast):
     expected_cube = "<iris 'Cube' of air_temperature / (K) (hour: 24; grid_latitude: 3; grid_longitude: 3)>"
     assert repr(collapsed_cube) == expected_cube
 
-    # Ensure cube data has changed when averaging 1-day only. Input data spans T=3 through to T=2.
+    # Ensure data has changed position in cube (averaging 1-day only).
+    # Input data spans T=3 through to T=2.
     assert collapsed_cube.data[0, 0, 0] == long_forecast.data[21, 0, 0]
     assert collapsed_cube.data[0, -1, -1] == long_forecast.data[21, -1, -1]
 
-    # Select different initialisation time from input data.
+    # Select different segment from long_forecast input data.
     long_forecast_2 = long_forecast[56:80]
     collapsed_cube = collapse.collapse_by_hour_of_day(long_forecast_2, "MEAN")
     expected_cube = "<iris 'Cube' of air_temperature / (K) (hour: 24; grid_latitude: 3; grid_longitude: 3)>"
     assert repr(collapsed_cube) == expected_cube
 
-    # Ensure cube data has changed when averaging 1-day only. Input data spans T=11 through to T=10
+    # Ensure cube data has changed position in cube (averaging 1-day only).
+    # Input data spans T=11 through to T=10
     assert collapsed_cube.data[0, 0, 0] == long_forecast_2.data[13, 0, 0]
     assert collapsed_cube.data[0, -1, -1] == long_forecast_2.data[13, -1, -1]
 
@@ -137,6 +139,49 @@ def test_collapse_by_hour_of_day_multi_forecast_cube(long_forecast_multi_day):
     collapsed_cube = collapse.collapse_by_hour_of_day(long_forecast_multi_day, "MEAN")
     expected_cube = "<iris 'Cube' of air_temperature / (K) (hour: 24; grid_latitude: 3; grid_longitude: 3)>"
     assert repr(collapsed_cube) == expected_cube
+
+
+def test_collapse_by_hour_of_day_multi_forecast_single_day(long_forecast_multi_day):
+    """Test time averaging and data rolling correct for collapse_hour_of_day."""
+    # Ensure data components are as expected, working with first 24h inputs.
+    long_forecast_pick_day = long_forecast_multi_day[0:24]
+    collapsed_cube = collapse.collapse_by_hour_of_day(long_forecast_pick_day, "MEAN")
+    expected_cube = "<iris 'Cube' of air_temperature / (K) (hour: 24; grid_latitude: 3; grid_longitude: 3)>"
+    assert repr(collapsed_cube) == expected_cube
+
+    # Ensure cube data has changed position in cube (averaging 1-day only).
+    # First initialisation segment in input spans T=3 through to T=2.
+    # Second initialisation segment in input spans T=15 through to T=14.
+    # Third initialisation segment in input spans T=3 through to T=2.
+    calc_mean = (
+        long_forecast_pick_day.data[21, 0, 0, 0]
+        + long_forecast_pick_day.data[9, 1, 0, 0]
+        + long_forecast_pick_day.data[21, 2, 0, 0]
+    ) / 3.0
+    assert collapsed_cube.data[0, 0, 0] == calc_mean
+    calc_mean2 = (
+        long_forecast_pick_day.data[21, 0, -1, -1]
+        + long_forecast_pick_day.data[9, 1, -1, -1]
+        + long_forecast_pick_day.data[21, 2, -1, -1]
+    ) / 3.0
+    assert collapsed_cube.data[0, -1, -1] == calc_mean2
+
+    # Select different segment from long_forecast input data.
+    # First segment T=1 to T=0. Second T=13 to T=12. Third T=1 to T=0.
+    long_forecast_pick_day2 = long_forecast_multi_day[22:46]
+    collapsed_cube = collapse.collapse_by_hour_of_day(long_forecast_pick_day2, "MEAN")
+    calc_mean = (
+        long_forecast_pick_day2.data[23, 0, 0, 0]
+        + long_forecast_pick_day2.data[11, 1, 0, 0]
+        + long_forecast_pick_day2.data[23, 2, 0, 0]
+    ) / 3.0
+    assert collapsed_cube.data[0, 0, 0] == calc_mean
+    calc_mean2 = (
+        long_forecast_pick_day2.data[23, 0, -1, -1]
+        + long_forecast_pick_day2.data[11, 1, -1, -1]
+        + long_forecast_pick_day2.data[23, 2, -1, -1]
+    ) / 3.0
+    assert collapsed_cube.data[0, -1, -1] == calc_mean2
 
 
 def test_collapse_by_lead_time_single_cube(long_forecast_multi_day):

--- a/tests/operators/test_collapse.py
+++ b/tests/operators/test_collapse.py
@@ -200,6 +200,20 @@ def test_collapse_by_lead_time_single_cube(long_forecast_multi_day):
     )
 
 
+def test_collapse_by_hour_of_day_multi_non_overlapping(long_forecast_multi_day):
+    """Identify when inputs have non-overlapping cubes."""
+    print(long_forecast_multi_day)
+    cube_day1 = long_forecast_multi_day[0:24, 0, :, :]
+    cube_day2 = long_forecast_multi_day[24:48, 2, :, :]
+    print(cube_day1.coord("time"))
+    print(cube_day2.coord("time"))
+    non_overlap_cubelist = iris.cube.CubeList([cube_day1, cube_day2])
+    with pytest.raises(
+        ValueError, match="No overlapping times detected in input cubes."
+    ):
+        collapse.collapse_by_hour_of_day(non_overlap_cubelist, "MEAN")
+
+
 def test_collapse_by_lead_time_single_cube_percentile_fail(long_forecast_multi_day):
     """Test fail by not setting additional percent."""
     with pytest.raises(ValueError, match="Must specify additional_percent"):

--- a/tests/operators/test_collapse.py
+++ b/tests/operators/test_collapse.py
@@ -112,7 +112,6 @@ def test_collapse_by_hour_of_day_cubelist(long_forecast):
     assert isinstance(collapsed_cubes, iris.cube.CubeList)
     assert len(collapsed_cubes) == 2
     expected_cube = "<iris 'Cube' of air_temperature / (K) (hour: 24; grid_latitude: 3; grid_longitude: 3)>"
-
     for collapsed_cube in collapsed_cubes:
         assert repr(collapsed_cube) == expected_cube
 

--- a/tests/operators/test_collapse.py
+++ b/tests/operators/test_collapse.py
@@ -78,7 +78,6 @@ def test_collapse_percentile(cube):
 
 def test_collapse_by_hour_of_day(long_forecast):
     """Convert and aggregates time dimension by hour of day."""
-    print(long_forecast)
     collapsed_cube = collapse.collapse_by_hour_of_day(long_forecast, "MEAN")
     expected_cube = "<iris 'Cube' of air_temperature / (K) (hour: 24; grid_latitude: 3; grid_longitude: 3)>"
     assert repr(collapsed_cube) == expected_cube
@@ -86,17 +85,24 @@ def test_collapse_by_hour_of_day(long_forecast):
 
 def test_collapse_by_hour_of_day_single_day(long_forecast):
     """Convert and aggregates time dimension by hour of day."""
-    print(long_forecast)
+    # Read in only first 24h of input data.
     collapsed_cube = collapse.collapse_by_hour_of_day(long_forecast[0:24], "MEAN")
     expected_cube = "<iris 'Cube' of air_temperature / (K) (hour: 24; grid_latitude: 3; grid_longitude: 3)>"
     assert repr(collapsed_cube) == expected_cube
-    print(collapsed_cube)
-    print(expected_cube)
 
-    # Ensure cube data has changed when averaging 1-day only - input data spans T=15 through to T=14
-    print(collapsed_cube.data[0, 0, 0])
-    print(long_forecast[0, 0, 0])
-    assert collapsed_cube.data[0, 0, 0] != long_forecast.data[0, 0, 0]
+    # Ensure cube data has changed when averaging 1-day only. Input data spans T=3 through to T=2.
+    assert collapsed_cube.data[0, 0, 0] == long_forecast.data[21, 0, 0]
+    assert collapsed_cube.data[0, -1, -1] == long_forecast.data[21, -1, -1]
+
+    # Select different initialisation time from input data.
+    long_forecast_2 = long_forecast[56:80]
+    collapsed_cube = collapse.collapse_by_hour_of_day(long_forecast_2, "MEAN")
+    expected_cube = "<iris 'Cube' of air_temperature / (K) (hour: 24; grid_latitude: 3; grid_longitude: 3)>"
+    assert repr(collapsed_cube) == expected_cube
+
+    # Ensure cube data has changed when averaging 1-day only. Input data spans T=11 through to T=10
+    assert collapsed_cube.data[0, 0, 0] == long_forecast_2.data[13, 0, 0]
+    assert collapsed_cube.data[0, -1, -1] == long_forecast_2.data[13, -1, -1]
 
 
 def test_collapse_by_hour_of_day_cubelist(long_forecast):
@@ -106,6 +112,7 @@ def test_collapse_by_hour_of_day_cubelist(long_forecast):
     assert isinstance(collapsed_cubes, iris.cube.CubeList)
     assert len(collapsed_cubes) == 2
     expected_cube = "<iris 'Cube' of air_temperature / (K) (hour: 24; grid_latitude: 3; grid_longitude: 3)>"
+
     for collapsed_cube in collapsed_cubes:
         assert repr(collapsed_cube) == expected_cube
 

--- a/tests/operators/test_collapse.py
+++ b/tests/operators/test_collapse.py
@@ -119,6 +119,15 @@ def test_collapse_by_hour_of_day_cubelist(long_forecast):
         assert repr(collapsed_cube) == expected_cube
 
 
+def test_collapse_by_hour_of_day_single_cubelist(long_forecast):
+    """Check single CubeList input collapsed by hour of day."""
+    # Test single cubelist entry.
+    cubes = iris.cube.CubeList([long_forecast])
+    collapsed_cube = collapse.collapse_by_hour_of_day(cubes, "MEAN")
+    expected_cube = "<iris 'Cube' of air_temperature / (K) (hour: 24; grid_latitude: 3; grid_longitude: 3)>"
+    assert repr(collapsed_cube) == expected_cube
+
+
 def test_collapse_by_hour_of_day_percentile(long_forecast):
     """Convert and aggregate time dimension by hour of day with percentiles."""
     # Test collapsing long forecast.

--- a/tests/operators/test_read.py
+++ b/tests/operators/test_read.py
@@ -566,17 +566,17 @@ def test_lfric_time_callback_hours(slammed_lfric_cube):
     assert all(fc_period_coord.points == [1, 2, 3, 4, 5, 6])
 
 
-# def test_lfric_time_callback_unknown_units(slammed_lfric_cube, caplog):
-#    """Error when forecast_period units cannot be determined."""
-#    slammed_lfric_cube.remove_coord("forecast_period")
-#    assert not slammed_lfric_cube.coords("forecast_period")
-#    slammed_lfric_cube.coord("time").units = None
-#
-#    with pytest.raises(iris.exceptions.UnitConversionError):
-#        read._lfric_time_callback(slammed_lfric_cube)
-#        _, level, message = caplog.record_tuples[0]
-#        assert level == logging.ERROR
-#        assert message == "Unrecognised base time unit: unknown"
+def test_lfric_time_callback_unknown_units(slammed_lfric_cube, caplog):
+    """Error when forecast_period units cannot be determined."""
+    slammed_lfric_cube.remove_coord("forecast_period")
+    assert not slammed_lfric_cube.coords("forecast_period")
+    slammed_lfric_cube.coord("time").units = None
+
+    with pytest.raises(iris.exceptions.UnitConversionError):
+        read._lfric_time_callback(slammed_lfric_cube)
+        _, level, message = caplog.record_tuples[0]
+        assert level == logging.ERROR
+        assert message == "Unrecognised base time unit: unknown"
 
 
 def test_lfric_normalise_varname(model_level_cube):

--- a/tests/operators/test_read.py
+++ b/tests/operators/test_read.py
@@ -516,10 +516,8 @@ def test_lfric_time_callback_forecast_reference_time(slammed_lfric_cube):
     assert ref_time_coord.standard_name == "forecast_reference_time"
     assert ref_time_coord.long_name == "forecast_reference_time"
     assert ref_time_coord.var_name is None
-    assert (
-        str(ref_time_coord.units) == "seconds since 2022-01-01 00:00:00"
-    )  # hours since 1970-01-01 00:00:00"
-    assert all(ref_time_coord.points == [0])  # [455832])
+    assert str(ref_time_coord.units) == "hours since 1970-01-01 00:00:00"
+    assert all(ref_time_coord.points == [455832])
 
 
 def test_lfric_time_callback_forecast_period(slammed_lfric_cube):

--- a/tests/operators/test_read.py
+++ b/tests/operators/test_read.py
@@ -282,6 +282,8 @@ def test_fix_um_radtime_posthour(cube):
     # Check all times are offset.
     for time in times:
         assert time.minute == 1
+    # Also offset forecast_period by one minute.
+    cube.coord("forecast_period").points += 1.0 / 60.0
 
     # Give cube a radiation STASH code.
     cube.attributes["STASH"] = "m01s01i208"
@@ -296,6 +298,13 @@ def test_fix_um_radtime_posthour(cube):
     assert rad_times[0] == datetime.datetime(2022, 9, 21, 3, 0)
     for time in rad_times:
         assert time.minute == 0
+
+    # Ensure radiation forecast_period values are fixed.
+    rad_time_coord = cube.coord("forecast_period")
+    # Check all times are fixed.
+    assert rad_time_coord.points[0] == 0
+    for time in rad_time_coord.points:
+        assert time.dtype == int
 
 
 def test_fix_um_radtime_posthour_skip_non_radiation(cube):
@@ -354,7 +363,7 @@ def test_fix_um_radtime_posthour_no_time_coordinate():
 
 
 def test_fix_um_radtime_prehour(cube):
-    """Check times that are 1 minute passed are rounded to the whole hour."""
+    """Check times that are 1 minute past are rounded to the whole hour."""
     # Offset times by one minute.
     time_coord = cube.coord("time")
     times = time_coord.units.num2pydate(time_coord.points) - datetime.timedelta(
@@ -364,6 +373,8 @@ def test_fix_um_radtime_prehour(cube):
     # Check all times are offset.
     for time in times:
         assert time.minute == 59
+    # Offset forecast_period by one minute.
+    cube.coord("forecast_period").points -= 1.0 / 60.0
 
     # Give cube a radiation STASH code.
     cube.attributes["STASH"] = "m01s01i207"
@@ -378,6 +389,13 @@ def test_fix_um_radtime_prehour(cube):
     assert rad_times[0] == datetime.datetime(2022, 9, 21, 3, 0)
     for time in rad_times:
         assert time.minute == 0
+
+    # Ensure radiation forecast_periods are fixed.
+    rad_time_coord = cube.coord("forecast_period")
+    # Check all times are fixed.
+    assert rad_time_coord.points[0] == 0
+    for time in rad_time_coord.points:
+        assert time.dtype == int
 
 
 def test_fix_um_radtime_prehour_skip_non_radiation(cube):

--- a/tests/operators/test_read.py
+++ b/tests/operators/test_read.py
@@ -516,8 +516,8 @@ def test_lfric_time_callback_forecast_reference_time(slammed_lfric_cube):
     assert ref_time_coord.standard_name == "forecast_reference_time"
     assert ref_time_coord.long_name == "forecast_reference_time"
     assert ref_time_coord.var_name is None
-    assert str(ref_time_coord.units) == "seconds since 2022-01-01 00:00:00"
-    assert all(ref_time_coord.points == [0])
+    assert str(ref_time_coord.units) == "hours since 1970-01-01 00:00:00"
+    assert all(ref_time_coord.points == [455832])
 
 
 def test_lfric_time_callback_forecast_period(slammed_lfric_cube):
@@ -548,14 +548,17 @@ def test_lfric_time_callback_hours(slammed_lfric_cube):
     assert all(fc_period_coord.points == [1, 2, 3, 4, 5, 6])
 
 
-def test_lfric_time_callback_unknown_units(slammed_lfric_cube):
+def test_lfric_time_callback_unknown_units(slammed_lfric_cube, caplog):
     """Error when forecast_period units cannot be determined."""
     slammed_lfric_cube.remove_coord("forecast_period")
     assert not slammed_lfric_cube.coords("forecast_period")
-    slammed_lfric_cube.coord("time").convert_units("days since 1970-01-01 00:00:00")
+    slammed_lfric_cube.coord("time").units = None
 
-    with pytest.raises(ValueError, match="Unrecognised base time unit:"):
+    with pytest.raises(iris.exceptions.UnitConversionError):
         read._lfric_time_callback(slammed_lfric_cube)
+        _, level, message = caplog.record_tuples[0]
+        assert level == logging.ERROR
+        assert message == "Unrecognised base time unit: unknown"
 
 
 def test_lfric_normalise_varname(model_level_cube):

--- a/tests/operators/test_read.py
+++ b/tests/operators/test_read.py
@@ -516,8 +516,10 @@ def test_lfric_time_callback_forecast_reference_time(slammed_lfric_cube):
     assert ref_time_coord.standard_name == "forecast_reference_time"
     assert ref_time_coord.long_name == "forecast_reference_time"
     assert ref_time_coord.var_name is None
-    assert str(ref_time_coord.units) == "hours since 1970-01-01 00:00:00"
-    assert all(ref_time_coord.points == [455832])
+    assert (
+        str(ref_time_coord.units) == "seconds since 2022-01-01 00:00:00"
+    )  # hours since 1970-01-01 00:00:00"
+    assert all(ref_time_coord.points == [0])  # [455832])
 
 
 def test_lfric_time_callback_forecast_period(slammed_lfric_cube):
@@ -548,17 +550,17 @@ def test_lfric_time_callback_hours(slammed_lfric_cube):
     assert all(fc_period_coord.points == [1, 2, 3, 4, 5, 6])
 
 
-def test_lfric_time_callback_unknown_units(slammed_lfric_cube, caplog):
-    """Error when forecast_period units cannot be determined."""
-    slammed_lfric_cube.remove_coord("forecast_period")
-    assert not slammed_lfric_cube.coords("forecast_period")
-    slammed_lfric_cube.coord("time").units = None
-
-    with pytest.raises(iris.exceptions.UnitConversionError):
-        read._lfric_time_callback(slammed_lfric_cube)
-        _, level, message = caplog.record_tuples[0]
-        assert level == logging.ERROR
-        assert message == "Unrecognised base time unit: unknown"
+# def test_lfric_time_callback_unknown_units(slammed_lfric_cube, caplog):
+#    """Error when forecast_period units cannot be determined."""
+#    slammed_lfric_cube.remove_coord("forecast_period")
+#    assert not slammed_lfric_cube.coords("forecast_period")
+#    slammed_lfric_cube.coord("time").units = None
+#
+#    with pytest.raises(iris.exceptions.UnitConversionError):
+#        read._lfric_time_callback(slammed_lfric_cube)
+#        _, level, message = caplog.record_tuples[0]
+#        assert level == logging.ERROR
+#        assert message == "Unrecognised base time unit: unknown"
 
 
 def test_lfric_normalise_varname(model_level_cube):


### PR DESCRIPTION
<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->
Fixes #1447. Ensures data are rolled as well as hour points where sorting of inputs to hour 0-23 required when adding hour coordinate to cubes. Only plotting common time points also fixed by ensuring all time coordinates have common base time in callbak. 

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [x] Documentation has been updated to reflect change.
- [x] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
