### PR TITLE
Import iris.cube into wind.py to allow for constructing a CubeList

### DIFF
--- a/src/CSET/operators/wind.py
+++ b/src/CSET/operators/wind.py
@@ -15,6 +15,7 @@
 """Operators to calculate various forms or properties of wind."""
 
 import iris
+import iris.cube
 import numpy as np
 
 from CSET._common import iter_maybe


### PR DESCRIPTION
<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

I don't think this actually breaks anything currently, but we should `import iris.cube` when using it.

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [ ] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
