### PR TITLE
Load environment before spawning rose-bunch tasks

### DIFF
--- a/src/CSET/cset_workflow/app/bake_recipes/bin/baker.sh
+++ b/src/CSET/cset_workflow/app/bake_recipes/bin/baker.sh
@@ -29,5 +29,5 @@ opt_conf="$CYLC_WORKFLOW_RUN_DIR/app/bake_recipes/opt/rose-app-${optconfkey}.con
 printf "[bunch]\npool-size=%s\n[bunch-args]\nrecipe_file=%s\n" "$parallelism" "$recipes" > "$opt_conf"
 unset opt_conf parallelism recipes
 
-# Run bake_recipes rose app.
-exec rose task-run -v --app-key=bake_recipes --opt-conf-key="${optconfkey}"
+# Run bake_recipes rose app inside of conda environment.
+exec app_env_wrapper rose task-run -v --app-key=bake_recipes --opt-conf-key="${optconfkey}"

--- a/src/CSET/cset_workflow/app/bake_recipes/rose-app.conf
+++ b/src/CSET/cset_workflow/app/bake_recipes/rose-app.conf
@@ -1,5 +1,5 @@
 mode = rose_bunch
 
 [bunch]
-command-format=app_env_wrapper bake.sh "$RECIPE_DIR/%(recipe_file)s"
+command-format=bake.sh "$RECIPE_DIR/%(recipe_file)s"
 # [bunch-args] come from an optional config written by bin/baker.sh


### PR DESCRIPTION
This allows us to only load the environment once, which should make it slightly faster and require less memory (~50 MiB per task). It isn't going to make a huge difference though.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
