### PR TITLE
Add sstrip utility function

### DIFF
--- a/src/CSET/_common.py
+++ b/src/CSET/_common.py
@@ -21,6 +21,7 @@ import logging
 import re
 from collections.abc import Iterable
 from pathlib import Path
+from textwrap import dedent
 
 import ruamel.yaml
 
@@ -371,3 +372,25 @@ def sort_dict(d: dict) -> dict:
         k: sort_dict(v) if isinstance(v, dict) else v
         for k, v in human_sorted(d.items())
     }
+
+
+def sstrip(text):
+    """Dedent and strip text.
+
+    Parameters
+    ----------
+    text: str
+        The string to strip.
+
+    Examples
+    --------
+    >>> print(sstrip('''
+    ...     foo
+    ...       bar
+    ...     baz
+    ... '''))
+    foo
+      bar
+    baz
+    """
+    return dedent(text).strip()

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -303,3 +303,23 @@ def test_sort_dicts():
     """Test recursively sorting a dictionary."""
     d = {"b": {"ba": 1, "bb": 2}, "a": {"ab": 2, "aa": 1}}
     assert common.sort_dict(d) == {"a": {"aa": 1, "ab": 2}, "b": {"ba": 1, "bb": 2}}
+
+
+def test_sstrip():
+    """Check strings are unindented and stripped properly."""
+    test_cases = [
+        ("normal", "normal"),
+        (" leading", "leading"),
+        ("trailing ", "trailing"),
+        (" both ", "both"),
+        ("", ""),
+        ("    indented\n    lines", "indented\nlines"),
+        ("not indented\n  indented", "not indented\n  indented"),
+        ("  indented\n    more indented", "indented\n  more indented"),
+        ("\n\n  indented\n\n", "indented"),
+        (" \n    indented\n    indented", "indented\nindented"),
+        ("internal \ntrailing \nspace", "internal \ntrailing \nspace"),
+    ]
+    # Test all those cases.
+    for case, expected in test_cases:
+        assert common.sstrip(case) == expected


### PR DESCRIPTION
A useful helper function for allowing multiline strings to be indented with the test of the code.

This function is not used yet, but I wanted to get it ahead of using it in a coming change, to make review easier.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [ ] All tests and CI checks pass.
- [ ] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [ ] Marked the PR as ready to review.
