### PR TITLE
Use temporary working directory for plotting tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -177,3 +177,27 @@ def model_level_cube_read_only():
 def model_level_cube(model_level_cube_read_only):
     """Get model level cube to run tests on. It is safe to modify."""
     return model_level_cube_read_only.copy()
+
+
+@pytest.fixture(scope="session")
+def global_cube_read_only():
+    """Get global cube to run tests on. It is NOT safe to modify."""
+    return read.read_cube("tests/test_data/air_temperature_global.nc")
+
+
+@pytest.fixture()
+def global_cube(global_cube_read_only):
+    """Get global cube to run tests on. It is safe to modify."""
+    return global_cube_read_only.copy()
+
+
+@pytest.fixture(scope="session")
+def ensemble_cube_read_only():
+    """Get ensemble cube to run tests on. It is NOT safe to modify."""
+    return read.read_cube("tests/test_data/exeter_em*.nc")
+
+
+@pytest.fixture()
+def ensemble_cube(ensemble_cube_read_only):
+    """Get ensemble cube to run tests on. It is safe to modify."""
+    return ensemble_cube_read_only.copy()

--- a/tests/operators/test_plots.py
+++ b/tests/operators/test_plots.py
@@ -24,7 +24,7 @@ import matplotlib as mpl
 import numpy as np
 import pytest
 
-from CSET.operators import collapse, plot, read
+from CSET.operators import collapse, plot
 
 
 def test_check_single_cube():
@@ -259,9 +259,8 @@ def test_contour_plot_sequence(cube, tmp_working_dir):
     assert Path("untitled_462149.0.png").is_file()
 
 
-def test_postage_stamp_contour_plot(monkeypatch, tmp_path):
+def test_postage_stamp_contour_plot(ensemble_cube, monkeypatch, tmp_path):
     """Plot postage stamp plots of ensemble data."""
-    ensemble_cube = read.read_cube("tests/test_data/exeter_em*.nc")
     # Get a single time step.
     ensemble_cube_3d = next(ensemble_cube.slices_over("time"))
     monkeypatch.chdir(tmp_path)
@@ -314,9 +313,8 @@ def test_pcolormesh_plot_sequence(cube, tmp_working_dir):
     assert Path("untitled_462149.0.png").is_file()
 
 
-def test_pcolormesh_plot_global(caplog):
+def test_pcolormesh_plot_global(global_cube, caplog, tmp_working_dir):
     """Plot global lat-lon cube."""
-    global_cube = read.read_cube("tests/test_data/air_temperature_global.nc")
     with caplog.at_level(logging.DEBUG):
         plot.spatial_pcolormesh_plot(global_cube)
         message_match = False
@@ -326,9 +324,8 @@ def test_pcolormesh_plot_global(caplog):
     assert message_match
 
 
-def test_postage_stamp_pcolormesh_plot(monkeypatch, tmp_path):
+def test_postage_stamp_pcolormesh_plot(ensemble_cube, monkeypatch, tmp_path):
     """Plot postage stamp plots of ensemble data."""
-    ensemble_cube = read.read_cube("tests/test_data/exeter_em*.nc")
     # Get a single time step.
     ensemble_cube_3d = next(ensemble_cube.slices_over("time"))
     monkeypatch.chdir(tmp_path)
@@ -344,7 +341,7 @@ def test_postage_stamp_pcolormesh_plot_sequence_coord_check(cube, tmp_working_di
         plot.spatial_pcolormesh_plot(cube)
 
 
-def test_pcolormesh_coastline(cube, caplog):
+def test_pcolormesh_coastline(cube, caplog, tmp_working_dir):
     """Check coastlines plotted in black for air_temperature colormap."""
     with caplog.at_level(logging.DEBUG):
         plot.spatial_pcolormesh_plot(cube)
@@ -355,7 +352,7 @@ def test_pcolormesh_coastline(cube, caplog):
         assert message_match
 
 
-def test_pcolormesh_coastline_m(cube, caplog):
+def test_pcolormesh_coastline_m(cube, caplog, tmp_working_dir):
     """Check coastlines plotted in magenta for viridis colormap."""
     with caplog.at_level(logging.DEBUG):
         # Set cube name to unknown to trigger viridis default cmap
@@ -695,9 +692,8 @@ def test_invalid_plotting_method_postage_stamp_spatial_plot(cube, tmp_working_di
         )
 
 
-def test_levels_postage_stamp_spatial_plot(cube):
+def test_levels_postage_stamp_spatial_plot(ensemble_cube, tmp_working_dir):
     """Test no levels raises TypeError for pcolormesh with no levels."""
-    ensemble_cube = read.read_cube("tests/test_data/exeter_em*.nc")
     with pytest.raises(TypeError, match="Unknown vmin and vmax range."):
         ensemble_cube.rename("unknown")
         plot._plot_and_save_postage_stamp_spatial_plot(


### PR DESCRIPTION
This prevents them dumping their artefacts in the repository when the tests are run. Additionally a couple direct reads were moved to fixtures to support this.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [x] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
