### PR TITLE
Adds a differentitation operator

### DIFF
--- a/src/CSET/operators/misc.py
+++ b/src/CSET/operators/misc.py
@@ -19,7 +19,7 @@ import logging
 from collections.abc import Iterable
 
 import iris
-import iris.analysis.calculus as iac
+import iris.analysis.calculus
 import numpy as np
 from iris.cube import Cube, CubeList
 
@@ -461,7 +461,7 @@ def differentiate(
     """
     new_cubelist = iris.cube.CubeList([])
     for cube in iter_maybe(cubes):
-        dcube = iac.differentiate(cube, coordinate)
+        dcube = iris.analysis.calculus.differentiate(cube, coordinate)
         new_cubelist.append(dcube)
     if len(new_cubelist) == 1:
         return new_cubelist[0]

--- a/tests/operators/test_misc.py
+++ b/tests/operators/test_misc.py
@@ -17,6 +17,7 @@
 import datetime
 
 import iris
+import iris.analysis.calculus
 import iris.coords
 import iris.cube
 import iris.exceptions
@@ -354,4 +355,25 @@ def test_convert_units_cubelist(cube):
         expected_cubelist.append(cube_a)
     for actual, expected in zip(new_cubelist, expected_cubelist, strict=True):
         assert actual.units == expected.units
+        assert np.allclose(actual.data, expected.data, rtol=1e-6, atol=1e-2)
+
+
+def test_differentitate(vertical_profile_cube):
+    """Test a differentitation of a vertical profile cube."""
+    expected_cube = iris.analysis.calculus.differentiate(
+        vertical_profile_cube, "pressure"
+    )
+    actual_cube = misc.differentiate(vertical_profile_cube, coordinate="pressure")
+    assert np.allclose(actual_cube.data, expected_cube.data, rtol=1e-6, atol=1e-2)
+
+
+def test_differentitate_cubelist(long_forecast):
+    """Test a differentiation of a CubeList."""
+    # Create input CubeList.
+    input_cubes = iris.cube.CubeList([long_forecast, long_forecast])
+    # Create expected cube and then convert to a CubeList
+    expectedcube = iris.analysis.calculus.differentiate(long_forecast, "time")
+    expected_cubelist = iris.cube.CubeList([expectedcube, expectedcube])
+    new_cubelist = misc.differentiate(input_cubes, "time")
+    for actual, expected in zip(new_cubelist, expected_cubelist, strict=True):
         assert np.allclose(actual.data, expected.data, rtol=1e-6, atol=1e-2)


### PR DESCRIPTION
Acts as a wrapper around iris.analysis.calculus.differentiate. It is being fed into #1865 to allow calculation of extreme rainfall diagnostics in future subsequent, and related PRs.

Fixes #1959

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [x] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [ ] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Ensure `rose-suite.conf.example` has been updated if new diagnostic added.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [ ] Marked the PR as ready to review.
