### PR TITLE
Fix custom style file support in workflow

### DIFF
--- a/src/CSET/cset_workflow/app/bake_recipes/bin/bake.sh
+++ b/src/CSET/cset_workflow/app/bake_recipes/bin/bake.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 cset_command=( cset bake \
     --recipe "$1" \
     --output-dir "${CYLC_WORKFLOW_SHARE_DIR}/web/plots/${CYLC_TASK_CYCLE_POINT}/$(basename "$1" .yaml)" \
-    ${COLORBAR_FILE:+"--style-file='${CYLC_WORKFLOW_SHARE_DIR}/style.json'"} \
+    ${COLORBAR_FILE:+"--style-file=${CYLC_WORKFLOW_SHARE_DIR}/style.json"} \
     ${PLOT_RESOLUTION:+"--plot-resolution=$PLOT_RESOLUTION"} \
     ${SKIP_WRITE:+"--skip-write"} )
 

--- a/src/CSET/cset_workflow/flow.cylc
+++ b/src/CSET/cset_workflow/flow.cylc
@@ -94,6 +94,7 @@ final cycle point = {{CSET_TRIAL_END_DATE}}
 
         CONDA_PATH = {{CONDA_PATH}}
         LOGLEVEL = {{LOGLEVEL}}
+        COLORBAR_FILE = {{COLORBAR_FILE}}
         PLOT_RESOLUTION = {{PLOT_RESOLUTION|default(100)}}
         {% if SKIP_WRITE|default(False) %}
         SKIP_WRITE = True
@@ -137,7 +138,6 @@ final cycle point = {{CSET_TRIAL_END_DATE}}
     # consistency between the many runs.
     execution time limit = PT5M
         [[[environment]]]
-        COLORBAR_FILE = {{COLORBAR_FILE}}
         MODEL_NAMES = {{ b64json(models|map(attribute="name")|list) }}
 
     {% for model in models %}


### PR DESCRIPTION
This was broken is two ways. The environment variable wasn't being set in the baking task, so the override wasn't being used, and the quoting was incorrect stopping the CYLC_WORKFLOW_SHARE_DIR expanding.

Fixes #1990

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Ensure `rose-suite.conf.example` has been updated if new diagnostic added.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
