### PR TITLE
[Experimental] Add pickle backed load cache to fetch_fcst

### DIFF
--- a/src/CSET/cset_workflow/app/fetch_fcst/bin/fetch_data.py
+++ b/src/CSET/cset_workflow/app/fetch_fcst/bin/fetch_data.py
@@ -20,6 +20,7 @@ import glob
 import itertools
 import logging
 import os
+import pickle
 import ssl
 import sys
 import urllib.parse
@@ -30,6 +31,8 @@ from pathlib import Path
 from typing import Literal
 
 import isodate
+
+from CSET.operators import read
 
 logging.basicConfig(
     level=os.getenv("LOGLEVEL", "INFO"),
@@ -299,6 +302,23 @@ def fetch_data(file_retriever: FileRetrieverABC):
         any_files_found = any(list(files_found))
     if not any_files_found:
         raise FileNotFoundError("No files found for model!")
+
+    # Create the load cache for this model.
+    prime_load_cache(cycle_data_dir)
+
+
+def prime_load_cache(data_directory: str):
+    """Create the load cache for directory."""
+    # Load in the cubes, applying all the callbacks and such.
+    logging.info("Reading in cubes for caching.")
+    cubes = read.read_cubes(data_directory)
+    # Remove the added cset_comparison_base attribute.
+    for cube in cubes:
+        del cube.attributes["cset_comparison_base"]
+    logging.info("Writing cache file.")
+    # Pickle to a cache file.
+    with open(Path(data_directory, "loadcache.pickle"), "wb") as fp:
+        pickle.dump(cubes, fp)
 
 
 def fetch_obs(obs_retriever: FileRetrieverABC):

--- a/src/CSET/operators/read.py
+++ b/src/CSET/operators/read.py
@@ -20,6 +20,7 @@ import functools
 import glob
 import itertools
 import logging
+import pickle
 from pathlib import Path
 from typing import Literal
 
@@ -219,12 +220,19 @@ def _load_model(
     constraint: iris.Constraint | None,
 ) -> iris.cube.CubeList:
     """Load a single model's data into a CubeList."""
-    input_files = _check_input_files(paths)
-    # If unset, a constraint of None lets everything be loaded.
-    logging.debug("Constraint: %s", constraint)
-    cubes = iris.load(input_files, constraint, callback=_loading_callback)
-    # Make the UM's winds consistent with LFRic.
-    _fix_um_winds(cubes)
+    cache_file = Path(paths, "loadcache.pickle") if isinstance(paths, str) else None
+    if cache_file and cache_file.is_file():
+        # Load from pickled cache.
+        with open(cache_file, "rb") as fp:
+            all_cubes = pickle.load(fp)
+        cubes = all_cubes.extract(constraint)
+    else:
+        input_files = _check_input_files(paths)
+        # If unset, a constraint of None lets everything be loaded.
+        logging.debug("Constraint: %s", constraint)
+        cubes = iris.load(input_files, constraint, callback=_loading_callback)
+        # Make the UM's winds consistent with LFRic.
+        _fix_um_winds(cubes)
 
     # Add model_name attribute to each cube to make it available at any further
     # step without needing to pass it as function parameter.


### PR DESCRIPTION
This does the loading of the data into cubes (with all associated callbacks) once in the fetch_fcst step, vastly speeding up the loading during recipe baking.

The read operator is updated to use this cache when it is provided a directory, and that directory contains a `loadcache.pickle` file. Otherwise loading will continue as normal.

## TODO

- [ ] Unit testing
- [ ] Validation that it is actually faster (currently running)
- [x] The callbacks that realise data need fixing to not do that. #1985

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [ ] All tests and CI checks pass.
- [ ] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [ ] Marked the PR as ready to review.
