### PR TITLE
Add constraint to remove single ensemble member

### DIFF
--- a/src/CSET/operators/constraints.py
+++ b/src/CSET/operators/constraints.py
@@ -299,6 +299,14 @@ def generate_remove_single_ensemble_member_constraint(
     Returns
     -------
         iris.Constraint
+
+    Notes
+    -----
+    This operator is primarily used to remove the control member to allow
+    ensemble metrics to be calculated without the control member. For
+    example, the ensemble mean is not normally calculated including the
+    control member. It is particularly useful to remove the control member
+    when it is not an equally-likely member of the ensemble.
     """
     return iris.Constraint(realization=lambda m: m.point != ens_member)
 

--- a/src/CSET/operators/constraints.py
+++ b/src/CSET/operators/constraints.py
@@ -293,7 +293,7 @@ def generate_remove_single_ensemble_member_constraint(
 
     Arguments
     ---------
-    ens_member: int
+    ensemble_member: int
         Default is 0. The ensemble member realization to remove.
 
     Returns

--- a/src/CSET/operators/constraints.py
+++ b/src/CSET/operators/constraints.py
@@ -279,6 +279,30 @@ def generate_area_constraint(
     return area_constraint
 
 
+def generate_remove_single_ensemble_member_constraint(
+    ens_member: int = 0, **kwargs
+) -> iris.Constraint:
+    """
+    Generate a constraint to remove a single ensemble member.
+
+    Operators that returns a constraint to remove the given ensemble member. By
+    default the ensemble member removed is the control member (assumed to have
+    a realization of zero). However, any ensemble member can be removed, thus
+    allowing a non-zero control member to be removed if the control is a
+    different member.
+
+    Arguments
+    ---------
+    ens_member: int
+        Default is 0. The ensemble member realization to remove.
+
+    Returns
+    -------
+        iris.Constraint
+    """
+    return iris.Constraint(realization=lambda m: m.point != ens_member)
+
+
 def combine_constraints(
     constraint: iris.Constraint = None, **kwargs
 ) -> iris.Constraint:

--- a/src/CSET/operators/constraints.py
+++ b/src/CSET/operators/constraints.py
@@ -280,7 +280,7 @@ def generate_area_constraint(
 
 
 def generate_remove_single_ensemble_member_constraint(
-    ens_member: int = 0, **kwargs
+    ensemble_member: int = 0, **kwargs
 ) -> iris.Constraint:
     """
     Generate a constraint to remove a single ensemble member.
@@ -308,7 +308,7 @@ def generate_remove_single_ensemble_member_constraint(
     control member. It is particularly useful to remove the control member
     when it is not an equally-likely member of the ensemble.
     """
-    return iris.Constraint(realization=lambda m: m.point != ens_member)
+    return iris.Constraint(realization=lambda m: m.point != ensemble_member)
 
 
 def combine_constraints(

--- a/tests/operators/test_constraints.py
+++ b/tests/operators/test_constraints.py
@@ -162,6 +162,28 @@ def test_generate_area_constraint_invalid_arguments():
         constraints.generate_area_constraint(None, None, None, 0)
 
 
+def test_generate_remove_single_ensemble_member_constraint():
+    """Generate a constraint to remove a single ensemble member using default value."""
+    single_member_constraint = (
+        constraints.generate_remove_single_ensemble_member_constraint()
+    )
+    assert (
+        "Constraint(coord_values={'realization': <function generate_remove_single_ensemble_member_constraint.<locals>.<lambda> at 0x"
+        in repr(single_member_constraint)
+    )
+
+
+def test_generate_remove_single_ensemble_member_constraint_any_value():
+    """Generate a constraint to remove a single ensemble member using chosen value."""
+    single_member_constraint = (
+        constraints.generate_remove_single_ensemble_member_constraint(2)
+    )
+    assert (
+        "Constraint(coord_values={'realization': <function generate_remove_single_ensemble_member_constraint.<locals>.<lambda> at 0x"
+        in repr(single_member_constraint)
+    )
+
+
 def test_combine_constraints():
     """Combine constraint."""
     stash_constraint = constraints.generate_stash_constraint("m01s03i236")

--- a/tests/operators/test_constraints.py
+++ b/tests/operators/test_constraints.py
@@ -176,7 +176,7 @@ def test_generate_remove_single_ensemble_member_constraint():
 def test_generate_remove_single_ensemble_member_constraint_any_value():
     """Generate a constraint to remove a single ensemble member using chosen value."""
     single_member_constraint = (
-        constraints.generate_remove_single_ensemble_member_constraint(2)
+        constraints.generate_remove_single_ensemble_member_constraint(ensemble_member=2)
     )
     assert (
         "Constraint(coord_values={'realization': <function generate_remove_single_ensemble_member_constraint.<locals>.<lambda> at 0x"

--- a/tests/operators/test_filters.py
+++ b/tests/operators/test_filters.py
@@ -298,3 +298,19 @@ def test_apply_mask(cube):
         atol=1e-02,
         equal_nan=True,
     )
+
+
+def test_generate_single_ensemble_member_constraint_reduced_member(ensemble_cube):
+    """Remove a single ensemble member from a cube."""
+    remove_member_constraint = (
+        constraints.generate_remove_single_ensemble_member_constraint(ensemble_member=1)
+    )
+    filter_cube = filters.filter_cubes(
+        ensemble_cube, constraint=remove_member_constraint
+    )
+    # Assert one of the ensemble members have been removed.
+    assert len(filter_cube.coord("realization").points) == (
+        len(ensemble_cube.coord("realization").points) - 1
+    )
+    # Assert remain ensemble member is expected one.
+    assert filter_cube.coord("realization").points == [2]


### PR DESCRIPTION
<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->
Adding in a constraint to remove a single ensemble member to allow ensemble statistics to be calculated with and without the control member (for example).

Fixes #1628
### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [x] Documentation has been updated to reflect change.
- [x] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
