### PR TITLE
Update collapse to ensure processing overlapping times only where multiple model inputs

### DIFF
--- a/src/CSET/operators/collapse.py
+++ b/src/CSET/operators/collapse.py
@@ -73,6 +73,26 @@ def collapse(
         return cubes
     if method == "PERCENTILE" and additional_percent is None:
         raise ValueError("Must specify additional_percent")
+
+    # Remove T0 from UM inputs to allow time-averaged comparison with LFRic.
+    # This is intended as a short-term fix while different length inputs
+    # often used in comparing different models.
+    ####cubes = remove_time0(cubes)
+
+    # Retain only common time points between different models if multiple model inputs.
+    if isinstance(cubes, iris.cube.CubeList) and len(cubes) > 1:
+        logging.debug(
+            "Extracting common time points as multiple model inputs detected."
+        )
+        for cube in cubes:
+            cube.coord("forecast_reference_time").bounds = None
+            cube.coord("forecast_period").bounds = None
+        cubes = cubes.extract_overlapping(
+            ["forecast_reference_time", "forecast_period"]
+        )
+        if len(cubes) == 0:
+            raise ValueError("No overlapping times detected in input cubes.")
+
     collapsed_cubes = iris.cube.CubeList([])
     with warnings.catch_warnings():
         warnings.filterwarnings(

--- a/src/CSET/operators/collapse.py
+++ b/src/CSET/operators/collapse.py
@@ -74,11 +74,6 @@ def collapse(
     if method == "PERCENTILE" and additional_percent is None:
         raise ValueError("Must specify additional_percent")
 
-    # Remove T0 from UM inputs to allow time-averaged comparison with LFRic.
-    # This is intended as a short-term fix while different length inputs
-    # often used in comparing different models.
-    ####cubes = remove_time0(cubes)
-
     # Retain only common time points between different models if multiple model inputs.
     if isinstance(cubes, iris.cube.CubeList) and len(cubes) > 1:
         logging.debug(

--- a/src/CSET/operators/read.py
+++ b/src/CSET/operators/read.py
@@ -186,10 +186,6 @@ def read_cubes(
     # Unify time units so different case studies can merge.
     iris.util.unify_time_units(cubes)
 
-    # Remove T0 from UM inputs to allow time-averaged comparison with LFRic.
-    # TODO: Remove this hack. (See docstring for issue.)
-    _remove_time0(cubes)
-
     # Select sub region.
     cubes = _cutout_cubes(cubes, subarea_type, subarea_extent)
     # Merge and concatenate cubes now metadata has been fixed.
@@ -995,30 +991,3 @@ def _lfric_forecast_period_standard_name_callback(cube: iris.cube.Cube):
             coord.standard_name = "forecast_period"
     except iris.exceptions.CoordinateNotFoundError:
         pass
-
-
-def _remove_time0(cubes: iris.cube.CubeList):
-    """Remove T0 from UM inputs to allow time-averaged comparison with LFRic.
-
-    A number of UM outputs contain T=0 initial time diagnostic fields, while
-    LFRic diagnostics begin from T=1 output step. This does not cause issues
-    for comparing UM with LFRic for hour-by-hour comparisons, for which times
-    are matched up in code. However, for any recipes requiring collapse by
-    time ahead of comparison, computing averages over e.g. 24h vs 25h window
-    results in different timestamps in each collapsed cube, breaking subsequent
-    CSET time-checking steps to compare like-with-like.
-
-    This function removes any outputs at T=0 to support time-processed comparisons.
-    """
-    valid_cubes = iris.cube.CubeList()
-    for cube in cubes:
-        if cube.coords("forecast_period"):
-            valid_cube = cube.extract(
-                iris.Constraint(forecast_period=lambda cell: cell >= 0.25)
-            )
-            if valid_cube:
-                valid_cubes.append(valid_cube)
-        else:
-            valid_cubes.append(cube)
-
-    return valid_cubes

--- a/src/CSET/recipes/generic_level_domain_mean_time_series_case_aggregation_all.yaml
+++ b/src/CSET/recipes/generic_level_domain_mean_time_series_case_aggregation_all.yaml
@@ -16,11 +16,11 @@ steps:
         coordinate: $LEVELTYPE
         levels: $LEVEL
 
+  - operator: aggregate.ensure_aggregatable_across_cases
+
   - operator: collapse.collapse
     coordinate: [grid_latitude, grid_longitude]
     method: MEAN
-
-  - operator: aggregate.ensure_aggregatable_across_cases
 
   - operator: collapse.collapse_by_validity_time
     method: SEQ

--- a/src/CSET/recipes/generic_level_domain_mean_time_series_case_aggregation_hour_of_day.yaml
+++ b/src/CSET/recipes/generic_level_domain_mean_time_series_case_aggregation_hour_of_day.yaml
@@ -20,11 +20,11 @@ steps:
         coordinate: $LEVELTYPE
         levels: $LEVEL
 
+  - operator: aggregate.ensure_aggregatable_across_cases
+
   - operator: collapse.collapse
     coordinate: [grid_latitude, grid_longitude]
     method: MEAN
-
-  - operator: aggregate.ensure_aggregatable_across_cases
 
   - operator: collapse.collapse_by_hour_of_day
     method: MEAN

--- a/src/CSET/recipes/generic_level_domain_mean_time_series_case_aggregation_lead_time.yaml
+++ b/src/CSET/recipes/generic_level_domain_mean_time_series_case_aggregation_lead_time.yaml
@@ -20,11 +20,11 @@ steps:
         coordinate: $LEVELTYPE
         levels: $LEVEL
 
+  - operator: aggregate.ensure_aggregatable_across_cases
+
   - operator: collapse.collapse
     coordinate: [grid_latitude, grid_longitude]
     method: MEAN
-
-  - operator: aggregate.ensure_aggregatable_across_cases
 
   - operator: collapse.collapse
     coordinate: "forecast_reference_time"

--- a/src/CSET/recipes/generic_level_domain_mean_time_series_case_aggregation_validity_time.yaml
+++ b/src/CSET/recipes/generic_level_domain_mean_time_series_case_aggregation_validity_time.yaml
@@ -20,11 +20,11 @@ steps:
         coordinate: $LEVELTYPE
         levels: $LEVEL
 
+  - operator: aggregate.ensure_aggregatable_across_cases
+
   - operator: collapse.collapse
     coordinate: [grid_latitude, grid_longitude]
     method: MEAN
-
-  - operator: aggregate.ensure_aggregatable_across_cases
 
   - operator: collapse.collapse_by_validity_time
     method: MEAN

--- a/src/CSET/recipes/generic_level_domain_mean_vertical_profile_series_case_aggregation_all.yaml
+++ b/src/CSET/recipes/generic_level_domain_mean_vertical_profile_series_case_aggregation_all.yaml
@@ -18,11 +18,11 @@ steps:
         coordinate: $LEVELTYPE
         levels: "*"
 
+  - operator: aggregate.ensure_aggregatable_across_cases
+
   - operator: collapse.collapse
     coordinate: [grid_latitude, grid_longitude]
     method: MEAN
-
-  - operator: aggregate.ensure_aggregatable_across_cases
 
   - operator: collapse.collapse
     coordinate: [time]

--- a/src/CSET/recipes/generic_level_domain_mean_vertical_profile_series_case_aggregation_hour_of_day.yaml
+++ b/src/CSET/recipes/generic_level_domain_mean_vertical_profile_series_case_aggregation_hour_of_day.yaml
@@ -21,11 +21,11 @@ steps:
     subarea_type: $SUBAREA_TYPE
     subarea_extent: $SUBAREA_EXTENT
 
+  - operator: aggregate.ensure_aggregatable_across_cases
+
   - operator: collapse.collapse
     coordinate: [grid_latitude, grid_longitude]
     method: MEAN
-
-  - operator: aggregate.ensure_aggregatable_across_cases
 
   - operator: collapse.collapse_by_hour_of_day
     method: MEAN

--- a/src/CSET/recipes/generic_level_domain_mean_vertical_profile_series_case_aggregation_lead_time.yaml
+++ b/src/CSET/recipes/generic_level_domain_mean_vertical_profile_series_case_aggregation_lead_time.yaml
@@ -21,11 +21,11 @@ steps:
     subarea_type: $SUBAREA_TYPE
     subarea_extent: $SUBAREA_EXTENT
 
+  - operator: aggregate.ensure_aggregatable_across_cases
+
   - operator: collapse.collapse
     coordinate: [grid_latitude, grid_longitude]
     method: MEAN
-
-  - operator: aggregate.ensure_aggregatable_across_cases
 
   - operator: collapse.collapse
     coordinate: "forecast_reference_time"

--- a/src/CSET/recipes/generic_level_domain_mean_vertical_profile_series_case_aggregation_validity_time.yaml
+++ b/src/CSET/recipes/generic_level_domain_mean_vertical_profile_series_case_aggregation_validity_time.yaml
@@ -21,11 +21,11 @@ steps:
     subarea_type: $SUBAREA_TYPE
     subarea_extent: $SUBAREA_EXTENT
 
+  - operator: aggregate.ensure_aggregatable_across_cases
+
   - operator: collapse.collapse
     coordinate: [grid_latitude, grid_longitude]
     method: MEAN
-
-  - operator: aggregate.ensure_aggregatable_across_cases
 
   - operator: collapse.collapse_by_validity_time
     method: MEAN

--- a/src/CSET/recipes/generic_surface_domain_mean_time_series_case_aggregation_all.yaml
+++ b/src/CSET/recipes/generic_surface_domain_mean_time_series_case_aggregation_all.yaml
@@ -24,11 +24,11 @@ steps:
         coordinate: "pressure"
         levels: []
 
+  - operator: aggregate.ensure_aggregatable_across_cases
+
   - operator: collapse.collapse
     coordinate: [grid_latitude, grid_longitude]
     method: MEAN
-
-  - operator: aggregate.ensure_aggregatable_across_cases
 
   - operator: collapse.collapse_by_validity_time
     method: SEQ

--- a/src/CSET/recipes/generic_surface_domain_mean_time_series_case_aggregation_hour_of_day.yaml
+++ b/src/CSET/recipes/generic_surface_domain_mean_time_series_case_aggregation_hour_of_day.yaml
@@ -26,11 +26,11 @@ steps:
     subarea_type: $SUBAREA_TYPE
     subarea_extent: $SUBAREA_EXTENT
 
+  - operator: aggregate.ensure_aggregatable_across_cases
+
   - operator: collapse.collapse
     coordinate: [grid_latitude, grid_longitude]
     method: MEAN
-
-  - operator: aggregate.ensure_aggregatable_across_cases
 
   - operator: collapse.collapse_by_hour_of_day
     method: MEAN

--- a/src/CSET/recipes/generic_surface_domain_mean_time_series_case_aggregation_lead_time.yaml
+++ b/src/CSET/recipes/generic_surface_domain_mean_time_series_case_aggregation_lead_time.yaml
@@ -26,11 +26,11 @@ steps:
     subarea_type: $SUBAREA_TYPE
     subarea_extent: $SUBAREA_EXTENT
 
+  - operator: aggregate.ensure_aggregatable_across_cases
+
   - operator: collapse.collapse
     coordinate: [grid_latitude, grid_longitude]
     method: MEAN
-
-  - operator: aggregate.ensure_aggregatable_across_cases
 
   - operator: collapse.collapse
     coordinate: "forecast_reference_time"

--- a/src/CSET/recipes/generic_surface_domain_mean_time_series_case_aggregation_validity_time.yaml
+++ b/src/CSET/recipes/generic_surface_domain_mean_time_series_case_aggregation_validity_time.yaml
@@ -26,11 +26,11 @@ steps:
     subarea_type: $SUBAREA_TYPE
     subarea_extent: $SUBAREA_EXTENT
 
+  - operator: aggregate.ensure_aggregatable_across_cases
+
   - operator: collapse.collapse
     coordinate: [grid_latitude, grid_longitude]
     method: MEAN
-
-  - operator: aggregate.ensure_aggregatable_across_cases
 
   - operator: collapse.collapse_by_validity_time
     method: MEAN

--- a/tests/operators/test_collapse.py
+++ b/tests/operators/test_collapse.py
@@ -76,6 +76,17 @@ def test_collapse_percentile(cube):
     assert repr(collapsed_cube) == expected_cube
 
 
+def test_collapse_multi_non_overlapping(long_forecast_multi_day):
+    """Identify when inputs have non-overlapping cubes."""
+    cube_day1 = long_forecast_multi_day[0:24, 0, :, :]
+    cube_day2 = long_forecast_multi_day[24:48, 2, :, :]
+    non_overlap_cubelist = iris.cube.CubeList([cube_day1, cube_day2])
+    with pytest.raises(
+        ValueError, match="No overlapping times detected in input cubes."
+    ):
+        collapse.collapse(non_overlap_cubelist, "time", "MEAN")
+
+
 def test_collapse_by_hour_of_day(long_forecast):
     """Convert and aggregates time dimension by hour of day."""
     collapsed_cube = collapse.collapse_by_hour_of_day(long_forecast, "MEAN")
@@ -211,11 +222,8 @@ def test_collapse_by_lead_time_single_cube(long_forecast_multi_day):
 
 def test_collapse_by_hour_of_day_multi_non_overlapping(long_forecast_multi_day):
     """Identify when inputs have non-overlapping cubes."""
-    print(long_forecast_multi_day)
     cube_day1 = long_forecast_multi_day[0:24, 0, :, :]
     cube_day2 = long_forecast_multi_day[24:48, 2, :, :]
-    print(cube_day1.coord("time"))
-    print(cube_day2.coord("time"))
     non_overlap_cubelist = iris.cube.CubeList([cube_day1, cube_day2])
     with pytest.raises(
         ValueError, match="No overlapping times detected in input cubes."


### PR DESCRIPTION
<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->
Fixes #1532.
Adds the check for overlapping times if multi-model inputs to the generic collapse.py function. This enables removal of the temporary _remove_time0 function call from read.py (was in preprocess.py).
Note this requires updates to aggregation recipes to first call ensure_aggregatable_across_cases to organise input cubelists before being able to check on compatibility of input times.  

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [x] Documentation has been updated to reflect change.
- [x] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
