### PR TITLE
Use rose-bunch incremental mode when baking

### DIFF
--- a/src/CSET/cset_workflow/app/bake_recipes/bin/baker.sh
+++ b/src/CSET/cset_workflow/app/bake_recipes/bin/baker.sh
@@ -18,10 +18,17 @@ export RECIPE_DIR
 
 # Determine parallelism.
 parallelism="$(nproc)"
-if [ "$CYLC_TASK_TRY_NUMBER" -gt 1 ]; then
+if [ "$CYLC_TASK_SUBMIT_NUMBER" -gt 1 ]; then
     # This is a retry; enable DEBUG logging and run in serial.
     export LOGLEVEL="DEBUG"
     parallelism=1
+fi
+
+if [ -f .rose-bunch.db ]; then
+    # Set the pool-size in the rose_bunch database, so we don't rerun succeeded
+    # tasks. We need to do this as rose_bunch normally clears the database if
+    # the configuration has changed.
+    sqlite3 .rose-bunch.db "UPDATE config SET value=$parallelism WHERE "'key="bunch_pool-size";'
 fi
 
 # Get filenames without leading directory.

--- a/src/CSET/cset_workflow/app/bake_recipes/rose-app.conf
+++ b/src/CSET/cset_workflow/app/bake_recipes/rose-app.conf
@@ -1,5 +1,6 @@
 mode = rose_bunch
 
 [bunch]
+incremental=true
 command-format=app_env_wrapper bake.sh "$RECIPE_DIR/%(recipe_file)s"
 # [bunch-args] come from an optional config written by bin/baker.sh


### PR DESCRIPTION
Rose bunch incremental mode means that tasks that have suceeded are not rerun, so that only failed tasks need to be. This is the default, but it has been made explicit to be sure it is
enabled.

There are two issues fixed in this commit. The first is that we were
using the CYLC_TASK_TRY_NUMBER variable to determine if we were
retrying, which gets reset on a manual cylc trigger.
CYLC_TASK_SUBMIT_NUMBER is not, so that all runs after the first will
now run serially, regardless of how they were triggered.

The other issue was that rose_bunch was never running tasks
incrementally due to us changing the parallelism in the configuration.
We now avoid this by updating the recorded configuration in rose_bunch's
database to match.

This is decidedly a hack, but seems to work well, and means that we now
only retry the failed tasks, as intended. It also adds a dependency on
the sqlite command line, which will almost certainly be available, but
should be documented to be sure.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
