### PR TITLE
Remove conda-environment link from development workflow to fix failing tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,8 @@ conda:
 .git/hooks/pre-commit: conda
 	conda run -n cset-dev pre-commit install
 
-src/CSET/workflow/files/conda-environment:
-	conda run -n cset-dev bash -euc 'ln -s "$CONDA_PREFIX" src/CSET/workflow/files/conda-environment'
-
-setup: conda .git/hooks/pre-commit src/CSET/workflow/files/conda-environment ## Setup development environment.
+setup: conda .git/hooks/pre-commit ## Setup development environment.
+	rm -f src/CSET/workflow/files/conda-environment # Temporary fix for #1459
 	conda run -n cset-dev pip install --no-deps -e .
 
 docs: ## Build documentation.

--- a/docs/source/contributing/getting-started.rst
+++ b/docs/source/contributing/getting-started.rst
@@ -74,8 +74,6 @@ environment for you to use.
     conda activate cset-dev
     # Adds extra checks when you commit something with git.
     pre-commit install
-    # Create conda environment link for running in-development workflows.
-    ln -s "$CONDA_PREFIX" src/CSET/workflow/files/conda-environment
     # Make CSET runnable for manual testing
     pip install --no-deps -e .
 

--- a/src/CSET/workflow/files/bin/app_env_wrapper
+++ b/src/CSET/workflow/files/bin/app_env_wrapper
@@ -40,6 +40,9 @@ if [[ -d "${CYLC_WORKFLOW_RUN_DIR}/conda-environment" ]]; then
   echo "Using conda environment from ${CYLC_WORKFLOW_RUN_DIR}/conda-environment"
   exec "${CONDA_PATH}conda" run --prefix "${CYLC_WORKFLOW_RUN_DIR}/conda-environment" "$@"
 else
-  echo "No conda environment to use. Running directly..."
+  echo "No linked conda environment. Attempting to use 'cset-dev' environment."
+  if ! "${CONDA_PATH}conda" run -n cset-dev "$@" ; then
+  echo "No conda environment to use. Attempting last-ditch attempt to run directly."
   exec "$@"
+  fi
 fi


### PR DESCRIPTION
Having this link causes editable installs to pick up the linked conda environment inside the extract-workflow command. Now, instead of creating that link the workflow will automatically try to use an environment named "cset-dev" if there is no linked workflow.

A temporary cleanup command has been added to `make setup`, to fix this issue for those already affected. We can probably drop this line in a few weeks as those affected (developers in the past week) will have all updated.

Fixes #1459

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [x] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
