### PR TITLE
Don't guess instantaneous time coordinate bounds

### DIFF
--- a/requirements/environment.yml
+++ b/requirements/environment.yml
@@ -32,6 +32,7 @@ dependencies:
   - pytest-cov
   - pytest-xdist
   - pytest-playwright
+  - libnetcdf
 
   # Documentation dependencies
   - sphinx >= 6.0

--- a/src/CSET/operators/read.py
+++ b/src/CSET/operators/read.py
@@ -203,6 +203,12 @@ def read_cubes(
     # Ensure dimension coordinates are bounded.
     for cube in cubes:
         for dim_coord in cube.coords(dim_coords=True):
+            if (dim_coord.standard_name == "time") and (
+                dim_coord.name()
+                not in itertools.chain([m.coord_names for m in cube.cell_methods])
+            ):
+                # Instantaneous time coordinate
+                continue
             # Iris can't guess the bounds of a scalar coordinate.
             if not dim_coord.has_bounds() and dim_coord.shape[0] > 1:
                 dim_coord.guess_bounds()

--- a/src/CSET/operators/read.py
+++ b/src/CSET/operators/read.py
@@ -205,7 +205,9 @@ def read_cubes(
         for dim_coord in cube.coords(dim_coords=True):
             if (dim_coord.standard_name == "time") and (
                 dim_coord.name()
-                not in itertools.chain.from_iterable(m.coord_names for m in cube.cell_methods if m.method != "point")
+                not in itertools.chain.from_iterable(
+                    m.coord_names for m in cube.cell_methods if m.method != "point"
+                )
             ):
                 # Instantaneous time coordinate
                 continue

--- a/src/CSET/operators/read.py
+++ b/src/CSET/operators/read.py
@@ -205,7 +205,7 @@ def read_cubes(
         for dim_coord in cube.coords(dim_coords=True):
             if (dim_coord.standard_name == "time") and (
                 dim_coord.name()
-                not in itertools.chain([m.coord_names for m in cube.cell_methods])
+                not in itertools.chain.from_iterable(m.coord_names for m in cube.cell_methods)
             ):
                 # Instantaneous time coordinate
                 continue

--- a/src/CSET/operators/read.py
+++ b/src/CSET/operators/read.py
@@ -205,7 +205,7 @@ def read_cubes(
         for dim_coord in cube.coords(dim_coords=True):
             if (dim_coord.standard_name == "time") and (
                 dim_coord.name()
-                not in itertools.chain.from_iterable(m.coord_names for m in cube.cell_methods)
+                not in itertools.chain.from_iterable(m.coord_names for m in cube.cell_methods if m.method != "point")
             ):
                 # Instantaneous time coordinate
                 continue

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,11 +18,37 @@ https://docs.pytest.org/en/latest/reference/fixtures.html#conftest-py-sharing-fi
 """
 
 from pathlib import Path
+import subprocess
 
 import iris.cube
 import pytest
 
 from CSET.operators import constraints, filters, read
+
+
+def cdl_to_nc(name: str, cdl: str, outpath: Path) -> Path:
+    """
+    Convert a CDL description into a netcdf file.
+
+    Creates a file ``outpath/name.nc``
+
+    See https://docs.unidata.ucar.edu/nug/2.0-draft/cdl.html for the details of
+    CDL format.
+
+    Args:
+        name: prefix of the output file name
+        cdl: CDL description of the data
+        output: output directory
+
+    Returns:
+        Path of the created netcdf file
+    """
+    cdlpath = outpath / f"{name}.cdl"
+    ncpath = outpath / f"{name}.nc"
+    with open(cdlpath, "w") as f:
+        f.write(cdl)
+    subprocess.run(['ncgen','-k', 'nc4','-o',str(ncpath), str(cdlpath)], check=True)
+    return ncpath
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,8 +17,8 @@
 https://docs.pytest.org/en/latest/reference/fixtures.html#conftest-py-sharing-fixtures-across-multiple-files
 """
 
-from pathlib import Path
 import subprocess
+from pathlib import Path
 
 import iris.cube
 import pytest
@@ -30,24 +30,29 @@ def cdl_to_nc(name: str, cdl: str, outpath: Path) -> Path:
     """
     Convert a CDL description into a netcdf file.
 
-    Creates a file ``outpath/name.nc``
+    Parameters
+    ----------
+    name
+        prefix of the output file name
+    cdl
+        CDL description of the data
+    output
+        output directory
 
+    Returns
+    -------
+        Path of the created netcdf file (``{outdir}/{name}.nc``)
+
+    Notes
+    -----
     See https://docs.unidata.ucar.edu/nug/2.0-draft/cdl.html for the details of
     CDL format.
-
-    Args:
-        name: prefix of the output file name
-        cdl: CDL description of the data
-        output: output directory
-
-    Returns:
-        Path of the created netcdf file
     """
     cdlpath = outpath / f"{name}.cdl"
     ncpath = outpath / f"{name}.nc"
     with open(cdlpath, "w") as f:
         f.write(cdl)
-    subprocess.run(['ncgen','-k', 'nc4','-o',str(ncpath), str(cdlpath)], check=True)
+    subprocess.run(["ncgen", "-k", "nc4", "-o", str(ncpath), str(cdlpath)], check=True)
     return ncpath
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,42 +18,86 @@ https://docs.pytest.org/en/latest/reference/fixtures.html#conftest-py-sharing-fi
 """
 
 import subprocess
+from collections.abc import Callable
 from pathlib import Path
+from uuid import uuid4
 
+import iris
 import iris.cube
 import pytest
 
 from CSET.operators import constraints, filters, read
 
 
-def cdl_to_nc(name: str, cdl: str, outpath: Path) -> Path:
-    """
-    Convert a CDL description into a netcdf file.
+@pytest.fixture
+def cdl_to_nc_path(tmp_path) -> Callable[[str], Path]:
+    """Get a callback that will create a temporary NetCDF file based on a CDL definition."""
 
-    Parameters
-    ----------
-    name
-        prefix of the output file name
-    cdl
-        CDL description of the data
-    output
-        output directory
+    def cdl_to_nc(cdl: str) -> Path:
+        """
+        Convert a CDL description into a netcdf file.
 
-    Returns
-    -------
-        Path of the created netcdf file (``{outdir}/{name}.nc``)
+        Parameters
+        ----------
+        name
+            prefix of the output file name
+        cdl
+            CDL description of the data
+        output
+            output directory
 
-    Notes
-    -----
-    See https://docs.unidata.ucar.edu/nug/2.0-draft/cdl.html for the details of
-    CDL format.
-    """
-    cdlpath = outpath / f"{name}.cdl"
-    ncpath = outpath / f"{name}.nc"
-    with open(cdlpath, "w") as f:
-        f.write(cdl)
-    subprocess.run(["ncgen", "-k", "nc4", "-o", str(ncpath), str(cdlpath)], check=True)
-    return ncpath
+        Returns
+        -------
+            Path of the created netcdf file (``{outdir}/{name}.nc``)
+
+        Notes
+        -----
+        See https://docs.unidata.ucar.edu/nug/2.0-draft/cdl.html for the details of
+        CDL format.
+        """
+        # Random UUID
+        name = uuid4()
+
+        cdl_path = tmp_path / f"{name}.cdl"
+        nc_path = tmp_path / f"{name}.nc"
+        with open(cdl_path, "w") as f:
+            f.write(cdl)
+        subprocess.run(
+            ["ncgen", "-k", "nc4", "-o", str(nc_path), str(cdl_path)], check=True
+        )
+        return nc_path
+
+    return cdl_to_nc
+
+
+@pytest.fixture
+def cdl_to_cubes(
+    cdl_to_nc_path,
+) -> Callable[[str, str | iris.Constraint | None], iris.cube.CubeList]:
+    """Get a callback that will create CSET cubes based on a CDL definition."""
+
+    def callback(
+        cdl: str, constraint: str | iris.Constraint | None = None
+    ) -> iris.cube.CubeList:
+        path = cdl_to_nc_path(cdl)
+        return read.read_cubes(path, constraint)  # noqa
+
+    return callback
+
+
+@pytest.fixture
+def cdl_to_cube(
+    cdl_to_nc_path,
+) -> Callable[[str, str | iris.Constraint | None], iris.cube.Cube]:
+    """Get a callback that will create a CSET cube based on a CDL definition."""
+
+    def callback(
+        cdl: str, constraint: str | iris.Constraint | None = None
+    ) -> iris.cube.Cube:
+        path = cdl_to_nc_path(cdl)
+        return read.read_cube(path, constraint)  # noqa
+
+    return callback
 
 
 @pytest.fixture()

--- a/tests/operators/test_collapse.py
+++ b/tests/operators/test_collapse.py
@@ -285,8 +285,8 @@ def test_collapse_by_validity_time_no_time_coordinate(long_forecast_multi_day):
 
 def test_collapse_by_validity_time_no_common_points(cube):
     """Test exception when there are no common time points between cubes."""
-    c1 = cube.extract(iris.Constraint(time=datetime.datetime(2022, 9, 21, 2, 30)))
-    c2 = cube.extract(iris.Constraint(time=datetime.datetime(2022, 9, 21, 4, 30)))
+    c1 = cube.extract(iris.Constraint(time=datetime.datetime(2022, 9, 21, 3, 0)))
+    c2 = cube.extract(iris.Constraint(time=datetime.datetime(2022, 9, 21, 5, 0)))
     cubes = iris.cube.CubeList([c1, c2])
     with pytest.raises(
         ValueError,

--- a/tests/operators/test_imageprocessing.py
+++ b/tests/operators/test_imageprocessing.py
@@ -139,7 +139,7 @@ def test_SSIM_incorrect_number_of_cubes(cube: iris.cube.Cube):
 
 def test_SSIM_no_time_coord(cube: iris.cube.Cube):
     """Test SSIM fails with no time coordinate."""
-    c1 = cube.extract(iris.Constraint(time=datetime.datetime(2022, 9, 21, 3, 30)))
+    c1 = cube.extract(iris.Constraint(time=datetime.datetime(2022, 9, 21, 3, 0)))
     c1.remove_coord("time")
     c2 = c1.copy()
     del c2.attributes["cset_comparison_base"]

--- a/tests/operators/test_misc.py
+++ b/tests/operators/test_misc.py
@@ -223,7 +223,7 @@ def test_difference_no_var_name_fallback(cube: iris.cube.Cube):
 
 def test_difference_no_time_coord(cube):
     """Difference of cubes with no time coordinate."""
-    c1 = cube.extract(iris.Constraint(time=datetime.datetime(2022, 9, 21, 3, 30)))
+    c1 = cube.extract(iris.Constraint(time=datetime.datetime(2022, 9, 21, 3, 0)))
     c1.remove_coord("time")
     c2 = c1.copy()
     del c2.attributes["cset_comparison_base"]

--- a/tests/operators/test_plot.py
+++ b/tests/operators/test_plot.py
@@ -25,7 +25,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 
-from CSET.operators import collapse, misc, plot, read
+from CSET.operators import collapse, constraints, filters, misc, plot, read
 
 
 def test_check_single_cube():
@@ -1234,16 +1234,23 @@ def test_get_start_end_strings_nobounds(cube):
     assert fname == "_20220921030000_20220921050000"
 
 
-def test_get_start_end_strings_bounds(cube):
+def test_get_start_end_strings_bounds(cubes):
     """Test setting (startstring, endstring) from coord bounds."""
+    # Get a field with time bounds
+    cube = filters.filter_cubes(
+        cubes,
+        constraints.generate_cell_methods_constraint(
+            ["minimum"], coord="time", interval="1 hour"
+        ),
+    )
+
     title, fname = plot._get_start_end_strings(cube.coord("time"), use_bounds=True)
-    assert title == "\n [2022-09-21 02:30:00 to 2022-09-21 05:30:00]"
-    assert fname == "_20220921023000_20220921053000"
+    assert title == "\n [2022-09-21 03:00:00 to 2022-09-21 05:00:00]"
+    assert fname == "_20220921030000_20220921050000"
 
 
 def test_get_start_end_strings_remove_bounds(cube):
     """Test setting (startstring, endstring) from coord with no bounds."""
-    cube.coord("time").bounds = None
     title, fname = plot._get_start_end_strings(cube.coord("time"), use_bounds=True)
     assert title == "\n [2022-09-21 03:00:00 to 2022-09-21 05:00:00]"
     assert fname == "_20220921030000_20220921050000"

--- a/tests/operators/test_read.py
+++ b/tests/operators/test_read.py
@@ -27,6 +27,7 @@ import pytest
 from iris.time import PartialDateTime
 
 from CSET.operators import constraints, read
+from ..conftest import cdl_to_nc
 
 
 def test_read_cubes():
@@ -1174,18 +1175,6 @@ def test_normalise_ML_varname(transect_source_cube):
     assert cube.long_name == "temperature_at_pressure_levels"
 
 
-def test_time_bounds():
-    """Only cubes with time processing have time bounds."""
-    cubes = read.read_cubes("tests/test_data/air_temp.nc")
-    for c in cubes:
-        if c.coord("time").shape == (2,):
-            # Time processed fields
-            assert c.coord("time").bounds is not None
-        else:
-            # Instantaneous field
-            assert c.coord("time").bounds is None
-
-
 def test_read_time_constraint_in_bounds():
     """Cubes can be selected with any time inside the bounds."""
     cubes = read.read_cubes(
@@ -1201,3 +1190,53 @@ def test_read_time_constraint_in_bounds():
             # Time processed field was loaded even though its time doesn't match
             # since the constraint is inside time bounds
             assert c.coord("time").as_string_arrays().points == ["2022-09-21 03:30:00"]
+
+
+def test_cell_methods_computes_time_bounds(tmp_path):
+    """Only cubes with time processing have time bounds."""
+    # NC file with missing time bounds and various methods
+    cdl = """
+    netcdf cell_methods_sample {
+    dimensions:
+        lat = 2, lon = 2, time = 2; bnds = 2;
+    variables:
+        float lat(lat), lon(lon), time(time);
+        float lat_bnds(lat, bnds), lon_bnds(lon, bnds);
+            lat:standard_name = "latitude";
+            lat:bounds = "lat_bnds";
+            lon:standard_name = "longitude";
+            lon:bounds = "lon_bnds";
+            time:standard_name = "time";
+            time:units = "days since 2001-01-01";
+
+        float time_instant(time, lat, lon);
+        float time_point(time, lat, lon);
+            time_point:cell_methods = "time: point";
+        float time_mean(time, lat, lon);
+            time_mean:cell_methods = "time: mean";
+        float area_mean(time, lat, lon);
+            area_mean:cell_methods = "area: mean";
+        float all_mean(time, lat, lon);
+            all_mean:cell_methods = "area: mean time: mean";
+        float multi_mean(time, lat, lon);
+            multi_mean:cell_methods = "area: time: mean";
+    data:
+        time = 1, 2;
+        lat = 1, 2;
+        lon = 1, 2;
+        lat_bnds = 0.5, 1.5, 1.5, 2.5;
+        lon_bnds = 0.5, 1.5, 1.5, 2.5;
+    }
+    """
+    sample = cdl_to_nc("cell_methods_sample", cdl, tmp_path)
+    cubes = read.read_cubes(sample)
+
+    # Variables which should not have bounds
+    assert cubes.extract_cube("time_instant").coord('time').bounds is None
+    assert cubes.extract_cube("time_point").coord('time').bounds is None
+    assert cubes.extract_cube("area_mean").coord('time').bounds is None
+
+    # Variables which should have bounds
+    assert cubes.extract_cube("time_mean").coord('time').bounds is not None
+    assert cubes.extract_cube("all_mean").coord('time').bounds is not None
+    assert cubes.extract_cube("multi_mean").coord('time').bounds is not None

--- a/tests/operators/test_read.py
+++ b/tests/operators/test_read.py
@@ -1178,7 +1178,6 @@ def test_time_bounds():
     """Only cubes with time processing have time bounds."""
     cubes = read.read_cubes("tests/test_data/air_temp.nc")
     for c in cubes:
-        print(c)
         if c.coord("time").shape == (2,):
             # Time processed fields
             assert c.coord("time").bounds is not None

--- a/tests/operators/test_read.py
+++ b/tests/operators/test_read.py
@@ -28,8 +28,6 @@ from iris.time import PartialDateTime
 
 from CSET.operators import constraints, read
 
-from ..conftest import cdl_to_nc
-
 
 def test_read_cubes():
     """Read cube and verify."""
@@ -1193,7 +1191,7 @@ def test_read_time_constraint_in_bounds():
             assert c.coord("time").as_string_arrays().points == ["2022-09-21 03:30:00"]
 
 
-def test_cell_methods_computes_time_bounds(tmp_path):
+def test_cell_methods_computes_time_bounds(cdl_to_cubes):
     """Only cubes with time processing have time bounds."""
     # NC file with missing time bounds and various methods
     cdl = """
@@ -1229,8 +1227,7 @@ def test_cell_methods_computes_time_bounds(tmp_path):
         lon_bnds = 0.5, 1.5, 1.5, 2.5;
     }
     """
-    sample = cdl_to_nc("cell_methods_sample", cdl, tmp_path)
-    cubes = read.read_cubes(sample)
+    cubes = cdl_to_cubes(cdl)
 
     # Variables which should not have bounds
     assert cubes.extract_cube("time_instant").coord("time").bounds is None

--- a/tests/operators/test_read.py
+++ b/tests/operators/test_read.py
@@ -27,6 +27,7 @@ import pytest
 from iris.time import PartialDateTime
 
 from CSET.operators import constraints, read
+
 from ..conftest import cdl_to_nc
 
 
@@ -1232,11 +1233,11 @@ def test_cell_methods_computes_time_bounds(tmp_path):
     cubes = read.read_cubes(sample)
 
     # Variables which should not have bounds
-    assert cubes.extract_cube("time_instant").coord('time').bounds is None
-    assert cubes.extract_cube("time_point").coord('time').bounds is None
-    assert cubes.extract_cube("area_mean").coord('time').bounds is None
+    assert cubes.extract_cube("time_instant").coord("time").bounds is None
+    assert cubes.extract_cube("time_point").coord("time").bounds is None
+    assert cubes.extract_cube("area_mean").coord("time").bounds is None
 
     # Variables which should have bounds
-    assert cubes.extract_cube("time_mean").coord('time').bounds is not None
-    assert cubes.extract_cube("all_mean").coord('time').bounds is not None
-    assert cubes.extract_cube("multi_mean").coord('time').bounds is not None
+    assert cubes.extract_cube("time_mean").coord("time").bounds is not None
+    assert cubes.extract_cube("all_mean").coord("time").bounds is not None
+    assert cubes.extract_cube("multi_mean").coord("time").bounds is not None

--- a/tests/operators/test_read.py
+++ b/tests/operators/test_read.py
@@ -1172,3 +1172,16 @@ def test_normalise_ML_varname(transect_source_cube):
     cube.rename = "air_temperature"
     read._normalise_ML_varname(cube)
     assert cube.long_name == "temperature_at_pressure_levels"
+
+
+def test_time_bounds():
+    """Only cubes with time processing have time bounds."""
+    cubes = read.read_cubes("tests/test_data/air_temp.nc")
+    for c in cubes:
+        print(c)
+        if c.coord("time").shape == (2,):
+            # Time processed fields
+            assert c.coord("time").bounds is not None
+        else:
+            # Instantaneous field
+            assert c.coord("time").bounds is None

--- a/tests/operators/test_read.py
+++ b/tests/operators/test_read.py
@@ -1185,15 +1185,19 @@ def test_time_bounds():
             # Instantaneous field
             assert c.coord("time").bounds is None
 
+
 def test_read_time_constraint_in_bounds():
     """Cubes can be selected with any time inside the bounds."""
-    cubes = read.read_cubes("tests/test_data/air_temp.nc", constraint=iris.Constraint(time=datetime.datetime(2022, 9, 21, 3, 0)))
+    cubes = read.read_cubes(
+        "tests/test_data/air_temp.nc",
+        constraint=iris.Constraint(time=datetime.datetime(2022, 9, 21, 3, 0)),
+    )
 
     for c in cubes:
         if c.coord("time").bounds is None:
             # Instantaneous field was loaded
-            assert c.coord('time').as_string_arrays().points == ['2022-09-21 03:00:00']
+            assert c.coord("time").as_string_arrays().points == ["2022-09-21 03:00:00"]
         else:
             # Time processed field was loaded even though its time doesn't match
             # since the constraint is inside time bounds
-            assert c.coord('time').as_string_arrays().points == ['2022-09-21 03:30:00']
+            assert c.coord("time").as_string_arrays().points == ["2022-09-21 03:30:00"]

--- a/tests/operators/test_read.py
+++ b/tests/operators/test_read.py
@@ -1184,3 +1184,16 @@ def test_time_bounds():
         else:
             # Instantaneous field
             assert c.coord("time").bounds is None
+
+def test_read_time_constraint_in_bounds():
+    """Cubes can be selected with any time inside the bounds."""
+    cubes = read.read_cubes("tests/test_data/air_temp.nc", constraint=iris.Constraint(time=datetime.datetime(2022, 9, 21, 3, 0)))
+
+    for c in cubes:
+        if c.coord("time").bounds is None:
+            # Instantaneous field was loaded
+            assert c.coord('time').as_string_arrays().points == ['2022-09-21 03:00:00']
+        else:
+            # Time processed field was loaded even though its time doesn't match
+            # since the constraint is inside time bounds
+            assert c.coord('time').as_string_arrays().points == ['2022-09-21 03:30:00']


### PR DESCRIPTION
<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

Guessing time bounds for instantaneous fields causes problems for METplus and Verpy when working with CSET-processed files.

Fixes #2101 

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [x] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Ensure `rose-suite.conf.example` has been updated if new diagnostic added.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
