### PR TITLE
Enable transverse mercator plotting in spatial plot operator

### DIFF
--- a/src/CSET/operators/plot.py
+++ b/src/CSET/operators/plot.py
@@ -407,6 +407,16 @@ def _setup_spatial_map(
                 central_rotated_longitude=central_longitude,
             )
             crs = projection
+        elif isinstance(coord_system, iris.coord_systems.TransverseMercator):
+            # Define Transverse Mercator projection for TM inputs.
+            projection = ccrs.TransverseMercator(
+                central_longitude=coord_system.longitude_of_central_meridian,
+                central_latitude=coord_system.latitude_of_projection_origin,
+                false_easting=coord_system.false_easting,
+                false_northing=coord_system.false_northing,
+                scale_factor=coord_system.scale_factor_at_central_meridian,
+            )
+            crs = projection
         else:
             # Define regular map projection for non-rotated pole inputs.
             # Alternatives might include e.g. for global model outputs:


### PR DESCRIPTION
adds plotting of transverse mercator data to plot operator to enable plotting of nimrod radar data.

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [ ] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [x] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [ ] Marked the PR as ready to review.
