### PR TITLE
Correctly handle scalar coords in aggregated cubes

### DIFF
--- a/src/CSET/operators/_utils.py
+++ b/src/CSET/operators/_utils.py
@@ -24,6 +24,7 @@ import re
 from datetime import timedelta
 
 import iris
+import iris.coords
 import iris.cube
 import iris.exceptions
 import iris.util
@@ -403,7 +404,7 @@ def is_time_aggregatable(cube: iris.cube.Cube) -> bool:
     """Determine whether a cube can be aggregated in time.
 
     If a cube is aggregatable it will contain both a 'forecast_reference_time'
-    and 'forecast_period' coordinate as dimensional coordinates.
+    and 'forecast_period' coordinate as dimension or scalar coordinates.
 
     Arguments
     ---------
@@ -422,8 +423,15 @@ def is_time_aggregatable(cube: iris.cube.Cube) -> bool:
     # Acceptable time coordinate names for aggregatable cube.
     TEMPORAL_COORD_NAMES = ["forecast_period", "forecast_reference_time"]
 
-    # Coordinate names for the cube.
-    coord_names = [coord.name() for coord in cube.coords(dim_coords=True)]
+    def strictly_monotonic(coord: iris.coords.Coord) -> bool:
+        """Return whether a coord is strictly monotonic, catching errors."""
+        try:
+            return coord.is_monotonic()
+        except iris.exceptions.CoordinateMultiDimError:
+            return False
+
+    # Strictly monotonic coordinate names for the cube.
+    coord_names = [coord.name() for coord in cube.coords() if strictly_monotonic(coord)]
 
     # Check which temporal coordinates we have.
     temporal_coords = [coord for coord in coord_names if coord in TEMPORAL_COORD_NAMES]

--- a/src/CSET/operators/aggregate.py
+++ b/src/CSET/operators/aggregate.py
@@ -20,6 +20,8 @@ import iris
 import iris.analysis
 import iris.coord_categorisation
 import iris.cube
+import iris.exceptions
+import iris.util
 import isodate
 import numpy as np
 
@@ -179,9 +181,15 @@ def ensure_aggregatable_across_cases(
         # Create an aggregatable cube from the provided CubeList.
         to_merge = iris.cube.CubeList()
         for cube in bucket:
-            to_merge.extend(
-                cube.slices_over(["forecast_period", "forecast_reference_time"])
-            )
+            try:
+                to_merge.extend(
+                    cube.slices_over(["forecast_period", "forecast_reference_time"])
+                )
+            except iris.exceptions.CoordinateNotFoundError as err:
+                raise ValueError(
+                    "Cube should have 'forecast_period' and 'forecast_reference_time' dimension coordinates.",
+                    cube,
+                ) from err
         aggregatable_cube = to_merge.merge_cube()
 
         # Add attribute on number of forecast_reference_times

--- a/tests/operators/test_aggregate.py
+++ b/tests/operators/test_aggregate.py
@@ -56,10 +56,10 @@ def test_ensure_aggregatable_across_cases_true_aggregatable_cube(
     )
 
 
-def test_ensure_aggregatable_across_cases_false_aggregatable_cube(long_forecast):
+def test_ensure_aggregatable_across_cases_false_aggregatable_cube(cardington_cube):
     """Check that a non-aggregatable cube raises an error."""
     with pytest.raises(ValueError):
-        aggregate.ensure_aggregatable_across_cases(long_forecast)
+        aggregate.ensure_aggregatable_across_cases(cardington_cube)
 
 
 def test_ensure_aggregatable_across_cases_cubelist(

--- a/tests/operators/test_utils.py
+++ b/tests/operators/test_utils.py
@@ -344,9 +344,9 @@ def test_slice_over_ensemble(long_forecast):
     )
 
 
-def test_is_time_aggregatable_False(long_forecast):
+def test_is_time_aggregatable_False(cardington_cube):
     """Check that a cube that is not time aggregatable returns False."""
-    assert not operator_utils.is_time_aggregatable(long_forecast)
+    assert not operator_utils.is_time_aggregatable(cardington_cube)
 
 
 def test_is_time_aggregatable(long_forecast_multi_day):


### PR DESCRIPTION
This opens up the aggregation recipes to support aggregating across single values, which while theoretically useless ensures that aggregation can remain enabled across varied data.

Testing on a single forecast (2026-04-07T05:00Z initialisation time) of MOGREPS-UK forecast PP files from MASS worked.

Fixes #2023.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [x] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Ensure `rose-suite.conf.example` has been updated if new diagnostic added.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
