### PR TITLE
Switch pressure level plots to use pcolormesh

### DIFF
--- a/src/CSET/recipes/level_fields/generic_level_spatial_plot_sequence_case_aggregation_mean_all.yaml
+++ b/src/CSET/recipes/level_fields/generic_level_spatial_plot_sequence_case_aggregation_mean_all.yaml
@@ -23,7 +23,7 @@ steps:
     coordinate: time
     method: MEAN
 
-  - operator: plot.spatial_contour_plot
+  - operator: plot.spatial_pcolormesh_plot
     sequence_coordinate: time
 
   - operator: write.write_cube_to_nc

--- a/src/CSET/recipes/level_fields/generic_level_spatial_plot_sequence_case_aggregation_mean_hour_of_day.yaml
+++ b/src/CSET/recipes/level_fields/generic_level_spatial_plot_sequence_case_aggregation_mean_hour_of_day.yaml
@@ -24,7 +24,7 @@ steps:
   - operator: collapse.collapse_by_hour_of_day
     method: MEAN
 
-  - operator: plot.spatial_contour_plot
+  - operator: plot.spatial_pcolormesh_plot
     sequence_coordinate: hour
 
   - operator: write.write_cube_to_nc

--- a/src/CSET/recipes/level_fields/generic_level_spatial_plot_sequence_case_aggregation_mean_lead_time.yaml
+++ b/src/CSET/recipes/level_fields/generic_level_spatial_plot_sequence_case_aggregation_mean_lead_time.yaml
@@ -25,7 +25,7 @@ steps:
     coordinate: "forecast_reference_time"
     method: MEAN
 
-  - operator: plot.spatial_contour_plot
+  - operator: plot.spatial_pcolormesh_plot
     sequence_coordinate: forecast_period
 
   - operator: write.write_cube_to_nc


### PR DESCRIPTION
Switches pressure level spatial plots to use pcolormesh rather than contourf, given shapely geos errors arising occasionally and reproducibly, likely due to issues with the contour polygons.

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [X] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [X] All tests and CI checks pass.
- [X] Ensured the pull request title is descriptive.
- [ ] Ensure `rose-suite.conf.example` has been updated if new diagnostic added.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [X] Marked the PR as ready to review.
