### PR TITLE
Add relative gitignores for site specific files in workflow

### DIFF
--- a/src/CSET/cset_workflow/.gitignore
+++ b/src/CSET/cset_workflow/.gitignore
@@ -1,6 +1,7 @@
 # Exclude site-specific files that are held in a separate private repo.
-site/
-demo_pointstat/
+/site/
+/opt/
+/app/demo_pointstat/
 *metdb*
 restricted*
 


### PR DESCRIPTION
The previous attempt in c04f769970009602b961355b33dc5520999f6152 allows the app opt files to be included, but now doesn't exclude the top level workflow opt. To avoid this while still allowing app opt files, we now use an exclude pattern relative to the .gitignore file.

Fixes #1921 (but better.)
Follow up to #1924.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [x] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
