### PR TITLE
Use trusted publishing for uploading PyPI package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,25 +53,5 @@ jobs:
           name: packages
           path: dist/
 
-      # External actions are disabled via organization policies therefore we
-      # must instead manually implement it.
-      # https://docs.pypi.org/trusted-publishers/using-a-publisher/#the-manual-way
-      # - name: Publish package distributions to PyPI
-      #   uses: pypa/gh-action-pypi-publish@release/v1
-
-      - name: Setup python
-        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c
-        with:
-            python-version: "3.x"
-
-      - name: Install dependencies
-        run: pip install twine
-
-      - name: Check package metadata
-        run: twine check --strict dist/*
-
-      - name: Upload to PyPI
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-        run: twine upload --disable-progress-bar --verbose --non-interactive dist/*
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e


### PR DESCRIPTION
<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

Per https://docs.pypi.org/trusted-publishers/using-a-publisher/

I've already linked up the PyPI side of this, and revoked our existing publishing token. This should be a transparent change to the package release process.

Unfortunately the only real way to test this is to make a release.

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
