### PR TITLE
Enforce the description toggle on iframe load

### DIFF
--- a/src/CSET/cset_workflow/app/finish_website/file/html/script.js
+++ b/src/CSET/cset_workflow/app/finish_website/file/html/script.js
@@ -425,7 +425,7 @@ function setup_description_toggle_button() {
   });
   // Ensure the description toggle persists across changing the frame content.
   for (const plot_frame of document.querySelectorAll("iframe")) {
-    plot_frame.addEventListener("DOMContentLoaded", () => {
+    plot_frame.addEventListener("load", () => {
       enforce_description_toggle();
     });
   }


### PR DESCRIPTION
The DOMContentLoaded event doesn't seem to fire. Load does however, so we can use that instead.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Ensure `rose-suite.conf.example` has been updated if new diagnostic added.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
