### PR TITLE
#837 part 1: Add `bake_recipes` rose app

### DIFF
--- a/src/CSET/cset_workflow/app/bake_recipes/bin/bake.sh
+++ b/src/CSET/cset_workflow/app/bake_recipes/bin/bake.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Run CSET bake for a recipe file.
+set -euo pipefail
+
+# Put together path to output dir from nice name for recipe.
+output_dir="${CYLC_WORKFLOW_SHARE_DIR}/web/plots/${CYLC_TASK_CYCLE_POINT}/$(basename "$1" .yaml)"
+
+set -x
+# Bake recipe.
+exec cset bake \
+    --recipe "$1" \
+    --output-dir "$output_dir" \
+    ${COLORBAR_FILE:+"--style-file='${CYLC_WORKFLOW_SHARE_DIR}/style.json'"} \
+    ${PLOT_RESOLUTION:+"--plot-resolution=$PLOT_RESOLUTION"} \
+    ${SKIP_WRITE:+"--skip-write"}

--- a/src/CSET/cset_workflow/app/bake_recipes/bin/baker.sh
+++ b/src/CSET/cset_workflow/app/bake_recipes/bin/baker.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Setup rose app for baking, then bake.
+set -euo pipefail
+
+# Use the appropriate recipes.
+optconfkey="$CYLC_TASK_CYCLE_POINT"
+if [ -n "${DO_CASE_AGGREGATION-}" ]; then
+    RECIPE_DIR=$CYLC_WORKFLOW_SHARE_DIR/cycle/$CYLC_TASK_CYCLE_POINT/aggregation_recipes
+    optconfkey="${optconfkey}-aggregation"
+else
+    RECIPE_DIR=$CYLC_WORKFLOW_SHARE_DIR/cycle/$CYLC_TASK_CYCLE_POINT/recipes
+fi
+export RECIPE_DIR
+
+# Determine parallelism.
+parallelism="$(nproc)"
+if [ "$CYLC_TASK_TRY_NUMBER" -gt 1 ]; then
+    # This is a retry; enable DEBUG logging and run in serial.
+    export LOGLEVEL="DEBUG"
+    parallelism=1
+fi
+
+# Get filenames without leading directory.
+recipes="$(cd "$RECIPE_DIR" && echo *.yaml)"
+
+# Write rose-bunch optional configuration.
+mkdir -p "$CYLC_WORKFLOW_RUN_DIR/app/bake_recipes/opt/"
+opt_conf="$CYLC_WORKFLOW_RUN_DIR/app/bake_recipes/opt/rose-app-${optconfkey}.conf"
+printf "[bunch]\npool-size=%s\n[bunch-args]\nrecipe_file=%s\n" "$parallelism" "$recipes" > "$opt_conf"
+unset opt_conf parallelism recipes
+
+# Run bake_recipes rose app.
+exec rose task-run -v --app-key=bake_recipes --opt-conf-key="${optconfkey}"

--- a/src/CSET/cset_workflow/app/bake_recipes/rose-app.conf
+++ b/src/CSET/cset_workflow/app/bake_recipes/rose-app.conf
@@ -1,0 +1,5 @@
+mode = rose_bunch
+
+[bunch]
+command-format=app_env_wrapper bake.sh "$RECIPE_DIR/%(recipe_file)s"
+# [bunch-args] come from an optional config written by bin/baker.sh

--- a/src/CSET/cset_workflow/flow.cylc
+++ b/src/CSET/cset_workflow/flow.cylc
@@ -185,6 +185,26 @@ final cycle point = {{CSET_TRIAL_END_DATE}}
         ANALYSIS_OFFSET = {{model["analysis_offset"]}}
     {% endfor %}
 
+    [[bake_recipes]]
+    # Bake the parbaked recipes for this cycle.
+    script = "$CYLC_WORKFLOW_RUN_DIR/app/bake_recipes/bin/baker.sh"
+    execution time limit = PT3H
+    execution retry delays = PT1M
+        [[[directives]]]
+        --ntasks=32
+        --mem=64000
+
+    [[bake_aggregation_recipes]]
+    # Bake the parbaked aggregation recipes.
+    script = "$CYLC_WORKFLOW_RUN_DIR/app/bake_recipes/bin/baker.sh"
+    execution time limit = PT3H
+    execution retry delays = PT1M
+        [[[directives]]]
+        --ntasks=8
+        --mem=64000
+        [[[environment]]]
+        DO_CASE_AGGREGATION = True
+
     [[housekeeping]]
     # Housekeep input data files.
         [[[environment]]]


### PR DESCRIPTION
This uses rose-bunch to bake multiple recipes in parallel inside of a single cylc job. This makes it significantly faster than running thousands of tiny jobs.

To allow it to dynamically find the available jobs, cylc executes the baker.sh script, which writes a rose optional configuration specifying the recipes and parallelism, then runs the rose app using that configuration.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
