### PR TITLE
Allow broadcast command to fail when skipping baking

### DIFF
--- a/src/CSET/cset_workflow/app/parbake_recipes/bin/parbake.py
+++ b/src/CSET/cset_workflow/app/parbake_recipes/bin/parbake.py
@@ -64,11 +64,15 @@ def main():
             cylc_cycle,
             "--namespace",
             "bake_aggregation_recipes" if aggregation else "bake_recipes",
+            "--comms-timeout",
+            "10",
             "--set",
             "run mode = skip",
             cylc_workflow_id,
         ]
-        subprocess.run(broadcast_command, check=True)
+        # Will fail if can't communicate with scheduler, but as this is just an
+        # optimisation continue on regardless.
+        subprocess.run(broadcast_command, check=False)
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
Previously this would cause the workflow to hang and then fail if the scheduler can't be reached. This can occur if the compute nodes don't have network access to the scheduler. As this is only an optimisation we can safely let the broadcast command fail and continue on.

The extra baking tasks spawned should finish instantly, though they do have to get through the queue.

Fixes #1993

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Ensure `rose-suite.conf.example` has been updated if new diagnostic added.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
