### PR TITLE
Normalise shebangs to use `/usr/bin/env`

### DIFF
--- a/scripts/generate_rose_meta.py
+++ b/scripts/generate_rose_meta.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python3
+#!/usr/bin/env python3
 # © Crown copyright, Met Office (2022-2025) and CSET contributors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/scripts/sort_json.py
+++ b/scripts/sort_json.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python3
+#!/usr/bin/env python3
 # © Crown copyright, Met Office (2022-2024) and CSET contributors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/CSET/cset_workflow/app/assign_model_colours/bin/assign_model_colours.py
+++ b/src/CSET/cset_workflow/app/assign_model_colours/bin/assign_model_colours.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python3
+#!/usr/bin/env python3
 # © Crown copyright, Met Office (2022-2025) and CSET contributors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/CSET/cset_workflow/app/fetch_fcst/bin/fetch-data-filesystem.py
+++ b/src/CSET/cset_workflow/app/fetch_fcst/bin/fetch-data-filesystem.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python3
+#!/usr/bin/env python3
 
 """Retrieve files from the filesystem."""
 

--- a/src/CSET/cset_workflow/app/fetch_fcst/bin/fetch-data-http.py
+++ b/src/CSET/cset_workflow/app/fetch_fcst/bin/fetch-data-http.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python3
+#!/usr/bin/env python3
 
 """Retrieve files via HTTP."""
 

--- a/src/CSET/cset_workflow/app/fetch_fcst/bin/fetch-data-mass.py
+++ b/src/CSET/cset_workflow/app/fetch_fcst/bin/fetch-data-mass.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python3
+#!/usr/bin/env python3
 
 """Retrieve files from MASS."""
 

--- a/src/CSET/cset_workflow/app/finish_website/bin/finish_website.py
+++ b/src/CSET/cset_workflow/app/finish_website/bin/finish_website.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python3
+#!/usr/bin/env python3
 # © Crown copyright, Met Office (2022-2025) and CSET contributors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/CSET/cset_workflow/app/housekeeping/bin/housekeep.sh
+++ b/src/CSET/cset_workflow/app/housekeeping/bin/housekeep.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # Removes intermediatory files to free up disk space. How thoroughly they are

--- a/src/CSET/cset_workflow/app/install_website_skeleton/bin/install-website.sh
+++ b/src/CSET/cset_workflow/app/install_website_skeleton/bin/install-website.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copies the static files for the web interface into the correct location, and
 # creates a symbolic link under the web server's document root.

--- a/src/CSET/cset_workflow/app/run_cset_recipe/bin/run_cset_recipe.py
+++ b/src/CSET/cset_workflow/app/run_cset_recipe/bin/run_cset_recipe.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python3
+#!/usr/bin/env python3
 # © Crown copyright, Met Office (2022-2025) and CSET contributors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/CSET/cset_workflow/app/send_email/bin/send_email.py
+++ b/src/CSET/cset_workflow/app/send_email/bin/send_email.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python3
+#!/usr/bin/env python3
 # © Crown copyright, Met Office (2022-2025) and CSET contributors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/CSET/cset_workflow/install_restricted_files.sh
+++ b/src/CSET/cset_workflow/install_restricted_files.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 IFS="$(printf '\n\t')"

--- a/src/CSET/extract_workflow.py
+++ b/src/CSET/extract_workflow.py
@@ -37,9 +37,9 @@ def make_script_executable(p: Path):
     """Make scripts (starting with a shebang) executable."""
     if p.is_file():
         with open(p, "rb") as fd:
-            shebang = fd.read(2)
-        # Assume the first two bytes of a script are #!
-        if shebang == b"#!":
+            shebang = fd.read(14)
+        # Assume the first 14 bytes of a script are #!/usr/bin/env
+        if shebang == b"#!/usr/bin/env":
             logger.debug("Changing file mode to executable: %s", p)
             mode = p.stat().st_mode
             # Make executable by all who can read.

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -54,7 +54,7 @@ def test_save_graph_auto_open_xdg_open(tmp_path: Path, monkeypatch):
     """Test the auto-opening of the graph with (a mocked) xdg-open."""
     xdg_open = tmp_path / "xdg-open"
     with open(xdg_open, "wt", encoding="UTF-8") as fp:
-        fp.write("#!/bin/bash\ntrue")
+        fp.write("#!/usr/bin/env bash\ntrue")
     xdg_open.chmod(stat.S_IRUSR | stat.S_IXUSR)
     monkeypatch.setenv("PATH", str(tmp_path), prepend=os.pathsep)
     graph.save_graph(Path("tests/test_data/plot_instant_air_temp.yaml"), auto_open=True)
@@ -68,7 +68,7 @@ def test_save_graph_auto_open_no_xdg_open(tmp_path: Path, monkeypatch):
     """
     xdg_open = tmp_path / "xdg-open"
     with open(xdg_open, "wt", encoding="UTF-8") as fp:
-        fp.write("#!/bin/bash\nfalse")
+        fp.write("#!/usr/bin/env bash\nfalse")
     xdg_open.chmod(stat.S_IRUSR | stat.S_IXUSR)
     monkeypatch.setenv("PATH", str(tmp_path), prepend=os.pathsep)
     graph.save_graph(Path("tests/test_data/plot_instant_air_temp.yaml"), auto_open=True)

--- a/tests/workflow_utils/test_install_workflow.py
+++ b/tests/workflow_utils/test_install_workflow.py
@@ -68,7 +68,7 @@ def test_make_script_executable_not_script(tmp_path):
 
 
 def test_make_script_executable_short_file(tmp_path):
-    """Short files (<2 bytes) are not marked executable."""
+    """Short files (<14 bytes) are not marked executable."""
     f = tmp_path / "file"
     # Mode is u=rw,g=r,o=r
     f.touch(mode=stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH)


### PR DESCRIPTION
<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

Mostly done for visual consistency, but this does have a couple positive technical effects:

1. Using /usr/bin/env should be more portable to systems like MacOS with no or ancient versions of bash.
2. Using `#!/usr/bin/env` for script detection should avoid marking the flow.cylc as executable.

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [x] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
