### PR TITLE
Fixed issue in the docs with a missing line in the recipe

### DIFF
--- a/docs/source/getting-started/create-first-recipe.rst
+++ b/docs/source/getting-started/create-first-recipe.rst
@@ -93,6 +93,8 @@ to the input data as its implicit input.
 
     steps:
       - operator: read.read_cubes
+        file_paths: "$INPUT_PATHS"
+
 
 Once we have read the data, we need to filter them down to the data we require
 for our computations. ``filter.filter_cubes`` is the operator for that. It also
@@ -157,6 +159,7 @@ After following this far your recipe should look like this:
 
     steps:
       - operator: read.read_cubes
+        file_paths: "$INPUT_PATHS"
 
       - operator: filters.filter_cubes
         constraint:


### PR DESCRIPTION
Closes #2099 

### Changes:
When working through the tutorials I had an issue with the create-first-recipe tutorial. Adding the `file_paths: "$INPUT_PATHS"` line to the steps as found in other tutorials fixed this error for me. 



