### PR TITLE
Correct description for standard deviation time aggregation method in rose edit

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -104,6 +104,7 @@ the main CSET package for easier testing and distribution.
 * Remove preprocess task by `@jfrost-mo`_ in :pr:`1514`
 * Simplify release instructions to reflect the workflow being bundled into the CSET package by `@jfrost-mo`_ in :pr:`1515`
 * Add CSET v25.7.0 release notes to changelog by `@jfrost-mo`_ in :pr:`1516`
+* Correct description for standard deviation time aggregation method in rose edit by `@Sylviabohnenstengel`_ in :pr:`1513`
 
 New Contributors
 

--- a/src/CSET/cset_workflow/meta/diagnostics/rose-meta.conf
+++ b/src/CSET/cset_workflow/meta/diagnostics/rose-meta.conf
@@ -60,7 +60,7 @@ sort-key=0surface2
 ns=Diagnostics/Fields
 description=Select analysis method(s) for output mapped plots. Add all options required.
             Leave blank or set to "SEQ" (sequence) for plots each diagnostic output time.
-            For time-collapsed outputs over each analysis period, set to "MEAN", "MAX", "MIN", "STD" etc.
+            For time-collapsed outputs over each analysis period, set to "MEAN", "MAX", "MIN", "STD_DEV" etc.
 help=Quoted analysis methods. Settings should be based on available iris.analysis methods for collapsing cube dimensions.
 type=python_list
 compulsory=true


### PR DESCRIPTION
<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->
correct METHOD for time aggregation from STD to STD_DEV in rose-meta.conf in line with iris.analysis methods.
### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [ ] All tests and CI checks pass.
- [ ] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [ ] Marked the PR as ready to review.
