### PR TITLE
Gitignore NFS synchronisation files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,6 @@ dmypy.json
 
 # Ruff
 .ruff_cache/
+
+# NFS synchronisation files
+.nfs*


### PR DESCRIPTION
This prevents them from being accidentally committed, as in https://github.com/MetOffice/CSET/pull/1890/changes/48eb7154a2422ed39da89931591b0e251f2675dc

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [x] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
