### PR TITLE
Add behavioural tests for generate_cell_methods_constraint

### DIFF
--- a/tests/operators/test_constraints.py
+++ b/tests/operators/test_constraints.py
@@ -16,9 +16,26 @@
 
 from datetime import datetime
 
+import iris.coords
+import iris.cube
+import numpy as np
 import pytest
 
 from CSET.operators import constraints
+
+
+def _cube_with_cell_methods(methods):
+    """Build a minimal ``iris.cube.Cube`` carrying the named cell methods.
+
+    Used by the ``generate_cell_methods_constraint`` tests below to exercise
+    the generated constraint's actual filtering behaviour rather than its
+    ``repr()``.
+    """
+    return iris.cube.Cube(
+        np.array([0.0]),
+        var_name="x",
+        cell_methods=[iris.coords.CellMethod(m) for m in methods],
+    )
 
 
 def test_generate_stash_constraint():
@@ -42,34 +59,43 @@ def test_generate_var_constraint_stash():
     assert repr(var_constraint) == expected_stash_constraint
 
 
-def test_generate_cell_methods_constraint():
-    """Generate iris cube constraint for cell methods."""
+def test_generate_cell_methods_constraint_mean():
+    """``cell_methods=["mean"]`` accepts only cubes with a ``mean`` cell method."""
     cell_methods_constraint = constraints.generate_cell_methods_constraint(["mean"])
-    expected_cell_methods_constraint = "Constraint(cube_func=<function generate_cell_methods_constraint.<locals>.check_cell_methods at"
-    assert expected_cell_methods_constraint in repr(cell_methods_constraint)
+    assert (
+        _cube_with_cell_methods(["mean"]).extract(cell_methods_constraint) is not None
+    )
+    assert _cube_with_cell_methods(["sum"]).extract(cell_methods_constraint) is None
+    assert _cube_with_cell_methods([]).extract(cell_methods_constraint) is None
 
 
 def test_generate_cell_methods_constraint_sum():
-    """Generate aggregate iris cube constraint for cell methods."""
+    """``cell_methods=["sum"]`` accepts only cubes with a ``sum`` cell method."""
     cell_methods_constraint = constraints.generate_cell_methods_constraint(["sum"])
-    expected_cell_methods_constraint = "Constraint(cube_func=<function generate_cell_methods_constraint.<locals>.check_cell_methods at"
-    assert expected_cell_methods_constraint in repr(cell_methods_constraint)
+    assert _cube_with_cell_methods(["sum"]).extract(cell_methods_constraint) is not None
+    assert _cube_with_cell_methods(["mean"]).extract(cell_methods_constraint) is None
+    assert _cube_with_cell_methods([]).extract(cell_methods_constraint) is None
 
 
 def test_generate_cell_methods_constraint_no_aggregation():
-    """Generate iris cube constraint for no aggregation cell methods."""
+    """Empty ``cell_methods`` means instantaneous: accept point or empty, reject aggregates."""
     cell_methods_constraint = constraints.generate_cell_methods_constraint([])
-    expected_cell_methods_constraint = "Constraint(cube_func=<function generate_cell_methods_constraint.<locals>.check_no_aggregation at"
-    assert expected_cell_methods_constraint in repr(cell_methods_constraint)
+    assert _cube_with_cell_methods([]).extract(cell_methods_constraint) is not None
+    assert (
+        _cube_with_cell_methods(["point"]).extract(cell_methods_constraint) is not None
+    )
+    assert _cube_with_cell_methods(["mean"]).extract(cell_methods_constraint) is None
+    assert _cube_with_cell_methods(["sum"]).extract(cell_methods_constraint) is None
 
 
-def test_generate_cell_methods_constraint_varname():
-    """Generate variable-dependent iris cube constraint for cell methods."""
+def test_generate_cell_methods_constraint_varname_requires_sum():
+    """For ``number_of_lightning_flashes``, only ``sum`` cell_method inputs are valid."""
     cell_methods_constraint = constraints.generate_cell_methods_constraint(
         [], "number_of_lightning_flashes"
     )
-    expected_cell_methods_constraint = "Constraint(cube_func=<function generate_cell_methods_constraint.<locals>.check_cell_sum at"
-    assert expected_cell_methods_constraint in repr(cell_methods_constraint)
+    assert _cube_with_cell_methods(["sum"]).extract(cell_methods_constraint) is not None
+    assert _cube_with_cell_methods(["mean"]).extract(cell_methods_constraint) is None
+    assert _cube_with_cell_methods([]).extract(cell_methods_constraint) is None
 
 
 def test_generate_time_constraint():

--- a/tests/operators/test_constraints.py
+++ b/tests/operators/test_constraints.py
@@ -18,7 +18,6 @@ from datetime import datetime
 
 import iris.coords
 import iris.cube
-import numpy as np
 import pytest
 
 from CSET.operators import constraints
@@ -32,7 +31,7 @@ def _cube_with_cell_methods(methods):
     ``repr()``.
     """
     return iris.cube.Cube(
-        np.array([0.0]),
+        shape=(1,),
         var_name="x",
         cell_methods=[iris.coords.CellMethod(m) for m in methods],
     )


### PR DESCRIPTION
## What changed

Partial fix for #838 — narrow and careful.

The four `generate_cell_methods_constraint` tests in `tests/operators/test_constraints.py` were the specific ones @SGallagherMet flagged in the [PR #765 review](https://github.com/MetOffice/CSET/pull/765#discussion_r1740967262), where `repr(constraint)` only surfaced an opaque `<function ...check_cell_methods at 0x...>`. A test like:

```python
assert "<function generate_cell_methods_constraint.<locals>.check_cell_methods at" in repr(cell_methods_constraint)
```

would happily pass if `check_cell_methods` were replaced by `def check_cell_methods(cube): return False`. That is the exact failure mode the issue describes.

This PR replaces those four tests with behavioural tests that exercise the underlying filter:

- Build a minimal `iris.cube.Cube` carrying the cell methods under test (via a small `_cube_with_cell_methods(methods)` helper).
- Call `cube.extract(constraint)` and assert whether the cube is kept or dropped.

That catches the swap-with-nonsense regression: if `check_cell_methods` returned `False` for everything, the "accepts mean" assertion would immediately fail.

## Coverage of the four cases

| Case | Accepts | Rejects |
|---|---|---|
| `cell_methods=["mean"]` | mean | sum, empty |
| `cell_methods=["sum"]` | sum | mean, empty |
| `cell_methods=[]` (no aggregation) | empty, point | mean, sum |
| `cell_methods=[]`, `varname="number_of_lightning_flashes"` | sum | mean, empty |

The last row reflects the existing `check_cell_sum` branch in `generate_cell_methods_constraint`.

## Scope

Intentionally narrow. The other `repr()` assertions in the file (e.g., `test_generate_time_constraint`, `test_generate_area_constraint`) check substantive constraint-value information that would not pass if swapped with nonsense, so they are not weak in the same way #838 calls out. Happy to revisit them in a follow-up PR if you want a broader sweep.

## Test

Ran locally:

```
tests/operators/test_constraints.py ..........................
============================== 26 passed in 0.19s ==============================
```

Includes the four new tests (`..._mean`, `..._sum`, `..._no_aggregation`, `..._varname_requires_sum`) plus all 22 existing tests unchanged.

## Closes

#838.


This PR contains AI generated code from Claude Code.
