### PR TITLE
Add diagnostic for daily maximum temperature between 0900 UTC and 0900 UTC

### DIFF
--- a/src/CSET/operators/aggregate.py
+++ b/src/CSET/operators/aggregate.py
@@ -215,3 +215,46 @@ def add_hour_coordinate(
         return new_cubelist[0]
     else:
         return new_cubelist
+
+
+def rolling_window_time_aggregation(
+    cubes: iris.cube.Cube | iris.cube.CubeList, method: str, window: int
+) -> iris.cube.Cube | iris.cube.CubeList:
+    """Aggregate a cube along the time dimension using a rolling window.
+
+    Arguments
+    ---------
+    cubes: iris.cube.Cube | iris.cube.CubeList
+        Cube or Cubelist of any variable to be aggregated over a rolling window
+        in time.
+    method: str
+        Type of aggregate i.e. method: 'MAX', getattr creates
+        iris.analysis.MAX, etc.
+    window: int
+        The rolling window size.
+
+    Returns
+    -------
+    cube: iris.cube.Cube | iris.cube.CubeList
+        A Cube or Cubelist of the rolling window aggregate. The Cubes will have
+        a time dimension that is reduced in size to the original cube by the
+        window size.
+
+    Notes
+    -----
+    This opereator is designed to be used to help create daily maxima and minima
+    for any variable.
+    """
+    new_cubelist = iris.cube.CubeList()
+    for cube in iter_maybe(cubes):
+        # Use a rolling window in time to applied specified aggregation method
+        # over a specified window length.
+        window_cube = cube.rolling_window(
+            "time", getattr(iris.analysis, method), window
+        )
+        new_cubelist.append(window_cube)
+
+    if len(new_cubelist) == 1:
+        return new_cubelist[0]
+    else:
+        return new_cubelist

--- a/src/CSET/operators/constraints.py
+++ b/src/CSET/operators/constraints.py
@@ -279,6 +279,46 @@ def generate_area_constraint(
     return area_constraint
 
 
+def generate_hour_constraint(
+    hour_start: int,
+    hour_end: int = None,
+    **kwargs,
+) -> iris.Constraint:
+    """Generate an hour constraint between hour of day limits.
+
+    Operator that takes a set of hour of day limits and returns a constraint that
+    selects only hours within that time frame regardless of day.
+
+    Alternatively, the result can be constrained to a single hour by just entering
+    a starting hour.
+
+    Arguments
+    ---------
+    hour_start: int
+        The hour of day for the lower bound, within 0 to 23.
+    hour_end: int | None
+        The hour of day for the upper bound, within 0 to 23. Alternatively,
+        set to None if only one hour required.
+
+    Returns
+    -------
+    hour_constraint: iris.Constraint
+
+    Raises
+    ------
+    ValueError
+        If the provided arguments are outside of the range 0 to 23.
+    """
+    if hour_end is None:
+        hour_end = hour_start
+
+    if (hour_start < 0) or (hour_start > 23) or (hour_end < 0) or (hour_end > 23):
+        raise ValueError("Hours must be between 0 and 23 inclusive.")
+
+    hour_constraint = iris.Constraint(hour=lambda h: hour_start <= h.point <= hour_end)
+    return hour_constraint
+
+
 def combine_constraints(
     constraint: iris.Constraint = None, **kwargs
 ) -> iris.Constraint:


### PR DESCRIPTION
Add a diagnostic for daily maximum temperature between 0900 UTC and 0900 UTC. It utilises rolling_window aggregation and creates a new constraint based on hour of day, alongside recipes for the daily maximum temperature.

Fixes #1552

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [ ] All tests and CI checks pass.
- [ ] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [ ] Marked the PR as ready to review.
