### PR TITLE
Change sorted function when assigning model colours

### DIFF
--- a/src/CSET/cset_workflow/app/assign_model_colours/bin/assign_model_colours.py
+++ b/src/CSET/cset_workflow/app/assign_model_colours/bin/assign_model_colours.py
@@ -20,6 +20,8 @@ import json
 import os
 from base64 import b64decode
 
+from CSET._common import human_sorted
+
 # matplotlib tab20[::2] + tab20[1::2]
 DISCRETE_COLORS = (
     "#1f77b4",
@@ -65,7 +67,9 @@ def create_model_colour_mapping(model_names: list[str]) -> dict:
     infinite_colours = itertools.cycle(DISCRETE_COLORS)
     return {
         model: color
-        for model, color in zip(sorted(model_names), infinite_colours, strict=False)
+        for model, color in zip(
+            human_sorted(model_names), infinite_colours, strict=False
+        )
     }
 
 


### PR DESCRIPTION
Changes sorted function to human_sorted to fix labelling of lines when models greater than 10 plotted.
Fixes #1846

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [ ] All tests and CI checks pass.
- [ ] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [ ] Marked the PR as ready to review.
