### PR TITLE
Remove `opt/` from workflow .gitignore

### DIFF
--- a/src/CSET/cset_workflow/.gitignore
+++ b/src/CSET/cset_workflow/.gitignore
@@ -1,6 +1,5 @@
 # Exclude site-specific files that are held in a separate private repo.
 site/
-opt/
 demo_pointstat/
 *metdb*
 restricted*


### PR DESCRIPTION
It is no longer needed, as the restricted optional configs have the restricted prefix.

Fixes #1921

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
