### PR TITLE
Correct file_paths in tutorial recipe

### DIFF
--- a/docs/source/getting-started/air_temperature_spatial_plot.yaml
+++ b/docs/source/getting-started/air_temperature_spatial_plot.yaml
@@ -13,7 +13,7 @@ steps:
   # Specify the operator to run in each step.
   - operator: read.read_cubes
     # Specify the name of the argument, and its value.
-    file_paths: "/data/*.nc"
+    file_paths: "$INPUT_PATHS"
 
   - operator: filters.filter_cubes
     # Can specify extra keyword arguments as sub-maps.


### PR DESCRIPTION
This was causing the tutorial example to not work.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [x] Documentation has been updated to reflect change.
- [x] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Ensure `rose-suite.conf.example` has been updated if new diagnostic added.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
