### PR TITLE
Add `b64json` jinja utility function

### DIFF
--- a/src/CSET/cset_workflow/app/assign_model_colours/bin/assign_model_colours.py
+++ b/src/CSET/cset_workflow/app/assign_model_colours/bin/assign_model_colours.py
@@ -18,6 +18,7 @@
 import itertools
 import json
 import os
+from base64 import b64decode
 
 # matplotlib tab20[::2] + tab20[1::2]
 DISCRETE_COLORS = (
@@ -70,7 +71,7 @@ def create_model_colour_mapping(model_names: list[str]) -> dict:
 
 def main():
     """Create model name <-> colour mappings add to a copy of the style file."""
-    model_names = json.loads(os.environ["MODEL_NAMES"])
+    model_names = json.loads(b64decode(os.environ["MODEL_NAMES"]))
     print(f"Processing models: {', '.join(model_names)}")
 
     style_file = os.getenv("COLORBAR_FILE")

--- a/src/CSET/cset_workflow/flow.cylc
+++ b/src/CSET/cset_workflow/flow.cylc
@@ -5,7 +5,7 @@ description = Workflow for running CSET.
 URL = https://metoffice.github.io/CSET
 
 # Import all of our Jinja utilities for use in the workflow.
-{% from "jinja_utils" import get_model_names, get_model_ids, get_models, glob, max, min, zip, sanitise_task_name %}
+{% from "jinja_utils" import b64json, get_model_names, get_model_ids, get_models, glob, max, min, zip, sanitise_task_name %}
 # Load a list a model detail dictionaries.
 {% set models = get_models(ROSE_SUITE_VARIABLES) %}
 {% set model_ids = get_model_ids(models) %}
@@ -170,7 +170,7 @@ final cycle point = {{CSET_TRIAL_END_DATE}}
     execution time limit = PT5M
         [[[environment]]]
         COLORBAR_FILE = {{COLORBAR_FILE}}
-        MODEL_NAMES = '{{model_names}}'
+        MODEL_NAMES = {{ b64json(models|map(attribute="name")|list) }}
 
     {% for model in models %}
     [[fetch_fcst_m{{model["id"]}}]]

--- a/src/CSET/cset_workflow/lib/python/jinja_utils.py
+++ b/src/CSET/cset_workflow/lib/python/jinja_utils.py
@@ -1,4 +1,4 @@
-# © Crown copyright, Met Office (2022-2024) and CSET contributors.
+# © Crown copyright, Met Office (2022-2025) and CSET contributors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
 
 """Useful functions for the workflow."""
 
+import base64
 import json
 from builtins import max, min, zip
 from glob import glob
@@ -94,3 +95,13 @@ def sanitise_task_name(s: str) -> str:
     if s.lower().startswith("_cylc"):
         s = f"sanitised_{s}"
     return s
+
+
+def b64json(d: dict | list) -> str:
+    """Encode an object as base64 encoded JSON for transport though cylc."""
+    new_d = d.copy()
+    if isinstance(new_d, dict):
+        # Remove circular reference to ROSE_SUITE_VARIABLES.
+        new_d.pop("ROSE_SUITE_VARIABLES", None)
+    output = base64.b64encode(json.dumps(new_d).encode()).decode()
+    return output

--- a/tests/workflow_utils/test_jinja_utils.py
+++ b/tests/workflow_utils/test_jinja_utils.py
@@ -1,0 +1,60 @@
+# © Crown copyright, Met Office (2022-2025) and CSET contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for jinja_utils functions."""
+
+import base64
+import json
+
+import CSET.cset_workflow.lib.python.jinja_utils as jinja_utils
+
+
+def test_b64json_list():
+    """Check a list can be encoded as base64ed JSON."""
+    input_list = [1, "two", 3.0]
+    expected = "WzEsICJ0d28iLCAzLjBd"
+    actual = jinja_utils.b64json(input_list)
+    assert actual == expected
+
+
+def test_b64json_dict():
+    """Check a dictionary can be encoded as base64ed JSON."""
+    input_dict = {"foo": 1, "bar": {"baz": 2}}
+    expected = "eyJmb28iOiAxLCAiYmFyIjogeyJiYXoiOiAyfX0="
+    actual = jinja_utils.b64json(input_dict)
+    assert actual == expected
+
+
+def test_b64json_remove_rose_suite_variables():
+    """Check reference to circular ROSE_SUITE_VARIABLES is removed."""
+    input_dict = {"foo": 1, "ROSE_SUITE_VARIABLES": 2, "bar": 3}
+    encoded = jinja_utils.b64json(input_dict)
+    assert "ROSE_SUITE_VARIABLES" not in json.loads(base64.b64decode(encoded))
+
+
+def test_get_models():
+    """Check a list of model dictionaries can be built."""
+    ROSE_SUITE_VARIABLES = {
+        "m1_name": "foo",
+        "m1_number": 1000,
+        "m2_name": "bar",
+        "m2_number": 2000,
+    }
+    models = jinja_utils.get_models(ROSE_SUITE_VARIABLES)
+    expected_models = [
+        {"id": 1, "name": "foo", "number": 1000},
+        {"id": 2, "name": "bar", "number": 2000},
+    ]
+    assert isinstance(models, list)
+    assert models == expected_models


### PR DESCRIPTION
<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

This allows transporting structured data from cylc into a task, without worrying about that information being mangled by the multiple layers of shell in between.

It is then used for safely transporting model names.

The jinja_utils functions that are not tested will be removed in #1332.

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [ ] All tests and CI checks pass.
- [ ] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [ ] Marked the PR as ready to review.
