### PR TITLE
Reword and unify README and documentation home page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,67 +1,34 @@
 # CSET: Community Seamless Evaluation Toolkit
 
-CSET, the Community Seamless Evaluation Toolkit, is an open-source toolkit for evaluating weather and climate models, including physical numerical and machine learning models, as well as observations. It focuses on high-resolution atmospheric processes, from convective to turbulence scales, across regional to global domains.
+> [!TIP]
+> Useful links: [Documentation](https://metoffice.github.io/CSET) | [Source Code](https://github.com/MetOffice/CSET) | [Issue Tracker](https://github.com/MetOffice/CSET/issues) | [Releases](https://github.com/MetOffice/CSET/releases) | [Discussion Forum](https://github.com/MetOffice/simulation-systems/discussions/categories/cset-toolkit)
 
-CSET supports parametrisation, diagnostics, and evaluation research at the Met Office and Momentum® Partnership, and is integral to the Regional Atmosphere and Land (RAL) model development for the Unified Model and LFRic codes.
+The Community Seamless Evaluation Toolkit, CSET, is a community-developed open source toolkit for evaluation, verification, and investigation of weather and climate models. It supports the evaluation of physical numerical models, machine learning models, and observations seamlessly across time and space scales. CSET primarily targets, but is not limited to, high-resolution atmospheric processes, from convective to turbulence scales (i.e. kilometre to sub-kilometre grid spacing), across regional or global domains.
 
-CSET provides a centralised and peer-reviewed source of tools to aid
-process-oriented verification and evaluation for UM, LFRic physical and machine learning models, supporting both deterministic and ensemble configurations.
+CSET provides a centralised and peer-reviewed set of tools to aid process-oriented verification and evaluation for UM, LFRic, and machine learning models, supporting both deterministic and ensemble configurations.
 
-For CSET model and diagnostics developers, CSET offers:
-   - Well-documented and peer-reviewed evaluation tools.
-   - Community development through open access and agreed working practices.
-   - A clearly defined release cycle.
-   - Automatic testing.
-   - Flexible evaluation code that can adapt to user needs.
+At the Met Office and Momentum® Partnership CSET supports parametrisation development, diagnostic development and evaluation research. It is integral to the Regional Atmosphere and Land (RAL) model development process for the Unified Model and LFRic atmospheric modelling codes.
 
-CSET is built with portability in mind and can be run on:
-   - Local desktops.
-   - HPC systems.
-   - Cloud servers.
+CSET is designed to be continuously evolving and improving, driven by community inputs. Support for verification and evaluation of a range of machine learning models is expected to grow, alongside use of observations from an increasing range of sources to support evaluation. It will utilise the Model Evaluation Tools (MET) software to provide a range of verification metrics aligned with operational verification best practices. Where relevant, CSET will provide interfaces to utilise other evaluation packages to support particular evaluation requirements.
 
-CSET ensures:
-   - Traceable and reproducible results during a model development and assessment cycle.
-   - Diagnostics access to observations.
-   - A legacy for model and observation based diagnostics through continued maintenance and improved discoverability.
+Please [visit the documentation](https://metoffice.github.io/CSET) to learn more about CSET and how to use it.
 
-CSET is built using a modern software stack, underpinned by
-- python3,
-- iris and
-- METplus.
-
-
-
-Please read [the documentation](https://metoffice.github.io/CSET) to learn more
-about CSET, and how to use it.
-
-If you want to ask or share with the CSET community, please use the relevant
-category of the [Simulation Systems Discussions
-Forum](https://github.com/MetOffice/simulation-systems/discussions/categories/cset-toolkit).
+If you want to ask or share with the CSET community, please use the relevant category of the [Simulation Systems Discussions Forum](https://github.com/MetOffice/simulation-systems/discussions/categories/cset-toolkit).
 
 ## Contributing
 
-Contributions are readily welcomed! To get started with developing CSET visit
-the [Contributing](https://metoffice.github.io/CSET/contributing/) section of
-the documentation.
+Contributions are readily welcomed! Visit the [contributing documentation](https://metoffice.github.io/CSET/contributing/) to get started with developing CSET.
 
-In addition to reading the working practices, the key
-recommendation is early communication. Open an [issue on
-Github](https://github.com/MetOffice/CSET/issues) with your proposed change or
-addition in the design phase, and then others can provide guidance early.
+In addition to reading the working practices, the key recommendation is early communication. Open an [issue on GitHub](https://github.com/MetOffice/CSET/issues) while your proposed change or addition in the design phase so others can provide guidance.
 
 ## Licence
 
 © Crown copyright, Met Office (2022-2025) and CSET contributors.
 
-Licensed under the [Apache License, Version 2.0](LICENCE) (the "License"); you
-may not use this file except in compliance with the License. You may obtain a
-copy of the License at
+Licensed under the [Apache License, Version 2.0](LICENCE) (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
 
 <http://www.apache.org/licenses/LICENSE-2.0>
 
-Unless required by applicable law or agreed to in writing, software distributed
-under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-CONDITIONS OF ANY KIND, either express or implied. See the License for the
-specific language governing permissions and limitations under the License.
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 GitHub Copilot was used in the development of this software.

--- a/docs/source/background/why-cset.rst
+++ b/docs/source/background/why-cset.rst
@@ -10,10 +10,11 @@ assess the impacts of different model configurations and choices on results.
 Evaluation is an iterative process, and each step can unveil more questions
 that leads to a need for deeper investigation.
 
-CSET aids in this by providing a flexible way to interrogate model and observational
-data, using diagnostics that can be quickly created by the combination of operators in
-:doc:`/usage/operator-recipes`. Common operations such as reading, writing, and
-regridding are provided to reduce duplication of effort.
+CSET aids in this by providing a flexible way to interrogate model and
+observational data, using diagnostics that can be quickly created by the
+combination of operators in :doc:`operator recipes </usage/operator-recipes>`.
+Common operations such as reading, writing, and regridding are provided to
+reduce duplication of effort.
 
 CSET provides a legacy for user-developed evaluation methods and diagnostics to
 be shared and documented, with :doc:`well-defined working practices and review
@@ -26,11 +27,27 @@ climate timescales. CSET provides flexibility to provide consistent evaluation
 of physics-based or machine learning approaches, and to compare these directly.
 
 CSET provides many benefits to users and developers, including:
-- embeds and shares best practice for evaluation and verification of weather and
-climate models using observational data,
-- a legacy for user-developed evaluation methods and diagnostics to be shared and
-documented, with :doc:`well-defined working practices and review processes</contributing/index>`,
-- a route for contributors to CSET to ensure legacy of newly developed diagnostics,
-to ensure benefit to wider weather and climate modelling communities,
-- reproducibility, portability, accessibility, maintainability, and quality
-assurance of evaluation tools to support a range of applications.
+
+* Embeds and shares best practice for evaluation and verification of weather and climate models using observational data.
+* A legacy for user-developed evaluation methods and diagnostics to be shared and documented, with :doc:`well-defined working practices and review processes</contributing/index>`.
+* A route for contributors to CSET to ensure legacy of newly developed diagnostics, to ensure benefit to wider weather and climate modelling communities.
+* Reproducibility, portability, accessibility, maintainability, and quality assurance of evaluation tools to support a range of applications.
+
+Key Principles of CSET
+----------------------
+
+Community
+    Evaluation software developed for and by a wide network of model development and
+    evaluation scientists, enabling common approaches to distributed evaluation activities.
+
+Seamless
+    Supporting assessment, evaluation, verification and understanding of physical and
+    machine learning models as well as observations across time and space scales, and from regional to global application.
+
+Evaluation
+    Providing a process-oriented focus to model assessment, supporting depth of
+    comparison between different model configurations and assessment relative to a range of observations.
+
+Toolkit
+    A flexible software including code, recipes, diagnostics and workflow to manage a range of
+    user requirements, underpinned by modern software development practices.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -13,68 +13,44 @@ CSET Documentation
    changelog
    GitHub <https://github.com/MetOffice/CSET>
 
-Key Principles of CSET
-----------------------
-
-**Community**: Evaluation software developed for and by a wide network of model development and
-evaluation scientists, enabling common approaches to distributed evaluation activities.
-**Seamless**: Supporting assessment, evaluation, verification and understanding of physical and
-machine learning models as well as observations across time and space scales, and from regional to global application.
-**Evaluation**: Providing a process-oriented focus to model assessment, supporting depth of
-comparison between different model configurations and assessment relative to a range of observations.
-**Toolkit**: A flexible software including code, recipes, diagnostics and workflow to manage a range of
-user requirements, underpinned by modern software development practices.
-
 Overview of CSET
 ----------------
 
-CSET, the Community Seamless Evaluation Toolkit, is
-a community-developed open-source toolkit for the seamless evaluation, verification
-and investigation
-of weather and climate models. It supports the evaluation of physical numerical models and machine learning models
-as well as observations seamlessly across time and space scales. CSET primarily targets,
-but is not limited to, higher resolution atmosphere model processes (i.e. convective-scale
-with grid-spacing of order km's and turbulence-scale with sub-km grid spacing) on regional
-to global domains.
+The Community Seamless Evaluation Toolkit, CSET, is a community-developed open
+source toolkit for evaluation, verification, and investigation of weather and
+climate models. It supports the evaluation of physical numerical models, machine
+learning models, and observations seamlessly across time and space scales. CSET
+primarily targets, but is not limited to, high-resolution atmospheric processes,
+from convective to turbulence scales (i.e. kilometre to sub-kilometre grid
+spacing), across regional or global domains.
 
-CSET provides a centralised and peer-reviewed source of tools to aid
-process-oriented evaluation for UM, LFRic physical and machine learning models, supporting both
-deterministic and ensemble configurations.
+CSET provides a centralised and peer-reviewed set of tools to aid
+process-oriented verification and evaluation for UM, LFRic, and machine learning
+models, supporting both deterministic and ensemble configurations.
 
-CSET is designed to be continuously evolving and improving, driven by community inputs.
-Support for verification and evaluation of a range of machine learning models is expected
-to grow, alongside use of observations from an increasing range of sources to support
-evaluation. It will utilise the Model Evaluation Tools (MET) software to provide a
-range of verification metrics aligned with operational verification best practices.
-Where relevant, CSET will provide interfaces to utilise other evaluation packages to
-support particular evaluation requirements.
+At the Met Office and Momentum® Partnership CSET supports parametrisation
+development, diagnostic development and evaluation research. It is integral to
+the Regional Atmosphere and Land (RAL) model development process for the Unified
+Model and LFRic atmospheric modelling codes.
 
-CSET is closely aligned to parametrisation development, diagnostic development and
-evaluation research in the Met Office and Momentum® Partnership, serving as an
-integral part of the Regional Atmosphere and Land (RAL) model development process
-focussed on the Unified Model and LFRic atmosphere model codes.
+CSET is designed to be continuously evolving and improving, driven by community
+inputs. Support for verification and evaluation of a range of machine learning
+models is expected to grow, alongside use of observations from an increasing
+range of sources to support evaluation. It will utilise the Model Evaluation
+Tools (MET) software to provide a range of verification metrics aligned with
+operational verification best practices. Where relevant, CSET will provide
+interfaces to utilise other evaluation packages to support particular evaluation
+requirements.
 
-- For CSET model and diagnostics developers, CSET offers:
-   - Well-documented and peer-reviewed evaluation tools.
-   - Community development through open access and agreed working practices.
-   - A clearly defined release cycle.
-   - Automatic testing.
-   - Flexible evaluation code that can adapt to user needs.
-- CSET is built with portability in mind and can be run on:
-   - Local desktops.
-   - HPC systems.
-   - Cloud servers.
-- CSET ensures:
-   - Traceable and reproducible results during a model development and assessment cycle.
-   - Diagnostics access to observations.
-   - A legacy through continued maintenance and improved discoverability.
-- CSET is built using a modern software stack, underpinned by
-   - python3,
-   - iris and
-   - METplus.
+For model and diagnostics developers, CSET offers:
 
-Contributions to CSET are promoted by clear documentation and working practices,
-automatic testing, and an open access GitHub code base.
+* Well-documented, tested, and peer-reviewed evaluation tools.
+* Flexible evaluation code that can adapt to user needs.
+* Traceable and reproducible results during a model development and assessment cycle.
+* Community development through open access and agreed working practices.
+* Access to bespoke observations for diagnostics.
+* A legacy for diagnostics through continued maintenance and improved discoverability.
+* Portability across sites, including :doc:`easy installation </getting-started/installation>`.
 
 For information on how to use CSET, see :doc:`getting-started/index`.
 


### PR DESCRIPTION
The text from the README and documentation home page have been unified.

The additional details have been moved to the why-cset page, so they are not as overwhelming for someone's first visit to the documentation.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [x] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
