### PR TITLE
Fixes pressure model transect recipe

### DIFF
--- a/src/CSET/workflow/files/includes/plevel_transect.cylc
+++ b/src/CSET/workflow/files/includes/plevel_transect.cylc
@@ -1,5 +1,5 @@
 {% if EXTRACT_PLEVEL_TRANSECT|default(False) %}
-{% for field in PRESSURE_LEVEL_MODEL_FIELDS %}
+{% for field in PRESSURE_LEVEL_FIELDS %}
 {% for model in models %}
 [runtime]
     [[plevel_transect_m{{model["id"]}}_{{sanitise_task_name(field)}}]]


### PR DESCRIPTION
Removes `MODEL` from `PRESSURE_LEVELS_MODEL_FIELDS` to allow CSET to run.

Fixes #1466

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
