### PR TITLE
Send logs to stdout instead of stderr

### DIFF
--- a/src/CSET/__init__.py
+++ b/src/CSET/__init__.py
@@ -210,7 +210,7 @@ def setup_logging(verbosity: int):
 
     logging.getLogger("matplotlib.font_manager").addFilter(NoFontMessageFilter())
 
-    stderr_log = logging.StreamHandler()
+    stderr_log = logging.StreamHandler(stream=sys.stdout)
     stderr_log.setFormatter(
         logging.Formatter("%(asctime)s %(name)s %(levelname)s %(message)s")
     )

--- a/src/CSET/cset_workflow/app/fetch_fcst/bin/fetch_data.py
+++ b/src/CSET/cset_workflow/app/fetch_fcst/bin/fetch_data.py
@@ -21,6 +21,7 @@ import itertools
 import logging
 import os
 import ssl
+import sys
 import urllib.parse
 import urllib.request
 from concurrent.futures import ThreadPoolExecutor
@@ -31,7 +32,9 @@ from typing import Literal
 import isodate
 
 logging.basicConfig(
-    level=os.getenv("LOGLEVEL", "INFO"), format="%(asctime)s %(levelname)s %(message)s"
+    level=os.getenv("LOGLEVEL", "INFO"),
+    format="%(asctime)s %(levelname)s %(message)s",
+    stream=sys.stdout,
 )
 
 

--- a/src/CSET/cset_workflow/app/finish_website/bin/finish_website.py
+++ b/src/CSET/cset_workflow/app/finish_website/bin/finish_website.py
@@ -25,6 +25,7 @@ import json
 import logging
 import os
 import shutil
+import sys
 import time
 from importlib.metadata import version
 from pathlib import Path
@@ -32,7 +33,9 @@ from pathlib import Path
 from CSET._common import combine_dicts, sort_dict
 
 logging.basicConfig(
-    level=os.getenv("LOGLEVEL", "INFO"), format="%(asctime)s %(levelname)s %(message)s"
+    level=os.getenv("LOGLEVEL", "INFO"),
+    format="%(asctime)s %(levelname)s %(message)s",
+    stream=sys.stdout,
 )
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
This means they appear in `job.out` instead of being split over `job.out` and `job.err`.

This will allow us to better use the presence of `job.err` as an indicator of something having gone wrong, as the logs for normal operation are no longer sent there.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
