### PR TITLE
Allow ensembles to run for more than ten variables

### DIFF
--- a/src/CSET/cset_workflow/flow.cylc
+++ b/src/CSET/cset_workflow/flow.cylc
@@ -173,7 +173,7 @@ URL = https://metoffice.github.io/CSET
         ANALYSIS_LENGTH = {{ANALYSIS_LENGTH}}
 
     [[PREPROCESS_DATA]]
-    script = rose task-run -v --app-key=preprocess_data
+    script = true
     execution time limit = PT30M
     execution retry delays = PT1M, PT15M, PT1H
         [[[directives]]]


### PR DESCRIPTION
Attempt to fix running of CSET with ensemble data for more than ten variables, for which is currently crashes.

Fixes #1503

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
