### PR TITLE
Move aviation_colour_state loaders to correct for loop

### DIFF
--- a/src/CSET/loaders/spatial_field.py
+++ b/src/CSET/loaders/spatial_field.py
@@ -414,28 +414,6 @@ def load(conf: Config):
                 aggregation=False,
             )
 
-    # Screen-level temperature probabilities
-    for model, condition, threshold in itertools.product(
-        models,
-        conf.PROB_TEMPERATURE_CONDITION,
-        conf.PROB_TEMPERATURE_THRESHOLD,
-    ):
-        if conf.SCREEN_LEVEL_TEMPERATURE_SPATIAL_PROBABILITY_WITHOUT_CONTROL_MEMBER:
-            yield RawRecipe(
-                recipe="screen_level_temperature_spatial_probability_without_control.yaml",
-                variables={
-                    "CONDITION": condition,
-                    "THRESHOLD": threshold,
-                    "MODEL_NAME": model["name"],
-                    "SUBAREA_TYPE": conf.SUBAREA_TYPE if conf.SELECT_SUBAREA else None,
-                    "SUBAREA_EXTENT": conf.SUBAREA_EXTENT
-                    if conf.SELECT_SUBAREA
-                    else None,
-                },
-                model_ids=model["id"],
-                aggregation=False,
-            )
-
         # Aviation colour state due to visibility.
         if conf.AVIATION_COLOUR_STATE_VISIBILITY:
             yield RawRecipe(
@@ -471,6 +449,28 @@ def load(conf: Config):
             yield RawRecipe(
                 recipe="aviation_colour_state_spatial_plot.yaml",
                 variables={
+                    "MODEL_NAME": model["name"],
+                    "SUBAREA_TYPE": conf.SUBAREA_TYPE if conf.SELECT_SUBAREA else None,
+                    "SUBAREA_EXTENT": conf.SUBAREA_EXTENT
+                    if conf.SELECT_SUBAREA
+                    else None,
+                },
+                model_ids=model["id"],
+                aggregation=False,
+            )
+
+    # Screen-level temperature probabilities
+    for model, condition, threshold in itertools.product(
+        models,
+        conf.PROB_TEMPERATURE_CONDITION,
+        conf.PROB_TEMPERATURE_THRESHOLD,
+    ):
+        if conf.SCREEN_LEVEL_TEMPERATURE_SPATIAL_PROBABILITY_WITHOUT_CONTROL_MEMBER:
+            yield RawRecipe(
+                recipe="screen_level_temperature_spatial_probability_without_control.yaml",
+                variables={
+                    "CONDITION": condition,
+                    "THRESHOLD": threshold,
                     "MODEL_NAME": model["name"],
                     "SUBAREA_TYPE": conf.SUBAREA_TYPE if conf.SELECT_SUBAREA else None,
                     "SUBAREA_EXTENT": conf.SUBAREA_EXTENT


### PR DESCRIPTION
Fixes #1842

The aviation colour state loaders were in for loop expecting conditions and thresholds where only model is the required factor to loop over. Given this it was not running the recipe when selected. Here, the three relevant loaders are moved to the correct area.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
