### PR TITLE
Ignore failures to upload coverage report

### DIFF
--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -114,13 +114,17 @@ jobs:
         run: |
           # This links to a hosted version of the HTML report.
           tar -czf coverage-report.tar.gz htmlcov/
-          report_url="$(curl -sSf --user "token:${tmpweb_api_key}" --data-binary @coverage-report.tar.gz https://tmpweb.net)"
-          echo "Report hosted at $report_url"
-          badge_options="$(coverage json --fail-under=0 -qo - | jq -r .totals.percent_covered_display)%25-blue?style=for-the-badge"
-          echo "[![Coverage](https://img.shields.io/badge/coverage-${badge_options})](${report_url})" >> cov-report.md
-          # Edit last comment if it exists, else create new one.
-          if ! gh pr comment --repo "${repository}" --edit-last --create-if-none "${head_ref}" --body-file cov-report.md ; then
-            echo "Failed to post comment. This is likely due to this being a PR from a fork."
+          report_url="$(curl -sSf --user "token:${tmpweb_api_key}" --data-binary @coverage-report.tar.gz https://tmpweb.net || true)"
+          if [[ -n "${report_url}" ]] ; then
+            echo "Could not upload report."
+          else
+            echo "Report hosted at $report_url"
+            badge_options="$(coverage json --fail-under=0 -qo - | jq -r .totals.percent_covered_display)%25-blue?style=for-the-badge"
+            echo "[![Coverage](https://img.shields.io/badge/coverage-${badge_options})](${report_url})" >> cov-report.md
+            # Edit last comment if it exists, else create new one.
+            if ! gh pr comment --repo "${repository}" --edit-last --create-if-none "${head_ref}" --body-file cov-report.md ; then
+              echo "Failed to post comment. This is likely due to this being a PR from a fork."
+            fi
           fi
 
       - name: Check 90% minimum coverage


### PR DESCRIPTION
This handles pull requests from forks where the API token secret isn't provided.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Ensure `rose-suite.conf.example` has been updated if new diagnostic added.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
