### PR TITLE
Make the trial end date required

### DIFF
--- a/src/CSET/cset_workflow/flow.cylc
+++ b/src/CSET/cset_workflow/flow.cylc
@@ -15,17 +15,14 @@ URL = https://metoffice.github.io/CSET
 
 
 [scheduling]
-    # Initial and final cycle points cover the entire period of interest.
-    {% if CSET_CYCLING_MODE == "case_study" %}
-        initial cycle point = {{ min(CSET_CASE_DATES) }}
-        final cycle point = {{ max(CSET_CASE_DATES) }}
-    {% elif CSET_CYCLING_MODE == "trial" %}
-        initial cycle point = {{CSET_TRIAL_START_DATE}}
-        # End date can be blank.
-        {% if CSET_TRIAL_END_DATE|default(False) %}
-            final cycle point = {{CSET_TRIAL_END_DATE}}
-        {% endif %}
-    {% endif %}
+# Initial and final cycle points cover the entire period of interest.
+{% if CSET_CYCLING_MODE == "case_study" %}
+    initial cycle point = {{ CSET_CASE_DATES|min }}
+    final cycle point = {{ CSET_CASE_DATES|max }}
+{% elif CSET_CYCLING_MODE == "trial" %}
+    initial cycle point = {{CSET_TRIAL_START_DATE}}
+    final cycle point = {{CSET_TRIAL_END_DATE}}
+{% endif %}
 
     [[special tasks]]
         # cycle_complete depends on its previous instance. We then don't need to


### PR DESCRIPTION
It was already effectively required to produce any output, so this just makes it enforced by cylc validate.

(There might be minor conflicts of the indentation with #1603)

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [ ] All tests and CI checks pass.
- [ ] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [ ] Marked the PR as ready to review.
