### PR TITLE
Allow rotated pole plots to center on 180 meridian if required

### DIFF
--- a/src/CSET/operators/plot.py
+++ b/src/CSET/operators/plot.py
@@ -392,7 +392,7 @@ def _setup_spatial_map(
         # Consider map projection orientation.
         # Adapting orientation enables plotting across international dateline.
         # Users can adapt the default central_longitude if alternative projections views.
-        if x2 > 180.0:
+        if x2 > 180.0 or x1 < -180.0:
             central_longitude = 180.0
         else:
             central_longitude = 0.0
@@ -404,7 +404,7 @@ def _setup_spatial_map(
             projection = ccrs.RotatedPole(
                 pole_longitude=coord_system.grid_north_pole_longitude,
                 pole_latitude=coord_system.grid_north_pole_latitude,
-                central_rotated_longitude=0.0,
+                central_rotated_longitude=central_longitude,
             )
             crs = projection
         else:


### PR DESCRIPTION
The `central_rotated_longitude` kwarg in the definition of the rotated pole projection, needs to accommodate those domains whose `grid_latitude` coordinate crosses the 180 meridian. It also need to consider that the values of the longitude coordinate may be all negative.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [x] Documentation has been updated to reflect change.
- [x] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [x] Conda lock files have been updated if dependencies have changed.
- [x] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
