### PR TITLE
Revert "Skip rather than suicide bake task when there are no recipes"

### DIFF
--- a/src/CSET/cset_workflow/app/parbake_recipes/bin/parbake.py
+++ b/src/CSET/cset_workflow/app/parbake_recipes/bin/parbake.py
@@ -52,23 +52,21 @@ def main():
     # Parbake recipes for cycle.
     recipe_count = parbake_all(variables, rose_datac, share_dir, aggregation)
 
-    # If running under cylc, skip baking if we have no recipes.
+    # If running under cylc, notify cylc of task completion.
     cylc_workflow_id = os.getenv("CYLC_WORKFLOW_ID")
-    cylc_cycle = os.getenv("CYLC_TASK_CYCLE_POINT")
-    if cylc_workflow_id and cylc_cycle and not recipe_count:
-        print("No recipes needing to be baked; asking cylc to skip baking.")
-        broadcast_command = [
+    cylc_task_job = os.getenv("CYLC_TASK_JOB")
+    if cylc_workflow_id and cylc_task_job:
+        message_command = [
             "cylc",
-            "broadcast",
-            "--point",
-            cylc_cycle,
-            "--namespace",
-            "bake_aggregation_recipes" if aggregation else "bake_recipes",
-            "--set",
-            "run mode = skip",
+            "message",
+            "--",
             cylc_workflow_id,
+            cylc_task_job,
         ]
-        subprocess.run(broadcast_command, check=True)
+        if recipe_count:
+            subprocess.run(message_command + ["start baking"], check=True)
+        else:
+            subprocess.run(message_command + ["skip baking"], check=True)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/src/CSET/cset_workflow/flow.cylc
+++ b/src/CSET/cset_workflow/flow.cylc
@@ -39,7 +39,9 @@ final cycle point = {{CSET_TRIAL_END_DATE}}
             R1/{{date}} = """
             setup_complete[^] => parbake_recipes
             setup_complete[^] => FETCH_DATA:succeed-all => fetch_complete
-            fetch_complete & parbake_recipes => bake_recipes => cycle_complete
+            fetch_complete & parbake_recipes:start_baking? => bake_recipes
+            parbake_recipes:skip_baking? => ! bake_recipes
+            parbake_recipes:skip_baking? | bake_recipes => cycle_complete
             """
         {% endfor %}
     {% elif CSET_CYCLING_MODE == "trial" %}
@@ -47,7 +49,9 @@ final cycle point = {{CSET_TRIAL_END_DATE}}
         {{CSET_TRIAL_CYCLE_PERIOD}} = """
         setup_complete[^] => parbake_recipes
         setup_complete[^] => FETCH_DATA:succeed-all => fetch_complete
-        fetch_complete & parbake_recipes => bake_recipes => cycle_complete
+        fetch_complete & parbake_recipes:start_baking? => bake_recipes
+        parbake_recipes:skip_baking? => ! bake_recipes
+        parbake_recipes:skip_baking? | bake_recipes => cycle_complete
         """
     {% endif %}
 
@@ -55,7 +59,9 @@ final cycle point = {{CSET_TRIAL_END_DATE}}
     R1/$ = """
     # Run aggregation recipes.
     setup_complete[^] => parbake_aggregation_recipes
-    fetch_complete & parbake_aggregation_recipes => bake_aggregation_recipes => cycle_complete
+    fetch_complete & parbake_aggregation_recipes:start_baking? => bake_aggregation_recipes
+    parbake_aggregation_recipes:skip_baking? => ! bake_aggregation_recipes
+    parbake_aggregation_recipes:skip_baking? | bake_aggregation_recipes => cycle_complete
     # Finalise website and cleanup.
     cycle_complete => finish_website => send_email
     cycle_complete => housekeeping
@@ -101,8 +107,12 @@ final cycle point = {{CSET_TRIAL_END_DATE}}
     [[PARBAKE]]
         script = rose task-run -v --app-key=parbake_recipes
         execution time limit = PT5M
+        completion = succeeded and (start_baking or skip_baking)
         [[[environment]]]
             ENCODED_ROSE_SUITE_VARIABLES = {{b64json(ROSE_SUITE_VARIABLES)}}
+        [[[outputs]]]
+            start_baking='start baking'
+            skip_baking='skip baking'
 
     # Noop tasks to ensure a complete/efficient workflow graph.
     [[DUMMY_TASK]]

--- a/tests/workflow_utils/test_parbake_recipes.py
+++ b/tests/workflow_utils/test_parbake_recipes.py
@@ -27,7 +27,8 @@ def test_main(monkeypatch):
     """Check parbake.main() invokes parbake_all correctly."""
     function_ran = False
     recipes_parbaked = 0
-    cylc_broadcast_ran = False
+    cylc_message_ran = False
+    cylc_message = ""
 
     def mock_parbake_all(variables, rose_datac, share_dir, aggregation):
         nonlocal function_ran
@@ -40,9 +41,13 @@ def test_main(monkeypatch):
         return recipes_parbaked
 
     def mock_run(cmd, **kwargs):
-        nonlocal cylc_broadcast_ran
-        cylc_broadcast_ran = True
-        assert cmd[0:2] == ["cylc", "broadcast"]
+        nonlocal cylc_message
+        nonlocal cylc_message_ran
+        cylc_message_ran = True
+        assert cmd[0:3] == ["cylc", "message", "--"]
+        assert cmd[3] == "test-workflow"
+        assert cmd[4] == "test-job"
+        assert cmd[5] == cylc_message
 
     monkeypatch.setattr(parbake, "parbake_all", mock_parbake_all)
 
@@ -56,31 +61,29 @@ def test_main(monkeypatch):
     assert function_ran, "Function did not run!"
 
     # Retry without DO_CASE_AGGREGATION
-    monkeypatch.delenv("DO_CASE_AGGREGATION")
     function_ran = False
+    monkeypatch.delenv("DO_CASE_AGGREGATION")
     parbake.main()
     assert function_ran, "Function did not run!"
 
     # Retry with cylc environment variables set.
     monkeypatch.setattr(subprocess, "run", mock_run)
     monkeypatch.setenv("CYLC_WORKFLOW_ID", "test-workflow")
-    monkeypatch.setenv("CYLC_TASK_CYCLE_POINT", "20000101T0000Z")
+    monkeypatch.setenv("CYLC_TASK_JOB", "test-job")
 
     # No recipes parbaked.
     function_ran = False
-    cylc_broadcast_ran = False
     recipes_parbaked = 0
+    cylc_message = "skip baking"
     parbake.main()
-    assert function_ran, "Function did not run!"
-    assert cylc_broadcast_ran, "Cylc broadcast should have run."
+    assert cylc_message_ran, "Cylc message function did not run!"
 
     # Some recipes parbaked.
     function_ran = False
-    cylc_broadcast_ran = False
     recipes_parbaked = 3
+    cylc_message = "start baking"
     parbake.main()
-    assert function_ran, "Function did not run!"
-    assert not cylc_broadcast_ran, "Cylc broadcast should not have run."
+    assert cylc_message_ran, "Cylc message function did not run!"
 
 
 def test_parbake_all_none_enabled(tmp_working_dir, monkeypatch):


### PR DESCRIPTION
This reverts commit 9866e197f932f77cd2bc3b695ce0b399ebd0cb79.

Fixes #1993

Tested on a local workflow and sucessfully suicides the aggregation task when no jobs to run.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [x] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Ensure `rose-suite.conf.example` has been updated if new diagnostic added.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
