### PR TITLE
Error when no cubes loaded by read.read_cubes

### DIFF
--- a/src/CSET/operators/read.py
+++ b/src/CSET/operators/read.py
@@ -20,7 +20,6 @@ import functools
 import glob
 import itertools
 import logging
-import warnings
 from pathlib import Path
 from typing import Literal
 
@@ -38,8 +37,8 @@ from CSET.operators._stash_to_lfric import STASH_TO_LFRIC
 from CSET.operators._utils import get_cube_yxcoordname
 
 
-class NoDataWarning(UserWarning):
-    """Warning that no data has been loaded."""
+class NoDataError(FileNotFoundError):
+    """Error that no data has been loaded."""
 
 
 def read_cube(
@@ -201,9 +200,7 @@ def read_cubes(
 
     logging.info("Loaded cubes: %s", cubes)
     if len(cubes) == 0:
-        warnings.warn(
-            "No cubes loaded, check your constraints!", NoDataWarning, stacklevel=2
-        )
+        raise NoDataError("No cubes loaded, check your constraints!")
     return cubes
 
 

--- a/tests/operators/test_read.py
+++ b/tests/operators/test_read.py
@@ -39,11 +39,10 @@ def test_read_cubes():
         assert repr(cube) in expected_cubes
 
 
-def test_read_cubes_no_cubes_warning():
-    """Warning emitted when constraint gives no cubes."""
-    with pytest.warns(UserWarning, match="No cubes loaded"):
-        cubes = read.read_cubes("tests/test_data/air_temp.nc", "non-existent")
-    assert len(cubes) == 0
+def test_read_cubes_no_cubes_exception():
+    """Exception raised when constraint gives no cubes."""
+    with pytest.raises(read.NoDataError):
+        read.read_cubes("tests/test_data/air_temp.nc", "non-existent")
 
 
 def test_read_cubes_ensemble_with_realization_coord():


### PR DESCRIPTION
There are no circumstances I can think of where it would be useful to load no cubes. By explicitly erroring we make it easier to see what was wrong, rather than getting an obscure message when the next operator is given an empty CubeList.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [x] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
