### PR TITLE
Cleanup unnecessary imports in conftest.py

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,8 +89,6 @@ def vertical_profile_cube(vertical_profile_cube_readonly):
 @pytest.fixture(scope="session")
 def vector_cubes_readonly():
     """Get vector plot cubes. It is NOT safe to modify."""
-    from CSET.operators import read
-
     # Read the input cubes.
     in_cubes = read.read_cubes("tests/test_data/u10_v10.nc")
     # Generate constraints for the u and v components of the wind.
@@ -118,8 +116,6 @@ def vector_cubes(vector_cubes_readonly):
 @pytest.fixture(scope="session")
 def histogram_cube_readonly():
     """Get a histogram Cube. It is NOT safe to modify."""
-    from CSET.operators import read
-
     return read.read_cube(
         "tests/test_data/air_temperature_vertical_profile_as_series.nc"
     )
@@ -134,8 +130,6 @@ def histogram_cube(histogram_cube_readonly):
 @pytest.fixture(scope="session")
 def field2d_cube_readonly():
     """Get a 2D Cube for testing power spectrum code. It is NOT safe to modify."""
-    from CSET.operators import read
-
     return read.read_cube("tests/test_data/air_temperature_lat_lon.nc")
 
 
@@ -148,8 +142,6 @@ def field2d_cube(field2d_cube_readonly):
 @pytest.fixture(scope="session")
 def power_spectrum_cube_readonly():
     """Get a Cube for testing power spectrum code. It is NOT safe to modify."""
-    from CSET.operators import read
-
     return read.read_cube(
         "tests/test_data/power_spectrum_temperature_at_pressure_levels_pressure_250_1time.nc"
     )


### PR DESCRIPTION
We import CSET.operators.read at the top of the file.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [x] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
