### PR TITLE
Log rather than warn for existing unpacked recipes

### DIFF
--- a/src/CSET/recipes/__init__.py
+++ b/src/CSET/recipes/__init__.py
@@ -17,15 +17,10 @@
 import importlib.resources
 import logging
 import sys
-import warnings
 from collections.abc import Iterable
 from pathlib import Path
 
 from ruamel.yaml import YAML
-
-
-class FileExistsWarning(UserWarning):
-    """Warning a file already exists, and some unusual action shall be taken."""
 
 
 def _version_agnostic_importlib_resources_file() -> Path:
@@ -58,7 +53,7 @@ def _recipe_files_in_tree(
             yield from _recipe_files_in_tree(recipe_name, file)
 
 
-def _get_recipe_file(recipe_name: str, input_dir: Path = None) -> Path:
+def _get_recipe_file(recipe_name: str, input_dir: Path | None = None) -> Path:
     """Return a Path to the recipe file."""
     if input_dir is None:
         input_dir = _version_agnostic_importlib_resources_file()
@@ -94,11 +89,7 @@ def unpack_recipe(recipe_dir: Path, recipe_name: str) -> None:
     output_file = recipe_dir / file.name
     logging.debug("Saving recipe to %s", output_file)
     if output_file.exists():
-        warnings.warn(
-            f"{file.name} already exists in target directory, skipping.",
-            FileExistsWarning,
-            stacklevel=2,
-        )
+        logging.info("%s already exists in target directory, skipping.", file.name)
         return
     logging.info("Unpacking %s to %s", file.name, output_file)
     output_file.write_bytes(file.read_bytes())

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -40,7 +40,10 @@ def test_unpack_recipes(tmp_path: Path, caplog):
     assert (tmp_path / "CAPE_ratio_plot.yaml").is_file()
     with caplog.at_level("INFO"):
         recipes.unpack_recipe(tmp_path, "CAPE_ratio_plot.yaml")
-    _, level, message = caplog.record_tuples[0]
+    # Filter out unrelated log messages in case we are testing in parallel.
+    _, level, message = next(
+        filter(lambda r: "already exists" in r[2], caplog.record_tuples)
+    )
     assert level == logging.INFO
     assert (
         message == "CAPE_ratio_plot.yaml already exists in target directory, skipping."

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -14,6 +14,7 @@
 
 """Recipe tests."""
 
+import logging
 from pathlib import Path
 
 import pytest
@@ -33,13 +34,17 @@ def test_recipe_files_in_tree_from_package():
     assert any("CAPE_ratio_plot.yaml" == path.name for path in files)
 
 
-def test_unpack(tmp_path: Path):
-    """Unpack recipes."""
+def test_unpack_recipes(tmp_path: Path, caplog):
+    """Unpack a recipe and check a log message is produced when files collide."""
     recipes.unpack_recipe(tmp_path, "CAPE_ratio_plot.yaml")
     assert (tmp_path / "CAPE_ratio_plot.yaml").is_file()
-    # Unpack everything and check a warning is produced when files collide.
-    with pytest.warns():
+    with caplog.at_level("INFO"):
         recipes.unpack_recipe(tmp_path, "CAPE_ratio_plot.yaml")
+    _, level, message = caplog.record_tuples[0]
+    assert level == logging.INFO
+    assert (
+        message == "CAPE_ratio_plot.yaml already exists in target directory, skipping."
+    )
 
 
 def test_unpack_recipes_exception_collision(tmp_path: Path):

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -80,7 +80,7 @@ def test_get_recipe_file_missing():
 
 
 def test_get_recipe_file_in_package():
-    """Get a recipe file from a the default location inside the package."""
+    """Get a recipe file from the default location inside the package."""
     file = recipes._get_recipe_file("CAPE_ratio_plot.yaml")
     assert file.is_file()
 


### PR DESCRIPTION
<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

A warning is too scary for a harmless occurrence, and we unpack existing recipes a lot inside the workflow.

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [x] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
