### PR TITLE
Use } as / replacement in symlink filenames

### DIFF
--- a/src/CSET/cset_workflow/app/fetch_fcst/bin/fetch_data.py
+++ b/src/CSET/cset_workflow/app/fetch_fcst/bin/fetch_data.py
@@ -115,8 +115,8 @@ class FilesystemFileRetriever(FileRetrieverABC):
                 # Save to a filename derived from the full path, to
                 # differentiate similarly named files from different
                 # directories.
-                # `)` replaces `/` as it can be in file names.
-                os.symlink(file, f"{output_dir}/{')'.join(file.parts)}")
+                # `}` replaces `/` as it can be in file names.
+                os.symlink(file, f"{output_dir}/{'}'.join(file.parts)}")
                 any_files_copied = True
             except OSError as err:
                 logging.warning("Failed to copy %s, error: %s", file, err)


### PR DESCRIPTION
Unlike ) the character } is not a shell metacharacter, and thus doesn't cause issues when not quoted. This is especially an issue as libnetcdf < 4.10 doesn't properly quote a shell command it uses, producing concerning (but ultimately harmless) log messages.

Fixes #2083

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Ensure `rose-suite.conf.example` has been updated if new diagnostic added.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
