### PR TITLE
Add cache busting to CSET web UI to avoid showing old versions

### DIFF
--- a/src/CSET/cset_workflow/app/finish_website/file/html/index.html
+++ b/src/CSET/cset_workflow/app/finish_website/file/html/index.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>CSET</title>
-    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="style.css?v=CACHEBUSTER">
     <link rel="icon" href="favicon.ico" type="image/x-icon">
 </head>
 
@@ -32,7 +32,8 @@
             </article>
         </div>
     </main>
-    <script src="script.js"></script>
+    <script>const PLOTS_PATH = "plots-CACHEBUSTER";</script>
+    <script src="script.js?v=CACHEBUSTER"></script>
 </body>
 
 </html>

--- a/src/CSET/cset_workflow/app/finish_website/file/html/script.js
+++ b/src/CSET/cset_workflow/app/finish_website/file/html/script.js
@@ -115,7 +115,7 @@ function construct_sidebar_from_data(data) {
             event.preventDefault();
             // Set the appropriate frame layout.
             position == "full" ? ensure_single_frame() : ensure_dual_frame();
-            document.getElementById(`plot-frame-${position}`).src = `plots/${plot}`;
+            document.getElementById(`plot-frame-${position}`).src = `${PLOTS_PATH}/${plot}`;
           });
 
           // Add button to chooser.
@@ -146,7 +146,7 @@ function setup_plots_sidebar() {
     return;
   }
   // Loading of plot index file, and adding them to the sidebar.
-  fetch("plots/index.json")
+  fetch(`${PLOTS_PATH}/index.json`)
     .then((response) => {
       // Display a message and stop if the fetch fails.
       if (!response.ok) {


### PR DESCRIPTION
Adds a query string to direct requests and gives the plot directory a unique path. This avoids showing old plots/using old version of the script/CSS.

Fixes #1049

Based on #1879, so should be merged afterwards.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [x] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
