### PR TITLE
Add return type for `tmp_working_dir` fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,8 @@
 https://docs.pytest.org/en/latest/reference/fixtures.html#conftest-py-sharing-fixtures-across-multiple-files
 """
 
+from pathlib import Path
+
 import iris.cube
 import pytest
 
@@ -24,7 +26,7 @@ from CSET.operators import constraints, filters, read
 
 
 @pytest.fixture()
-def tmp_working_dir(tmp_path, monkeypatch):
+def tmp_working_dir(tmp_path, monkeypatch) -> Path:
     """Change the working directory for a test."""
     monkeypatch.chdir(tmp_path)
     return tmp_path


### PR DESCRIPTION
Largely to satisfy my type checker, but it also helps editor suggestions.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [ ] All tests and CI checks pass.
- [ ] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [ ] Marked the PR as ready to review.
