### PR TITLE
No longer set sender in mail command

### DIFF
--- a/src/CSET/cset_workflow/app/send_email/bin/send_email.py
+++ b/src/CSET/cset_workflow/app/send_email/bin/send_email.py
@@ -52,7 +52,7 @@ def run():
     except ValueError:
         body = "The webpage for your run of CSET is now ready, though the address could not be determined.\nCheck that WEB_ADDR and WEB_DIR are set correctly, then consider filing a bug report at https://github.com/MetOffice/CSET"
     subprocess.run(
-        f'printf "{body}" | mail -s "{subject}" -S "from=notifications" "$USER"',
+        f'printf "{body}" | mail -s "{subject}" "$USER"',
         check=True,
         shell=True,
     )

--- a/tests/workflow_utils/test_send_email.py
+++ b/tests/workflow_utils/test_send_email.py
@@ -69,7 +69,7 @@ def test_send_email(monkeypatch):
     def mock_subprocess_run(args, check, shell):
         assert (
             args
-            == 'printf "The webpage for your run of CSET is now ready. You can view it here:\nhttps://example.com/~user/CSET" | mail -s "CSET webpage ready" -S "from=notifications" "$USER"'
+            == 'printf "The webpage for your run of CSET is now ready. You can view it here:\nhttps://example.com/~user/CSET" | mail -s "CSET webpage ready" "$USER"'
         )
         assert check
         assert shell
@@ -84,7 +84,7 @@ def test_send_email_invalid_environment_variables(monkeypatch):
     def mock_subprocess_run(args, check, shell):
         assert (
             args
-            == 'printf "The webpage for your run of CSET is now ready, though the address could not be determined.\nCheck that WEB_ADDR and WEB_DIR are set correctly, then consider filing a bug report at https://github.com/MetOffice/CSET" | mail -s "CSET webpage ready" -S "from=notifications" "$USER"'
+            == 'printf "The webpage for your run of CSET is now ready, though the address could not be determined.\nCheck that WEB_ADDR and WEB_DIR are set correctly, then consider filing a bug report at https://github.com/MetOffice/CSET" | mail -s "CSET webpage ready" "$USER"'
         )
         assert check
         assert shell


### PR DESCRIPTION
It doesn't work on the current Met Office system, and complains in the logs.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
