### PR TITLE
Handle converting multiple wind cubes to point to true north

### DIFF
--- a/src/CSET/operators/read.py
+++ b/src/CSET/operators/read.py
@@ -888,11 +888,12 @@ def _convert_wind_true_dirn_um(cubes: iris.cube.CubeList):
     Convert from the components relative to the grid to true directions.
     This functionality only handles the simplest case.
     """
-    u_grid = cubes.extract_cube(iris.AttributeConstraint(STASH="m01s03i225"))
-    v_grid = cubes.extract_cube(iris.AttributeConstraint(STASH="m01s03i226"))
-    true_u, true_v = rotate_winds(u_grid, v_grid, iris.coord_systems.GeogCS(6371229.0))
-    u_grid.data = true_u.data
-    v_grid.data = true_v.data
+    u_grids = cubes.extract(iris.AttributeConstraint(STASH="m01s03i225"))
+    v_grids = cubes.extract(iris.AttributeConstraint(STASH="m01s03i226"))
+    for u, v in zip(u_grids, v_grids, strict=True):
+        true_u, true_v = rotate_winds(u, v, iris.coord_systems.GeogCS(6371229.0))
+        u.data = true_u.data
+        v.data = true_v.data
 
 
 def _normalise_var0_varname(cube: iris.cube.Cube):


### PR DESCRIPTION
This avoids crashing when loading data with more than one of each wind component, such as an instantaneous and an aggregation cube. This was especially problematic as it runs in the callback stage, so it will crash even recipes that don't use the wind.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
