### PR TITLE
Parse recipe separately from executing it

### DIFF
--- a/src/CSET/__init__.py
+++ b/src/CSET/__init__.py
@@ -225,7 +225,7 @@ def setup_logging(verbosity: int):
 
 
 def _bake_command(args, unparsed_args):
-    from CSET._common import iter_maybe, parse_variable_options
+    from CSET._common import iter_maybe, parse_recipe, parse_variable_options
     from CSET.operators import execute_recipe
 
     # Convert --input_dir=... to INPUT_PATHS recipe variable.
@@ -234,10 +234,10 @@ def _bake_command(args, unparsed_args):
         unparsed_args.append(f"--INPUT_PATHS={abs_paths}")
 
     recipe_variables = parse_variable_options(unparsed_args)
+    recipe = parse_recipe(args.recipe, recipe_variables)
     execute_recipe(
-        args.recipe,
+        recipe,
         args.output_dir,
-        recipe_variables,
         args.style_file,
         args.plot_resolution,
         args.skip_write,

--- a/src/CSET/__init__.py
+++ b/src/CSET/__init__.py
@@ -225,15 +225,10 @@ def setup_logging(verbosity: int):
 
 
 def _bake_command(args, unparsed_args):
-    from CSET._common import iter_maybe, parse_recipe, parse_variable_options
+    from CSET._common import parse_recipe, parse_variable_options
     from CSET.operators import execute_recipe
 
-    # Convert --input_dir=... to INPUT_PATHS recipe variable.
-    if args.input_dir:
-        abs_paths = [str(Path(p).absolute()) for p in iter_maybe(args.input_dir)]
-        unparsed_args.append(f"--INPUT_PATHS={abs_paths}")
-
-    recipe_variables = parse_variable_options(unparsed_args)
+    recipe_variables = parse_variable_options(unparsed_args, args.input_dir)
     recipe = parse_recipe(args.recipe, recipe_variables)
     execute_recipe(
         recipe,

--- a/src/CSET/_common.py
+++ b/src/CSET/_common.py
@@ -139,7 +139,9 @@ def get_recipe_metadata() -> dict:
         return {}
 
 
-def parse_variable_options(arguments: list[str]) -> dict:
+def parse_variable_options(
+    arguments: list[str], input_dir: str | list[str] | None = None
+) -> dict:
     """Parse a list of arguments into a dictionary of variables.
 
     The variable name arguments start with two hyphen-minus (`--`), consisting
@@ -150,6 +152,8 @@ def parse_variable_options(arguments: list[str]) -> dict:
     ----------
     arguments: list[str]
         List of arguments, e.g: `["--LEVEL", "2", "--STASH=m01s01i001"]`
+    input_dir: str | list[str], optional
+        List of input directories to add into the returned variables.
 
     Returns
     -------
@@ -161,6 +165,10 @@ def parse_variable_options(arguments: list[str]) -> dict:
     ValueError
         If any arguments cannot be parsed.
     """
+    # Convert --input_dir=... to INPUT_PATHS recipe variable.
+    if input_dir is not None:
+        abs_paths = [str(Path(p).absolute()) for p in iter_maybe(input_dir)]
+        arguments.append(f"--INPUT_PATHS={abs_paths}")
     recipe_variables = {}
     i = 0
     while i < len(arguments):

--- a/src/CSET/operators/__init__.py
+++ b/src/CSET/operators/__init__.py
@@ -25,7 +25,6 @@ from iris import FUTURE
 
 # Import operators here so they are exported for use by recipes.
 import CSET.operators
-from CSET._common import parse_recipe
 from CSET.operators import (
     ageofair,
     aggregate,
@@ -163,9 +162,8 @@ def create_diagnostic_archive():
 
 
 def execute_recipe(
-    recipe_yaml: Path | str,
+    recipe: dict,
     output_directory: Path,
-    recipe_variables: dict = None,
     style_file: Path = None,
     plot_resolution: int = None,
     skip_write: bool = None,
@@ -174,14 +172,10 @@ def execute_recipe(
 
     Parameters
     ----------
-    recipe_yaml: Path | str
-        Path to a file containing, or a string of, a recipe's YAML describing
-        the operators that need running. If a Path is provided it is opened and
-        read.
+    recipe: dict
+        Parsed recipe.
     output_directory: Path
         Pathlike indicating desired location of output.
-    recipe_variables: dict, optional
-        Dictionary of variables for the recipe.
     style_file: Path, optional
         Path to a style file.
     plot_resolution: int, optional
@@ -200,7 +194,6 @@ def execute_recipe(
     TypeError
         The provided recipe is not a stream or Path.
     """
-    recipe = parse_recipe(recipe_yaml, recipe_variables)
     # Create output directory.
     try:
         output_directory.mkdir(parents=True, exist_ok=True)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -147,6 +147,30 @@ def test_parse_variable_options_quoted():
     assert actual == expected
 
 
+def test_parse_variable_options_input_dir_conversion():
+    """--input-dir argument is converted to --INPUT_PATHS recipe variable."""
+    p = str(Path("foo").absolute())
+    expected = (p, [p])
+
+    # Check --input-dir is converted.
+    input_dir = "foo"
+    unparsed_args = []
+    variables = common.parse_variable_options(
+        arguments=unparsed_args, input_dir=input_dir
+    )
+    assert "INPUT_PATHS" in variables
+    assert variables["INPUT_PATHS"] in expected
+
+    # Check --INPUT_PATHS is directly used.
+    input_dir = None
+    unparsed_args = ["--INPUT_PATHS", p]
+    variables = common.parse_variable_options(
+        arguments=unparsed_args, input_dir=input_dir
+    )
+    assert "INPUT_PATHS" in variables
+    assert variables["INPUT_PATHS"] in expected
+
+
 def test_template_variables():
     """Multiple variables are correctly templated into recipe."""
     recipe = {

--- a/tests/test_execute_recipe.py
+++ b/tests/test_execute_recipe.py
@@ -20,6 +20,7 @@ from pathlib import Path
 
 import pytest
 
+import CSET._common
 import CSET.operators
 
 
@@ -50,32 +51,33 @@ def test_get_operator_exception_not_callable():
 def test_execute_recipe(tmp_path: Path):
     """Execute recipe to test happy case (this is really an integration test)."""
     variables = {"INPUT_PATHS": str(Path.cwd() / "tests/test_data/air_temp.nc")}
-    recipe = Path("tests/test_data/plot_instant_air_temp.yaml")
-    CSET.operators.execute_recipe(recipe, tmp_path, recipe_variables=variables)
+    recipe_file = Path("tests/test_data/plot_instant_air_temp.yaml")
+    recipe = CSET._common.parse_recipe(recipe_file, variables)
+    CSET.operators.execute_recipe(recipe, tmp_path)
 
 
 def test_execute_recipe_edge_cases(tmp_path: Path):
     """Test weird edge cases. Also tests data paths not being pathlib Paths."""
     variables = {"INPUT_PATHS": str(Path.cwd() / "tests/test_data/air_temp.nc")}
-    recipe = Path("tests/test_data/noop_recipe.yaml")
-    CSET.operators.execute_recipe(recipe, tmp_path, recipe_variables=variables)
+    recipe_file = Path("tests/test_data/noop_recipe.yaml")
+    recipe = CSET._common.parse_recipe(recipe_file, variables)
+    CSET.operators.execute_recipe(recipe, tmp_path)
 
 
 def test_execute_recipe_invalid_output_dir(tmp_path: Path):
     """Exception raised if output directory can't be created."""
-    variables = {"INPUT_PATHS": str(Path.cwd() / "tests/test_data/air_temp.nc")}
-    recipe = '{"steps":[{"operator": misc.noop}]}'
+    recipe = {"steps": [{"operator": "misc.noop"}]}
     output_dir = tmp_path / "actually_a_file"
     output_dir.touch()
     with pytest.raises((FileExistsError, NotADirectoryError)):
-        CSET.operators.execute_recipe(recipe, output_dir, recipe_variables=variables)
+        CSET.operators.execute_recipe(recipe, output_dir)
 
 
 def test_execute_recipe_style_file_metadata_written(tmp_path: Path):
     """Style file path metadata written out."""
     style_file_path = "/test/style_file_path.json"
     CSET.operators.execute_recipe(
-        '{"steps":[{"operator": misc.noop}]}',
+        {"steps": [{"operator": "misc.noop"}]},
         tmp_path,
         style_file=Path(style_file_path),
     )
@@ -87,7 +89,7 @@ def test_execute_recipe_style_file_metadata_written(tmp_path: Path):
 def test_execute_recipe_plot_resolution_metadata_written(tmp_path: Path):
     """Style file path metadata written out."""
     CSET.operators.execute_recipe(
-        '{"steps":[{"operator": misc.noop}]}', tmp_path, plot_resolution=72
+        {"steps": [{"operator": "misc.noop"}]}, tmp_path, plot_resolution=72
     )
     with open(tmp_path / "meta.json", "rb") as fp:
         metadata = json.load(fp)
@@ -97,7 +99,7 @@ def test_execute_recipe_plot_resolution_metadata_written(tmp_path: Path):
 def test_execute_recipe_skip_write_metadata_written(tmp_path: Path):
     """Skip write metadata written out."""
     CSET.operators.execute_recipe(
-        '{"steps":[{"operator": misc.noop}]}', tmp_path, skip_write=True
+        {"steps": [{"operator": "misc.noop"}]}, tmp_path, skip_write=True
     )
     with open(tmp_path / "meta.json", "rb") as fp:
         metadata = json.load(fp)


### PR DESCRIPTION
This allows easier testing and allows using the recipe parser when not executing a recipe, such as when parbaking.

Additionally the handling of the `--input-dir` argument is moved inside parse_variable_options so all the parsing code is in one place.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [ ] All tests and CI checks pass.
- [ ] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [ ] Marked the PR as ready to review.
