### PR TITLE
Explicitly check for existence of cset-dev environment when running development CSET

### DIFF
--- a/src/CSET/cset_workflow/bin/app_env_wrapper
+++ b/src/CSET/cset_workflow/bin/app_env_wrapper
@@ -40,10 +40,10 @@ if [[ -d "${CYLC_WORKFLOW_RUN_DIR}/conda-environment" ]]; then
   echo "Using conda environment from ${CYLC_WORKFLOW_RUN_DIR}/conda-environment"
   # Don't capture output so logs are seen while the program is still running.
   exec "${CONDA_PATH}conda" run --no-capture-output --prefix "${CYLC_WORKFLOW_RUN_DIR}/conda-environment" "$@"
-else
+elif conda info --envs | grep -q '^cset-dev '; then
   echo "No linked conda environment. Attempting to use 'cset-dev' environment."
-  if ! "${CONDA_PATH}conda" run --no-capture-output --name cset-dev "$@" ; then
+  exec "${CONDA_PATH}conda" run --no-capture-output --name cset-dev "$@"
+else
   echo "No conda environment to use. Attempting last-ditch attempt to run directly."
   exec "$@"
-  fi
 fi


### PR DESCRIPTION
When cset would fail, it exited non-zero which then triggered the else branch, causing an attempt to run with no environment. This would always also fail, so it preserved the workflow behaviour, but it produced some messy and confusing logs.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
