### PR TITLE
Create link to conda environment for workflow in `make setup`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,5 +147,8 @@ src/CSET/workflow/files/opt/
 src/CSET/workflow/files/app/demo_pointstat/
 restricted*
 
+# Link to development conda-environment.
+src/CSET/workflow/files/conda-environment
+
 # User workflow configuration.
 src/CSET/workflow/files/rose-suite.conf

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,10 @@ conda:
 .git/hooks/pre-commit: conda
 	conda run -n cset-dev pre-commit install
 
-setup: conda .git/hooks/pre-commit ## Setup development environment.
+src/CSET/workflow/files/conda-environment:
+	conda run -n cset-dev bash -euc 'ln -s "$CONDA_PREFIX" src/CSET/workflow/files/conda-environment'
+
+setup: conda .git/hooks/pre-commit src/CSET/workflow/files/conda-environment ## Setup development environment.
 	conda run -n cset-dev pip install --no-deps -e .
 
 docs: ## Build documentation.

--- a/docs/source/contributing/getting-started.rst
+++ b/docs/source/contributing/getting-started.rst
@@ -74,6 +74,8 @@ environment for you to use.
     conda activate cset-dev
     # Adds extra checks when you commit something with git.
     pre-commit install
+    # Create conda environment link for running in-development workflows.
+    ln -s "$CONDA_PREFIX" src/CSET/workflow/files/conda-environment
     # Make CSET runnable for manual testing
     pip install --no-deps -e .
 


### PR DESCRIPTION
This symlink is added to the gitignore, as it is not portable. The steps used to create it are also documented in the developer's guide.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [x] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [ ] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
