### PR TITLE
Use long_name for resulting difference cube before standard_name

### DIFF
--- a/src/CSET/operators/misc.py
+++ b/src/CSET/operators/misc.py
@@ -348,10 +348,9 @@ def difference(cubes: CubeList):
     # assuming we can rely on cubes having a long name, so we don't check for
     # its presents.
     difference.standard_name = None
-    if base.standard_name:
-        difference.long_name = base.standard_name + "_difference"
-    else:
-        difference.long_name = base.long_name + "_difference"
+    difference.long_name = (
+        base.long_name if base.long_name else base.name()
+    ) + "_difference"
     if base.var_name:
         difference.var_name = base.var_name + "_difference"
 

--- a/tests/operators/test_misc.py
+++ b/tests/operators/test_misc.py
@@ -162,8 +162,24 @@ def test_difference(cube: iris.cube.Cube):
         difference_cube.data, np.zeros_like(difference_cube.data), atol=1e-9
     )
     assert difference_cube.standard_name is None
-    assert difference_cube.long_name == cube.standard_name + "_difference"
-    assert difference_cube.var_name == cube.var_name + "_difference"
+    assert difference_cube.long_name == "temperature_at_screen_level_difference"
+    assert difference_cube.var_name == "air_temperature_difference"
+
+
+def test_difference_standard_name_fallback(cube: iris.cube.Cube):
+    """Test falling back to the standard name if no long name."""
+    # Data preparation.
+    cube.long_name = None
+    other_cube = cube.copy()
+    del other_cube.attributes["cset_comparison_base"]
+    cubes = iris.cube.CubeList([cube, other_cube])
+
+    # Take difference.
+    difference_cube = misc.difference(cubes)
+
+    assert difference_cube.standard_name is None
+    assert difference_cube.long_name == "air_temperature_difference"
+    assert difference_cube.var_name == "air_temperature_difference"
 
 
 def test_difference_no_time_coord(cube):


### PR DESCRIPTION
As we match colourbars off of names, we need to use them consistently. We have decided in other parts of the codebase to treat the long_name as higher priority than the standard_name, but this was missed in the difference operator, resulting in some difference plots not picking up their colourbars.

Fixes #1710

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [ ] All tests and CI checks pass.
- [ ] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [ ] Marked the PR as ready to review.
