### PR TITLE
Update cell_methods constraint to process time aggregated input cubes

### DIFF
--- a/src/CSET/operators/constraints.py
+++ b/src/CSET/operators/constraints.py
@@ -150,18 +150,18 @@ def generate_cell_methods_constraint(
 
         def check_cell_mean(cube: iris.cube.Cube) -> bool:
             """Check that any cell methods are "mean"."""
-            return set(cm.method for cm in cube.cell_methods) <= {"mean"}
+            return set(cm.method for cm in cube.cell_methods) == {"mean"}
 
         def check_cell_sum(cube: iris.cube.Cube) -> bool:
             """Check that any cell methods are "sum"."""
-            return set(cm.method for cm in cube.cell_methods) <= {"sum"}
+            return set(cm.method for cm in cube.cell_methods) == {"sum"}
 
         if varname:
+            # Require number_of_lightning_flashes to be "sum" cell_method input.
+            # Require surface_microphyisical_rainfall_amount and surface_microphysical_snowfall_amount to be "sum" cell_method inputs.
             if ("lightning" in varname) or (
                 "surface_microphysical" in varname and "amount" in varname
             ):
-                # Require number_of_lightning_flashes to be "sum" cell_method input.
-                # Require surface_microphyisical_rainfall_amount and surface_microphysical_snowfall_amount to be "sum" cell_method inputs.
                 cell_methods_constraint = iris.Constraint(cube_func=check_cell_sum)
                 return cell_methods_constraint
 

--- a/src/CSET/operators/read.py
+++ b/src/CSET/operators/read.py
@@ -97,7 +97,6 @@ def read_cube(
         subarea_type=subarea_type,
         subarea_extent=subarea_extent,
     )
-    print(cubes[0])
     # Check filtered cubes is a CubeList containing one cube.
     if len(cubes) == 1:
         return cubes[0]

--- a/src/CSET/operators/read.py
+++ b/src/CSET/operators/read.py
@@ -739,7 +739,8 @@ def _fix_um_radtime(cube: iris.cube.Cube):
 def _fix_cell_methods(cube: iris.cube.Cube):
     """To fix the assumed cell_methods in accumulation STASH from UM.
 
-    Lightning (m01s21i104), rainfall amount (m01s04i205) and snowfall amount in UM is being output as a time accumulation,
+    Lightning (m01s21i104), rainfall amount (m01s04i201, m01s05i201) and snowfall amount
+    (m01s04i202, m01s05i202) in UM is being output as a time accumulation,
     over each hour (TAcc1hr), but input cubes show cell_methods as "mean".
     For UM and LFRic inputs to be compatible, we assume accumulated cell_methods are
     "sum". This callback changes "mean" cube attribute cell_method to "sum",

--- a/src/CSET/recipes/generic_basic_qq_plot.yaml
+++ b/src/CSET/recipes/generic_basic_qq_plot.yaml
@@ -16,9 +16,10 @@ steps:
                 variable_constraint:
                     operator: constraints.generate_var_constraint
                     varname: $VARNAME_A
-                cell_method_constraint:
+                cell_methods_constraint:
                     operator: constraints.generate_cell_methods_constraint
                     cell_methods: []
+                    varname: $VARNAME_A
                 level_constraint:
                     operator: constraints.generate_level_constraint
                     coordinate: $VERTICAL_COORDINATE_A
@@ -35,9 +36,10 @@ steps:
                 variable_constraint:
                     operator: constraints.generate_var_constraint
                     varname: $VARNAME_B
-                cell_method_constraint:
+                cell_methods_constraint:
                     operator: constraints.generate_cell_methods_constraint
                     cell_methods: []
+                    varname: $VARNAME_B
                 level_constraint:
                     operator: constraints.generate_level_constraint
                     coordinate: $VERTICAL_COORDINATE_B

--- a/src/CSET/recipes/generic_level_histogram_series.yaml
+++ b/src/CSET/recipes/generic_level_histogram_series.yaml
@@ -21,6 +21,7 @@ steps:
       cell_methods_constraint:
         operator: constraints.generate_cell_methods_constraint
         cell_methods: []
+        varname: $VARNAME
       level_constraint:
         operator: constraints.generate_level_constraint
         coordinate: $LEVELTYPE

--- a/src/CSET/recipes/generic_level_histogram_series_case_aggregation_all.yaml
+++ b/src/CSET/recipes/generic_level_histogram_series_case_aggregation_all.yaml
@@ -23,6 +23,7 @@ steps:
       cell_methods_constraint:
         operator: constraints.generate_cell_methods_constraint
         cell_methods: []
+        varname: $VARNAME
       level_constraint:
         operator: constraints.generate_level_constraint
         coordinate: $LEVELTYPE

--- a/src/CSET/recipes/generic_level_histogram_series_case_aggregation_hour_of_day.yaml
+++ b/src/CSET/recipes/generic_level_histogram_series_case_aggregation_hour_of_day.yaml
@@ -23,6 +23,7 @@ steps:
       cell_methods_constraint:
         operator: constraints.generate_cell_methods_constraint
         cell_methods: []
+        varname: $VARNAME
       level_constraint:
         operator: constraints.generate_level_constraint
         coordinate: $LEVELTYPE

--- a/src/CSET/recipes/generic_level_histogram_series_case_aggregation_lead_time.yaml
+++ b/src/CSET/recipes/generic_level_histogram_series_case_aggregation_lead_time.yaml
@@ -23,6 +23,7 @@ steps:
       cell_methods_constraint:
         operator: constraints.generate_cell_methods_constraint
         cell_methods: []
+        varname: $VARNAME
       level_constraint:
         operator: constraints.generate_level_constraint
         coordinate: $LEVELTYPE

--- a/src/CSET/recipes/generic_level_histogram_series_case_aggregation_validity_time.yaml
+++ b/src/CSET/recipes/generic_level_histogram_series_case_aggregation_validity_time.yaml
@@ -23,6 +23,7 @@ steps:
       cell_methods_constraint:
         operator: constraints.generate_cell_methods_constraint
         cell_methods: []
+        varname: $VARNAME
       level_constraint:
         operator: constraints.generate_level_constraint
         coordinate: $LEVELTYPE

--- a/src/CSET/recipes/generic_surface_domain_mean_time_series.yaml
+++ b/src/CSET/recipes/generic_surface_domain_mean_time_series.yaml
@@ -14,6 +14,7 @@ steps:
       cell_methods_constraint:
         operator: constraints.generate_cell_methods_constraint
         cell_methods: []
+        varname: $VARNAME
       pressure_level_constraint:
         operator: constraints.generate_level_constraint
         coordinate: "pressure"

--- a/src/CSET/recipes/generic_surface_domain_mean_time_series_case_aggregation_hour_of_day.yaml
+++ b/src/CSET/recipes/generic_surface_domain_mean_time_series_case_aggregation_hour_of_day.yaml
@@ -16,6 +16,7 @@ steps:
       cell_methods_constraint:
         operator: constraints.generate_cell_methods_constraint
         cell_methods: []
+        varname: $VARNAME
       pressure_level_constraint:
         operator: constraints.generate_level_constraint
         coordinate: "pressure"

--- a/src/CSET/recipes/generic_surface_domain_mean_time_series_case_aggregation_lead_time.yaml
+++ b/src/CSET/recipes/generic_surface_domain_mean_time_series_case_aggregation_lead_time.yaml
@@ -16,6 +16,7 @@ steps:
       cell_methods_constraint:
         operator: constraints.generate_cell_methods_constraint
         cell_methods: []
+        varname: $VARNAME
       pressure_level_constraint:
         operator: constraints.generate_level_constraint
         coordinate: "pressure"

--- a/src/CSET/recipes/generic_surface_domain_mean_time_series_case_aggregation_validity_time.yaml
+++ b/src/CSET/recipes/generic_surface_domain_mean_time_series_case_aggregation_validity_time.yaml
@@ -16,6 +16,7 @@ steps:
       cell_methods_constraint:
         operator: constraints.generate_cell_methods_constraint
         cell_methods: []
+        varname: $VARNAME
       pressure_level_constraint:
         operator: constraints.generate_level_constraint
         coordinate: "pressure"

--- a/src/CSET/recipes/generic_surface_histogram_series.yaml
+++ b/src/CSET/recipes/generic_surface_histogram_series.yaml
@@ -19,6 +19,7 @@ steps:
       cell_methods_constraint:
         operator: constraints.generate_cell_methods_constraint
         cell_methods: []
+        varname: $VARNAME
       pressure_level_constraint:
         operator: constraints.generate_level_constraint
         coordinate: pressure

--- a/src/CSET/recipes/generic_surface_histogram_series_case_aggregation_all.yaml
+++ b/src/CSET/recipes/generic_surface_histogram_series_case_aggregation_all.yaml
@@ -20,6 +20,7 @@ steps:
       cell_methods_constraint:
         operator: constraints.generate_cell_methods_constraint
         cell_methods: []
+        varname: $VARNAME
       pressure_level_constraint:
         operator: constraints.generate_level_constraint
         coordinate: pressure

--- a/src/CSET/recipes/generic_surface_histogram_series_case_aggregation_hour_of_day.yaml
+++ b/src/CSET/recipes/generic_surface_histogram_series_case_aggregation_hour_of_day.yaml
@@ -20,6 +20,7 @@ steps:
       cell_methods_constraint:
         operator: constraints.generate_cell_methods_constraint
         cell_methods: []
+        varname: $VARNAME
       pressure_level_constraint:
         operator: constraints.generate_level_constraint
         coordinate: pressure

--- a/src/CSET/recipes/generic_surface_histogram_series_case_aggregation_lead_time.yaml
+++ b/src/CSET/recipes/generic_surface_histogram_series_case_aggregation_lead_time.yaml
@@ -20,6 +20,7 @@ steps:
       cell_methods_constraint:
         operator: constraints.generate_cell_methods_constraint
         cell_methods: []
+        varname: $VARNAME
       pressure_level_constraint:
         operator: constraints.generate_level_constraint
         coordinate: pressure

--- a/src/CSET/recipes/generic_surface_histogram_series_case_aggregation_validity_time.yaml
+++ b/src/CSET/recipes/generic_surface_histogram_series_case_aggregation_validity_time.yaml
@@ -20,6 +20,7 @@ steps:
       cell_methods_constraint:
         operator: constraints.generate_cell_methods_constraint
         cell_methods: []
+        varname: $VARNAME
       pressure_level_constraint:
         operator: constraints.generate_level_constraint
         coordinate: pressure

--- a/src/CSET/recipes/generic_surface_single_point_time_series.yaml
+++ b/src/CSET/recipes/generic_surface_single_point_time_series.yaml
@@ -14,6 +14,7 @@ steps:
       cell_methods_constraint:
         operator: constraints.generate_cell_methods_constraint
         cell_methods: []
+        varname: $VARNAME
       pressure_level_constraint:
         operator: constraints.generate_level_constraint
         levels: []

--- a/src/CSET/recipes/generic_surface_spatial_plot_sequence.yaml
+++ b/src/CSET/recipes/generic_surface_spatial_plot_sequence.yaml
@@ -13,6 +13,7 @@ steps:
       cell_methods_constraint:
         operator: constraints.generate_cell_methods_constraint
         cell_methods: []
+        varname: $VARNAME
       pressure_level_constraint:
         operator: constraints.generate_level_constraint
         coordinate: "pressure"

--- a/src/CSET/recipes/generic_surface_spatial_plot_sequence_case_aggregation_mean_hour_of_day.yaml
+++ b/src/CSET/recipes/generic_surface_spatial_plot_sequence_case_aggregation_mean_hour_of_day.yaml
@@ -15,6 +15,7 @@ steps:
       cell_methods_constraint:
         operator: constraints.generate_cell_methods_constraint
         cell_methods: []
+        varname: $VARNAME
       pressure_level_constraint:
         operator: constraints.generate_level_constraint
         coordinate: "pressure"

--- a/src/CSET/recipes/generic_surface_spatial_plot_sequence_case_aggregation_mean_lead_time.yaml
+++ b/src/CSET/recipes/generic_surface_spatial_plot_sequence_case_aggregation_mean_lead_time.yaml
@@ -15,6 +15,7 @@ steps:
       cell_methods_constraint:
         operator: constraints.generate_cell_methods_constraint
         cell_methods: []
+        varname: $VARNAME
       pressure_level_constraint:
         operator: constraints.generate_level_constraint
         coordinate: "pressure"

--- a/src/CSET/recipes/generic_surface_spatial_plot_sequence_case_aggregation_mean_validity_time.yaml
+++ b/src/CSET/recipes/generic_surface_spatial_plot_sequence_case_aggregation_mean_validity_time.yaml
@@ -15,6 +15,7 @@ steps:
       cell_methods_constraint:
         operator: constraints.generate_cell_methods_constraint
         cell_methods: []
+        varname: $VARNAME
       pressure_level_constraint:
         operator: constraints.generate_level_constraint
         coordinate: "pressure"

--- a/src/CSET/recipes/level_spatial_difference.yaml
+++ b/src/CSET/recipes/level_spatial_difference.yaml
@@ -11,6 +11,10 @@ steps:
       varname_constraint:
         operator: constraints.generate_var_constraint
         varname: $VARNAME
+      cell_methods_constraint:
+        operator: constraints.generate_cell_methods_constraint
+        cell_methods: []
+        varname: $VARNAME
       level_constraint:
         operator: constraints.generate_level_constraint
         coordinate: $LEVELTYPE

--- a/src/CSET/recipes/level_spatial_difference_case_aggregation_mean_hour_of_day.yaml
+++ b/src/CSET/recipes/level_spatial_difference_case_aggregation_mean_hour_of_day.yaml
@@ -16,6 +16,7 @@ steps:
       cell_methods_constraint:
         operator: constraints.generate_cell_methods_constraint
         cell_methods: []
+        varname: $VARNAME
       level_constraint:
         operator: constraints.generate_level_constraint
         coordinate: $LEVELTYPE

--- a/src/CSET/recipes/level_spatial_difference_case_aggregation_mean_lead_time.yaml
+++ b/src/CSET/recipes/level_spatial_difference_case_aggregation_mean_lead_time.yaml
@@ -16,6 +16,7 @@ steps:
       cell_methods_constraint:
         operator: constraints.generate_cell_methods_constraint
         cell_methods: []
+        varname: $VARNAME
       level_constraint:
         operator: constraints.generate_level_constraint
         coordinate: $LEVELTYPE

--- a/src/CSET/recipes/level_spatial_difference_case_aggregation_mean_validity_time.yaml
+++ b/src/CSET/recipes/level_spatial_difference_case_aggregation_mean_validity_time.yaml
@@ -16,6 +16,7 @@ steps:
       cell_methods_constraint:
         operator: constraints.generate_cell_methods_constraint
         cell_methods: []
+        varname: $VARNAME
       level_constraint:
         operator: constraints.generate_level_constraint
         coordinate: $LEVELTYPE

--- a/src/CSET/recipes/surface_spatial_difference.yaml
+++ b/src/CSET/recipes/surface_spatial_difference.yaml
@@ -14,6 +14,7 @@ steps:
       cell_methods_constraint:
         operator: constraints.generate_cell_methods_constraint
         cell_methods: []
+        varname: $VARNAME
       pressure_level_constraint:
         operator: constraints.generate_level_constraint
         coordinate: "pressure"

--- a/src/CSET/recipes/surface_spatial_difference_case_aggregation_mean_hour_of_day.yaml
+++ b/src/CSET/recipes/surface_spatial_difference_case_aggregation_mean_hour_of_day.yaml
@@ -16,6 +16,7 @@ steps:
       cell_methods_constraint:
         operator: constraints.generate_cell_methods_constraint
         cell_methods: []
+        varname: $VARNAME
       pressure_level_constraint:
         operator: constraints.generate_level_constraint
         coordinate: "pressure"

--- a/src/CSET/recipes/surface_spatial_difference_case_aggregation_mean_lead_time.yaml
+++ b/src/CSET/recipes/surface_spatial_difference_case_aggregation_mean_lead_time.yaml
@@ -16,6 +16,7 @@ steps:
       cell_methods_constraint:
         operator: constraints.generate_cell_methods_constraint
         cell_methods: []
+        varname: $VARNAME
       pressure_level_constraint:
         operator: constraints.generate_level_constraint
         coordinate: "pressure"

--- a/src/CSET/recipes/surface_spatial_difference_case_aggregation_mean_validity_time.yaml
+++ b/src/CSET/recipes/surface_spatial_difference_case_aggregation_mean_validity_time.yaml
@@ -16,6 +16,7 @@ steps:
       cell_methods_constraint:
         operator: constraints.generate_cell_methods_constraint
         cell_methods: []
+        varname: $VARNAME
       pressure_level_constraint:
         operator: constraints.generate_level_constraint
         coordinate: "pressure"

--- a/tests/operators/test_constraints.py
+++ b/tests/operators/test_constraints.py
@@ -49,6 +49,13 @@ def test_generate_cell_methods_constraint():
     assert expected_cell_methods_constraint in repr(cell_methods_constraint)
 
 
+def test_generate_cell_methods_constraint_sum():
+    """Generate aggregate iris cube constraint for cell methods."""
+    cell_methods_constraint = constraints.generate_cell_methods_constraint(["sum"])
+    expected_cell_methods_constraint = "Constraint(cube_func=<function generate_cell_methods_constraint.<locals>.check_cell_methods at"
+    assert expected_cell_methods_constraint in repr(cell_methods_constraint)
+
+
 def test_generate_cell_methods_constraint_no_aggregation():
     """Generate iris cube constraint for no aggregation cell methods."""
     cell_methods_constraint = constraints.generate_cell_methods_constraint([])

--- a/tests/operators/test_constraints.py
+++ b/tests/operators/test_constraints.py
@@ -56,6 +56,15 @@ def test_generate_cell_methods_constraint_no_aggregation():
     assert expected_cell_methods_constraint in repr(cell_methods_constraint)
 
 
+def test_generate_cell_methods_constraint_varname():
+    """Generate variable-dependent iris cube constraint for cell methods."""
+    cell_methods_constraint = constraints.generate_cell_methods_constraint(
+        [], "number_of_lightning_flashes"
+    )
+    expected_cell_methods_constraint = "Constraint(cube_func=<function generate_cell_methods_constraint.<locals>.check_cell_sum at"
+    assert expected_cell_methods_constraint in repr(cell_methods_constraint)
+
+
 def test_generate_time_constraint():
     """Generate iris cube constraint for dates."""
     # Try with str dates

--- a/tests/operators/test_read.py
+++ b/tests/operators/test_read.py
@@ -564,19 +564,12 @@ def test_fix_cell_methods_lightning(cube):
     """Check cell_methods are adjusted."""
     # Add UM lightning STASH code.
     cube.attributes["STASH"] = "m01s21i104"
-    # Apply fix.
-    read._fix_cell_methods(cube)
-    # Check instantaneous cell method assumed if no input cell method.
-    assert cube.cell_methods[0] == iris.coords.CellMethod(
-        method="point", coords=("time",), intervals=(), comments=()
-    )
-
-    # Now test with assumed time-averaged lightning diagnostic input.
+    # Set assumed time-averaged lightning diagnostic cell_method.
     cube.cell_methods = ()
     cube.add_cell_method(iris.coords.CellMethod("mean", coords="time"))
     # Apply fix.
     read._fix_cell_methods(cube)
-    # Check sum cell method now applied.
+    # Check sum cell method now applied to accumulated diagnostic.
     assert cube.cell_methods[0] == iris.coords.CellMethod(
         method="sum", coords=("time",), intervals=(), comments=()
     )
@@ -589,9 +582,7 @@ def test_fix_cell_methods_instantaneous(cube):
     # Apply fix.
     read._fix_cell_methods(cube)
     # Check that output cell method is non-aggregated.
-    assert cube.cell_methods[0] == iris.coords.CellMethod(
-        method="point", coords=("time",), intervals=(), comments=()
-    )
+    assert cube.cell_methods == ()
 
 
 def test_spatial_coord_auxcoord_callback():


### PR DESCRIPTION
<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->
Fixes #1434 and #1402.
Adds variable-dependent check in cell_method constraint, and updates callback to ensure UM inputs have "sum" cell_method where required.
 
### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [x] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
