### PR TITLE
Work around coverage issue with netcdf4 library

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,8 @@ relative_files = true
 source = ["src"]
 # TODO: Figure out how to test loaders. This will likely involve having some
 # example configurations and may be part of the effort to test the workflow.
-omit = ["__main__.py", "src/CSET/loaders/*.py"]
+# Omit _netCDF4.pyx to work around https://github.com/conda-forge/netcdf4-feedstock/issues/188
+omit = ["__main__.py", "src/CSET/loaders/*.py", "_netCDF4.pyx"]
 
 [tool.codespell]
 ignore-words-list = "lazyness,meaned,runn"


### PR DESCRIPTION
See https://github.com/conda-forge/netcdf4-feedstock/issues/188

A more permanent workaround than manually reverting each update PR.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Ensure `rose-suite.conf.example` has been updated if new diagnostic added.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
