### PR TITLE
Add a realization coordinate constraint

### DIFF
--- a/src/CSET/operators/constraints.py
+++ b/src/CSET/operators/constraints.py
@@ -285,7 +285,7 @@ def generate_remove_single_ensemble_member_constraint(
     """
     Generate a constraint to remove a single ensemble member.
 
-    Operators that returns a constraint to remove the given ensemble member. By
+    Operator that returns a constraint to remove the given ensemble member. By
     default the ensemble member removed is the control member (assumed to have
     a realization of zero). However, any ensemble member can be removed, thus
     allowing a non-zero control member to be removed if the control is a
@@ -309,6 +309,31 @@ def generate_remove_single_ensemble_member_constraint(
     when it is not an equally-likely member of the ensemble.
     """
     return iris.Constraint(realization=lambda m: m.point != ensemble_member)
+
+
+def generate_realization_constraint(
+    ensemble_members: int | list[int], **kwargs
+) -> iris.Constraint:
+    """
+    Generate a constraint to subset ensemble members.
+
+    Operator that is given a list of ensemble members and returns a constraint
+    to select those ensemble members. This operator is particularly useful for
+    subsetting ensembles.
+
+    Arguments
+    ---------
+    ensemble_members: int | list[int]
+        The ensemble members to be subsetted over.
+
+    Returns
+    -------
+    iris.Constraint
+    """
+    # Ensure ensemble_members is iterable.
+    if not isinstance(ensemble_members, Iterable):
+        ensemble_members = [ensemble_members]
+    return iris.Constraint(realization=ensemble_members)
 
 
 def combine_constraints(


### PR DESCRIPTION
Adds a constraint based on the realization coordinate to either select one or multiple ensemble members to allow subsetting.

Fixes #1630

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [ ] All tests and CI checks pass.
- [ ] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [ ] Marked the PR as ready to review.
