### PR TITLE
Use API key for uploading coverage reports to tmpweb.net

### DIFF
--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -111,12 +111,13 @@ jobs:
       - name: Add report to PR
         env:
           GH_TOKEN: ${{ github.token }}
+          tmpweb_api_key: ${{ secrets.TMPWEB_API_KEY }}
           repository: ${{ github.repository }}
           head_ref: ${{ github.head_ref }}
         run: |
           # This links to a hosted version of the HTML report.
           tar -czf coverage-report.tar.gz htmlcov/
-          report_url="$(curl -sSf --data-binary @coverage-report.tar.gz https://tmpweb.net)"
+          report_url="$(curl -sSf --user "token:${tmpweb_api_key}" --data-binary @coverage-report.tar.gz https://tmpweb.net)"
           echo "Report hosted at $report_url"
           badge_options="$(coverage json --fail-under=0 -qo - | jq -r .totals.percent_covered_display)%25-blue?style=for-the-badge"
           echo "[![Coverage](https://img.shields.io/badge/coverage-${badge_options})](${report_url})" >> cov-report.md


### PR DESCRIPTION
tmpweb.net was forced to implement authentication to combat malicious uploads.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [ ] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [ ] Marked the PR as ready to review.
