### PR TITLE
Rename rose-suite.conf.txt to rose-suite.conf

### DIFF
--- a/src/CSET/workflow/files/app/install_website_skeleton/file/html/placeholder.html
+++ b/src/CSET/workflow/files/app/install_website_skeleton/file/html/placeholder.html
@@ -27,7 +27,7 @@
             <p>Unknown</p>
         </div>
         <h3>CSET configuration file</h3>
-        <p><a href="rose-suite.conf.txt">rose-suite.conf</a></p>
+        <p><a href="rose-suite.conf">rose-suite.conf</a></p>
 	<h3>Send feedback</h3>
         <p>
             CSET is a new system, and we would love to hear about your

--- a/src/CSET/workflow/finish_website.py
+++ b/src/CSET/workflow/finish_website.py
@@ -70,9 +70,7 @@ def update_workflow_status():
 def copy_rose_config():
     """Copy the rose-suite.conf file to add to output web directory."""
     rose_suite_conf = Path(os.environ["CYLC_WORKFLOW_RUN_DIR"]) / "rose-suite.conf"
-    web_conf_file = (
-        Path(os.environ["CYLC_WORKFLOW_SHARE_DIR"]) / "web/rose-suite.conf.txt"
-    )
+    web_conf_file = Path(os.environ["CYLC_WORKFLOW_SHARE_DIR"]) / "web/rose-suite.conf"
     shutil.copy(rose_suite_conf, web_conf_file)
 
 

--- a/tests/workflow/test_finish_website.py
+++ b/tests/workflow/test_finish_website.py
@@ -31,7 +31,7 @@ def test_copy_rose_config(monkeypatch, tmp_path):
     monkeypatch.setenv("CYLC_WORKFLOW_RUN_DIR", str(tmp_path))
     monkeypatch.setenv("CYLC_WORKFLOW_SHARE_DIR", str(tmp_path))
     finish_website.copy_rose_config()
-    with open(web_dir / "rose-suite.conf.txt", "rt", encoding="UTF-8") as fp:
+    with open(web_dir / "rose-suite.conf", "rt", encoding="UTF-8") as fp:
         assert fp.read() == "Test rose-suite.conf file\n"
 
 


### PR DESCRIPTION
The Met Office webserver specific issue that blocked the .conf extension has been fixed.

Fixes #1455

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [ ] All tests and CI checks pass.
- [ ] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [ ] Marked the PR as ready to review.
