### PR TITLE
Revert "Adds capability to get last time in file for validity time and updates"

### DIFF
--- a/src/CSET/cset_workflow/app/fetch_fcst/bin/fetch_data.py
+++ b/src/CSET/cset_workflow/app/fetch_fcst/bin/fetch_data.py
@@ -217,13 +217,13 @@ def _template_file_path(
     match date_type:
         case "validity":
             date = data_time
-            while date <= data_time + forecast_length:
+            while date < data_time + forecast_length:
                 placeholder_times.append(date)
                 date += data_period
         case "initiation":
             placeholder_times.append(data_time)
             lead_time = forecast_offset
-            while lead_time <= forecast_length:
+            while lead_time < forecast_length:
                 lead_times.append(lead_time)
                 lead_time += data_period
         case _:

--- a/tests/workflow_utils/test_fetch_data.py
+++ b/tests/workflow_utils/test_fetch_data.py
@@ -186,7 +186,6 @@ def test_template_file_path_validity_time():
         "/path/2000-01-03.nc",
         "/path/2000-01-04.nc",
         "/path/2000-01-05.nc",
-        "/path/2000-01-06.nc",
     ]
     assert actual == expected
 


### PR DESCRIPTION
This reverts commit d77cb8a635a866fdd7741b7dfbd286a6a3ff9956.

Times and bounds really are confusing. The actual issue we were seeing was due to initiation time being selected rather than validity time.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [x] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [ ] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
