### PR TITLE
Don't set plot date if DO_CASE_AGGREGATION

### DIFF
--- a/src/CSET/operators/plot.py
+++ b/src/CSET/operators/plot.py
@@ -65,15 +65,8 @@ def _append_to_plot_index(plot_index: list) -> list:
         complete_plot_index = meta.get("plots", [])
         complete_plot_index = complete_plot_index + plot_index
         meta["plots"] = complete_plot_index
-        logging.debug(
-            "Cylc task namespace hierarchy: %s",
-            os.getenv(
-                "CYLC_TASK_NAMESPACE_HIERARCHY",
-                "$CYLC_TASK_NAMESPACE_HIERARCHY not set.",
-            ),
-        )
-        if "PROCESS_CASE_AGGREGATION" not in os.getenv(
-            "CYLC_TASK_NAMESPACE_HIERARCHY", ""
+        if os.getenv("CYLC_TASK_CYCLE_POINT") and not bool(
+            os.getenv("DO_CASE_AGGREGATION")
         ):
             meta["case_date"] = os.getenv("CYLC_TASK_CYCLE_POINT", "")
         fp.seek(0)

--- a/tests/operators/test_plot.py
+++ b/tests/operators/test_plot.py
@@ -930,15 +930,11 @@ def test_append_to_plot_index(monkeypatch, tmp_working_dir):
     assert "datetime" not in meta
 
 
-def test_append_to_plot_index_case_aggregation_no_datetime(
-    monkeypatch, tmp_working_dir
-):
+def test_append_to_plot_index_aggregation(monkeypatch, tmp_working_dir):
     """Ensure the datetime is not written for aggregation plots."""
     # Setup environment and required file.
     monkeypatch.setenv("CYLC_TASK_CYCLE_POINT", "20000101T0000Z")
-    monkeypatch.setenv(
-        "CYLC_TASK_NAMESPACE_HIERARCHY", "root PROCESS_CASE_AGGREGATION task_name"
-    )
+    monkeypatch.setenv("DO_CASE_AGGREGATION", "True")
     with open("meta.json", "wt") as fp:
         fp.write("{}\n")
 


### PR DESCRIPTION
This allows us to remove the complicated task family hierarchy in #1332.

We also skip if we can't get the information from cylc such as when not in a workflow.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [x] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
