### PR TITLE
Skip baking if we have no recipes

### DIFF
--- a/src/CSET/cset_workflow/app/bake_recipes/bin/baker.sh
+++ b/src/CSET/cset_workflow/app/bake_recipes/bin/baker.sh
@@ -10,6 +10,10 @@ if [ -n "${DO_CASE_AGGREGATION-}" ]; then
 else
     RECIPE_DIR=$CYLC_WORKFLOW_SHARE_DIR/cycle/$CYLC_TASK_CYCLE_POINT/recipes
 fi
+if ! [ -d "$RECIPE_DIR" ]; then
+    echo "No recipes to bake in $RECIPE_DIR"
+    exit 0
+fi
 export RECIPE_DIR
 
 # Determine parallelism.
@@ -21,7 +25,8 @@ if [ "$CYLC_TASK_TRY_NUMBER" -gt 1 ]; then
 fi
 
 # Get filenames without leading directory.
-recipes="$(cd "$RECIPE_DIR" && echo *.yaml)"
+# Portability note: printf is specific to GNU find.
+recipes="$(find "$RECIPE_DIR" -iname '*.yaml' -type f -printf '%P ')"
 
 # Write rose-bunch optional configuration.
 mkdir -p "$CYLC_WORKFLOW_RUN_DIR/app/bake_recipes/opt/"


### PR DESCRIPTION
This avoids task failures if we have no aggregation tasks enabled. I've also switched to using find over globbing as it avoids a potentual bug if the directory exists, but doesn't contain any recipes, where we would try and bake a literal "*.yaml" file.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
