### PR TITLE
Reduce required code coverage

### DIFF
--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -97,8 +97,8 @@ jobs:
           if ! gh pr comment --repo "${{ github.repository }}" --edit-last --create-if-none "${{ github.head_ref }}" --body-file "${{ runner.temp }}/cov-report.md" ; then
             echo "Failed to post comment. This is likely due to this being a PR from a fork."
           fi
-      - name: Check 95% minimum coverage
-        run: coverage report --fail-under=95
+      - name: Check 90% minimum coverage
+        run: coverage report --fail-under=90
 
   pre-commit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We should aim to increase this in future, but it is blocking pull requests currently. The main issue is that it will error when the coverage is too low, even if you new code isn't covered.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [ ] All tests and CI checks pass.
- [ ] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [ ] Marked the PR as ready to review.
