### PR TITLE
Add single point timeseries loader and fix indexing into aggregation type

### DIFF
--- a/src/CSET/loaders/histograms.py
+++ b/src/CSET/loaders/histograms.py
@@ -99,7 +99,11 @@ def load(conf: Config):
 
     # Surface (2D) fields.
     for atype, field in itertools.product(AGGREGATION_TYPES, conf.SURFACE_FIELDS):
-        if conf.HISTOGRAM_SURFACE_FIELD_AGGREGATION[AGGREGATION_TYPES.index(atype)]:
+        index = AGGREGATION_TYPES.index(atype)
+        if (
+            len(conf.HISTOGRAM_SURFACE_FIELD_AGGREGATION) > index
+            and conf.HISTOGRAM_SURFACE_FIELD_AGGREGATION[index]
+        ):
             yield RawRecipe(
                 recipe=f"generic_surface_histogram_series_case_aggregation_{atype}.yaml",
                 variables={
@@ -118,7 +122,11 @@ def load(conf: Config):
     for atype, field, plevel in itertools.product(
         AGGREGATION_TYPES, conf.PRESSURE_LEVEL_FIELDS, conf.PRESSURE_LEVELS
     ):
-        if conf.HISTOGRAM_PLEVEL_FIELD_AGGREGATION[AGGREGATION_TYPES.index(atype)]:
+        index = AGGREGATION_TYPES.index(atype)
+        if (
+            len(conf.HISTOGRAM_PLEVEL_FIELD_AGGREGATION) > index
+            and conf.HISTOGRAM_PLEVEL_FIELD_AGGREGATION[index]
+        ):
             yield RawRecipe(
                 recipe=f"generic_level_histogram_series_case_aggregation_{atype}.yaml",
                 variables={
@@ -139,7 +147,11 @@ def load(conf: Config):
     for atype, field, mlevel in itertools.product(
         AGGREGATION_TYPES, conf.MODEL_LEVEL_FIELDS, conf.MODEL_LEVELS
     ):
-        if conf.HISTOGRAM_MLEVEL_FIELD_AGGREGATION[AGGREGATION_TYPES.index(atype)]:
+        index = AGGREGATION_TYPES.index(atype)
+        if (
+            len(conf.HISTOGRAM_MLEVEL_FIELD_AGGREGATION) > index
+            and conf.HISTOGRAM_MLEVEL_FIELD_AGGREGATION[index]
+        ):
             yield RawRecipe(
                 recipe=f"generic_level_histogram_series_case_aggregation_{atype}.yaml",
                 variables={

--- a/src/CSET/loaders/histograms.py
+++ b/src/CSET/loaders/histograms.py
@@ -100,10 +100,8 @@ def load(conf: Config):
     # Surface (2D) fields.
     for atype, field in itertools.product(AGGREGATION_TYPES, conf.SURFACE_FIELDS):
         index = AGGREGATION_TYPES.index(atype)
-        if (
-            len(conf.HISTOGRAM_SURFACE_FIELD_AGGREGATION) > index
-            and conf.HISTOGRAM_SURFACE_FIELD_AGGREGATION[index]
-        ):
+        aggregations = conf.HISTOGRAM_SURFACE_FIELD_AGGREGATION
+        if len(aggregations) > index and aggregations[index]:
             yield RawRecipe(
                 recipe=f"generic_surface_histogram_series_case_aggregation_{atype}.yaml",
                 variables={
@@ -123,10 +121,8 @@ def load(conf: Config):
         AGGREGATION_TYPES, conf.PRESSURE_LEVEL_FIELDS, conf.PRESSURE_LEVELS
     ):
         index = AGGREGATION_TYPES.index(atype)
-        if (
-            len(conf.HISTOGRAM_PLEVEL_FIELD_AGGREGATION) > index
-            and conf.HISTOGRAM_PLEVEL_FIELD_AGGREGATION[index]
-        ):
+        aggregations = conf.HISTOGRAM_PLEVEL_FIELD_AGGREGATION
+        if len(aggregations) > index and aggregations[index]:
             yield RawRecipe(
                 recipe=f"generic_level_histogram_series_case_aggregation_{atype}.yaml",
                 variables={
@@ -148,10 +144,8 @@ def load(conf: Config):
         AGGREGATION_TYPES, conf.MODEL_LEVEL_FIELDS, conf.MODEL_LEVELS
     ):
         index = AGGREGATION_TYPES.index(atype)
-        if (
-            len(conf.HISTOGRAM_MLEVEL_FIELD_AGGREGATION) > index
-            and conf.HISTOGRAM_MLEVEL_FIELD_AGGREGATION[index]
-        ):
+        aggregations = conf.HISTOGRAM_MLEVEL_FIELD_AGGREGATION
+        if len(aggregations) > index and aggregations[index]:
             yield RawRecipe(
                 recipe=f"generic_level_histogram_series_case_aggregation_{atype}.yaml",
                 variables={

--- a/src/CSET/loaders/profiles.py
+++ b/src/CSET/loaders/profiles.py
@@ -76,10 +76,8 @@ def load(conf: Config):
         AGGREGATION_TYPES, conf.PRESSURE_LEVEL_FIELDS
     ):
         index = AGGREGATION_TYPES.index(atype)
-        if (
-            len(conf.PROFILE_PLEVEL_AGGREGATION) > index
-            and conf.PROFILE_PLEVEL_AGGREGATION[index]
-        ):
+        aggregations = conf.PROFILE_PLEVEL_AGGREGATION
+        if len(aggregations) > index and aggregations[index]:
             yield RawRecipe(
                 recipe=f"generic_level_domain_mean_vertical_profile_series_case_aggregation_{atype}.yaml",
                 variables={
@@ -98,10 +96,8 @@ def load(conf: Config):
     # Model level fields.
     for atype, field in itertools.product(AGGREGATION_TYPES, conf.MODEL_LEVEL_FIELDS):
         index = AGGREGATION_TYPES.index(atype)
-        if (
-            len(conf.PROFILE_MLEVEL_AGGREGATION) > index
-            and conf.PROFILE_MLEVEL_AGGREGATION[index]
-        ):
+        aggregations = conf.PROFILE_MLEVEL_AGGREGATION
+        if len(aggregations) > index and aggregations[index]:
             yield RawRecipe(
                 recipe=f"generic_level_domain_mean_vertical_profile_series_case_aggregation_{atype}.yaml",
                 variables={

--- a/src/CSET/loaders/profiles.py
+++ b/src/CSET/loaders/profiles.py
@@ -75,7 +75,11 @@ def load(conf: Config):
     for atype, field in itertools.product(
         AGGREGATION_TYPES, conf.PRESSURE_LEVEL_FIELDS
     ):
-        if conf.PROFILE_PLEVEL_AGGREGATION[AGGREGATION_TYPES.index(atype)]:
+        index = AGGREGATION_TYPES.index(atype)
+        if (
+            len(conf.PROFILE_PLEVEL_AGGREGATION) > index
+            and conf.PROFILE_PLEVEL_AGGREGATION[index]
+        ):
             yield RawRecipe(
                 recipe=f"generic_level_domain_mean_vertical_profile_series_case_aggregation_{atype}.yaml",
                 variables={
@@ -93,7 +97,11 @@ def load(conf: Config):
 
     # Model level fields.
     for atype, field in itertools.product(AGGREGATION_TYPES, conf.MODEL_LEVEL_FIELDS):
-        if conf.PROFILE_MLEVEL_AGGREGATION[AGGREGATION_TYPES.index(atype)]:
+        index = AGGREGATION_TYPES.index(atype)
+        if (
+            len(conf.PROFILE_MLEVEL_AGGREGATION) > index
+            and conf.PROFILE_MLEVEL_AGGREGATION[index]
+        ):
             yield RawRecipe(
                 recipe=f"generic_level_domain_mean_vertical_profile_series_case_aggregation_{atype}.yaml",
                 variables={

--- a/src/CSET/loaders/spatial_difference_field.py
+++ b/src/CSET/loaders/spatial_difference_field.py
@@ -488,9 +488,11 @@ def load(conf: Config):
     for model, atype, field in itertools.product(
         models[1:], AGGREGATION_TYPES, conf.SURFACE_FIELDS
     ):
-        if conf.SPATIAL_DIFFERENCE_SURFACE_FIELD_AGGREGATION[
-            AGGREGATION_TYPES.index(atype)
-        ]:
+        index = AGGREGATION_TYPES.index(atype)
+        if (
+            len(conf.SPATIAL_DIFFERENCE_SURFACE_FIELD_AGGREGATION) > index
+            and conf.SPATIAL_DIFFERENCE_SURFACE_FIELD_AGGREGATION[index]
+        ):
             base_model = models[0]
             yield RawRecipe(
                 recipe=f"surface_spatial_difference_case_aggregation_mean_{atype}.yaml",
@@ -511,9 +513,11 @@ def load(conf: Config):
     for model, atype, field, plevel in itertools.product(
         models[1:], AGGREGATION_TYPES, conf.PRESSURE_LEVEL_FIELDS, conf.PRESSURE_LEVELS
     ):
-        if conf.SPATIAL_DIFFERENCE_PLEVEL_FIELD_AGGREGATION[
-            AGGREGATION_TYPES.index(atype)
-        ]:
+        index = AGGREGATION_TYPES.index(atype)
+        if (
+            len(conf.SPATIAL_DIFFERENCE_PLEVEL_FIELD_AGGREGATION) > index
+            and conf.SPATIAL_DIFFERENCE_PLEVEL_FIELD_AGGREGATION[index]
+        ):
             base_model = models[0]
             yield RawRecipe(
                 recipe=f"level_spatial_difference_case_aggregation_mean_{atype}.yaml",
@@ -536,9 +540,11 @@ def load(conf: Config):
     for model, atype, field, mlevel in itertools.product(
         models[1:], AGGREGATION_TYPES, conf.MODEL_LEVEL_FIELDS, conf.MODEL_LEVELS
     ):
-        if conf.SPATIAL_DIFFERENCE_MLEVEL_FIELD_AGGREGATION[
-            AGGREGATION_TYPES.index(atype)
-        ]:
+        index = AGGREGATION_TYPES.index(atype)
+        if (
+            len(conf.SPATIAL_DIFFERENCE_MLEVEL_FIELD_AGGREGATION) > index
+            and conf.SPATIAL_DIFFERENCE_MLEVEL_FIELD_AGGREGATION[index]
+        ):
             base_model = models[0]
             yield RawRecipe(
                 recipe=f"level_spatial_difference_case_aggregation_mean_{atype}.yaml",

--- a/src/CSET/loaders/spatial_difference_field.py
+++ b/src/CSET/loaders/spatial_difference_field.py
@@ -489,10 +489,8 @@ def load(conf: Config):
         models[1:], AGGREGATION_TYPES, conf.SURFACE_FIELDS
     ):
         index = AGGREGATION_TYPES.index(atype)
-        if (
-            len(conf.SPATIAL_DIFFERENCE_SURFACE_FIELD_AGGREGATION) > index
-            and conf.SPATIAL_DIFFERENCE_SURFACE_FIELD_AGGREGATION[index]
-        ):
+        aggregations = conf.SPATIAL_DIFFERENCE_SURFACE_FIELD_AGGREGATION
+        if len(aggregations) > index and aggregations[index]:
             base_model = models[0]
             yield RawRecipe(
                 recipe=f"surface_spatial_difference_case_aggregation_mean_{atype}.yaml",
@@ -514,10 +512,8 @@ def load(conf: Config):
         models[1:], AGGREGATION_TYPES, conf.PRESSURE_LEVEL_FIELDS, conf.PRESSURE_LEVELS
     ):
         index = AGGREGATION_TYPES.index(atype)
-        if (
-            len(conf.SPATIAL_DIFFERENCE_PLEVEL_FIELD_AGGREGATION) > index
-            and conf.SPATIAL_DIFFERENCE_PLEVEL_FIELD_AGGREGATION[index]
-        ):
+        aggregations = conf.SPATIAL_DIFFERENCE_PLEVEL_FIELD_AGGREGATION
+        if len(aggregations) > index and aggregations[index]:
             base_model = models[0]
             yield RawRecipe(
                 recipe=f"level_spatial_difference_case_aggregation_mean_{atype}.yaml",
@@ -541,10 +537,8 @@ def load(conf: Config):
         models[1:], AGGREGATION_TYPES, conf.MODEL_LEVEL_FIELDS, conf.MODEL_LEVELS
     ):
         index = AGGREGATION_TYPES.index(atype)
-        if (
-            len(conf.SPATIAL_DIFFERENCE_MLEVEL_FIELD_AGGREGATION) > index
-            and conf.SPATIAL_DIFFERENCE_MLEVEL_FIELD_AGGREGATION[index]
-        ):
+        aggregations = conf.SPATIAL_DIFFERENCE_MLEVEL_FIELD_AGGREGATION
+        if len(aggregations) > index and aggregations[index]:
             base_model = models[0]
             yield RawRecipe(
                 recipe=f"level_spatial_difference_case_aggregation_mean_{atype}.yaml",

--- a/src/CSET/loaders/spatial_field.py
+++ b/src/CSET/loaders/spatial_field.py
@@ -585,7 +585,11 @@ def load(conf: Config):
     for model, atype, field in itertools.product(
         models, AGGREGATION_TYPES, conf.SURFACE_FIELDS
     ):
-        if conf.SPATIAL_SURFACE_FIELD_AGGREGATION[AGGREGATION_TYPES.index(atype)]:
+        index = AGGREGATION_TYPES.index(atype)
+        if (
+            len(conf.SPATIAL_SURFACE_FIELD_AGGREGATION) > index
+            and conf.SPATIAL_SURFACE_FIELD_AGGREGATION[index]
+        ):
             yield RawRecipe(
                 recipe=f"generic_surface_spatial_plot_sequence_case_aggregation_mean_{atype}.yaml",
                 variables={
@@ -604,7 +608,11 @@ def load(conf: Config):
     for model, atype, field, plevel in itertools.product(
         models, AGGREGATION_TYPES, conf.PRESSURE_LEVEL_FIELDS, conf.PRESSURE_LEVELS
     ):
-        if conf.SPATIAL_PLEVEL_FIELD_AGGREGATION[AGGREGATION_TYPES.index(atype)]:
+        index = AGGREGATION_TYPES.index(atype)
+        if (
+            len(conf.SPATIAL_PLEVEL_FIELD_AGGREGATION) > index
+            and conf.SPATIAL_PLEVEL_FIELD_AGGREGATION[index]
+        ):
             yield RawRecipe(
                 recipe=f"generic_level_spatial_plot_sequence_case_aggregation_mean_{atype}.yaml",
                 variables={
@@ -625,7 +633,11 @@ def load(conf: Config):
     for model, atype, field, mlevel in itertools.product(
         models, AGGREGATION_TYPES, conf.MODEL_LEVEL_FIELDS, conf.MODEL_LEVELS
     ):
-        if conf.SPATIAL_MLEVEL_FIELD_AGGREGATION[AGGREGATION_TYPES.index(atype)]:
+        index = AGGREGATION_TYPES.index(atype)
+        if (
+            len(conf.SPATIAL_MLEVEL_FIELD_AGGREGATION) > index
+            and conf.SPATIAL_MLEVEL_FIELD_AGGREGATION[index]
+        ):
             yield RawRecipe(
                 recipe=f"generic_level_spatial_plot_sequence_case_aggregation_mean_{atype}.yaml",
                 variables={

--- a/src/CSET/loaders/spatial_field.py
+++ b/src/CSET/loaders/spatial_field.py
@@ -586,10 +586,8 @@ def load(conf: Config):
         models, AGGREGATION_TYPES, conf.SURFACE_FIELDS
     ):
         index = AGGREGATION_TYPES.index(atype)
-        if (
-            len(conf.SPATIAL_SURFACE_FIELD_AGGREGATION) > index
-            and conf.SPATIAL_SURFACE_FIELD_AGGREGATION[index]
-        ):
+        aggregations = conf.SPATIAL_SURFACE_FIELD_AGGREGATION
+        if len(aggregations) > index and aggregations[index]:
             yield RawRecipe(
                 recipe=f"generic_surface_spatial_plot_sequence_case_aggregation_mean_{atype}.yaml",
                 variables={
@@ -609,10 +607,8 @@ def load(conf: Config):
         models, AGGREGATION_TYPES, conf.PRESSURE_LEVEL_FIELDS, conf.PRESSURE_LEVELS
     ):
         index = AGGREGATION_TYPES.index(atype)
-        if (
-            len(conf.SPATIAL_PLEVEL_FIELD_AGGREGATION) > index
-            and conf.SPATIAL_PLEVEL_FIELD_AGGREGATION[index]
-        ):
+        aggregations = conf.SPATIAL_PLEVEL_FIELD_AGGREGATION
+        if len(aggregations) > index and aggregations[index]:
             yield RawRecipe(
                 recipe=f"generic_level_spatial_plot_sequence_case_aggregation_mean_{atype}.yaml",
                 variables={
@@ -634,10 +630,8 @@ def load(conf: Config):
         models, AGGREGATION_TYPES, conf.MODEL_LEVEL_FIELDS, conf.MODEL_LEVELS
     ):
         index = AGGREGATION_TYPES.index(atype)
-        if (
-            len(conf.SPATIAL_MLEVEL_FIELD_AGGREGATION) > index
-            and conf.SPATIAL_MLEVEL_FIELD_AGGREGATION[index]
-        ):
+        aggregations = conf.SPATIAL_MLEVEL_FIELD_AGGREGATION
+        if len(aggregations) > index and aggregations[index]:
             yield RawRecipe(
                 recipe=f"generic_level_spatial_plot_sequence_case_aggregation_mean_{atype}.yaml",
                 variables={

--- a/src/CSET/loaders/timeseries.py
+++ b/src/CSET/loaders/timeseries.py
@@ -468,10 +468,8 @@ def load(conf: Config):
     # Surface (2D) fields.
     for atype, field in itertools.product(AGGREGATION_TYPES, conf.SURFACE_FIELDS):
         index = AGGREGATION_TYPES.index(atype)
-        if (
-            len(conf.TIMESERIES_SURFACE_FIELD_AGGREGATION) > index
-            and conf.TIMESERIES_SURFACE_FIELD_AGGREGATION[index]
-        ):
+        aggregations = conf.TIMESERIES_SURFACE_FIELD_AGGREGATION
+        if len(aggregations) > index and aggregations[index]:
             yield RawRecipe(
                 recipe=f"generic_surface_domain_mean_time_series_case_aggregation_{atype}.yaml",
                 variables={
@@ -491,10 +489,8 @@ def load(conf: Config):
         AGGREGATION_TYPES, conf.PRESSURE_LEVEL_FIELDS, conf.PRESSURE_LEVELS
     ):
         index = AGGREGATION_TYPES.index(atype)
-        if (
-            len(conf.TIMESERIES_PLEVEL_FIELD_AGGREGATION) > index
-            and conf.TIMESERIES_PLEVEL_FIELD_AGGREGATION[index]
-        ):
+        aggregations = conf.TIMESERIES_PLEVEL_FIELD_AGGREGATION
+        if len(aggregations) > index and aggregations[index]:
             yield RawRecipe(
                 recipe=f"generic_level_domain_mean_time_series_case_aggregation_{atype}.yaml",
                 variables={
@@ -516,10 +512,8 @@ def load(conf: Config):
         AGGREGATION_TYPES, conf.MODEL_LEVEL_FIELDS, conf.MODEL_LEVELS
     ):
         index = AGGREGATION_TYPES.index(atype)
-        if (
-            len(conf.TIMESERIES_MLEVEL_FIELD_AGGREGATION) > index
-            and conf.TIMESERIES_MLEVEL_FIELD_AGGREGATION[index]
-        ):
+        aggregations = conf.TIMESERIES_MLEVEL_FIELD_AGGREGATION
+        if len(aggregations) > index and aggregations[index]:
             yield RawRecipe(
                 recipe=f"generic_level_domain_mean_time_series_case_aggregation_{atype}.yaml",
                 variables={

--- a/src/CSET/loaders/timeseries.py
+++ b/src/CSET/loaders/timeseries.py
@@ -467,7 +467,11 @@ def load(conf: Config):
 
     # Surface (2D) fields.
     for atype, field in itertools.product(AGGREGATION_TYPES, conf.SURFACE_FIELDS):
-        if conf.TIMESERIES_SURFACE_FIELD_AGGREGATION[AGGREGATION_TYPES.index(atype)]:
+        index = AGGREGATION_TYPES.index(atype)
+        if (
+            len(conf.TIMESERIES_SURFACE_FIELD_AGGREGATION) > index
+            and conf.TIMESERIES_SURFACE_FIELD_AGGREGATION[index]
+        ):
             yield RawRecipe(
                 recipe=f"generic_surface_domain_mean_time_series_case_aggregation_{atype}.yaml",
                 variables={
@@ -486,7 +490,11 @@ def load(conf: Config):
     for atype, field, plevel in itertools.product(
         AGGREGATION_TYPES, conf.PRESSURE_LEVEL_FIELDS, conf.PRESSURE_LEVELS
     ):
-        if conf.TIMESERIES_PLEVEL_FIELD_AGGREGATION[AGGREGATION_TYPES.index(atype)]:
+        index = AGGREGATION_TYPES.index(atype)
+        if (
+            len(conf.TIMESERIES_PLEVEL_FIELD_AGGREGATION) > index
+            and conf.TIMESERIES_PLEVEL_FIELD_AGGREGATION[index]
+        ):
             yield RawRecipe(
                 recipe=f"generic_level_domain_mean_time_series_case_aggregation_{atype}.yaml",
                 variables={
@@ -507,7 +515,11 @@ def load(conf: Config):
     for atype, field, mlevel in itertools.product(
         AGGREGATION_TYPES, conf.MODEL_LEVEL_FIELDS, conf.MODEL_LEVELS
     ):
-        if conf.TIMESERIES_MLEVEL_FIELD_AGGREGATION[AGGREGATION_TYPES.index(atype)]:
+        index = AGGREGATION_TYPES.index(atype)
+        if (
+            len(conf.TIMESERIES_MLEVEL_FIELD_AGGREGATION) > index
+            and conf.TIMESERIES_MLEVEL_FIELD_AGGREGATION[index]
+        ):
             yield RawRecipe(
                 recipe=f"generic_level_domain_mean_time_series_case_aggregation_{atype}.yaml",
                 variables={

--- a/src/CSET/loaders/timeseries.py
+++ b/src/CSET/loaders/timeseries.py
@@ -41,6 +41,23 @@ def load(conf: Config):
                 aggregation=False,
             )
 
+    # Single point timeseries
+    if conf.SURFACE_SINGLE_POINT_TIME_SERIES:
+        for field in conf.SURFACE_FIELDS:
+            yield RawRecipe(
+                recipe="generic_surface_single_point_time_series.yaml",
+                variables={
+                    "VARNAME": field,
+                    "MODEL_NAME": [model["name"] for model in models],
+                    "LATITUDE_POINT": conf.LATITUDE_POINT,
+                    "LONGITUDE_POINT": conf.LONGITUDE_POINT,
+                    "LATLON_IN_TYPE": conf.LATLON_IN_TYPE,
+                    "SINGLE_POINT_METHOD": conf.SINGLE_POINT_METHOD,
+                },
+                model_ids=[model["id"] for model in models],
+                aggregation=False,
+            )
+
     # Surface time series: land mask.
     if conf.TIMESERIES_SURFACE_FIELD_LAND_MASK:
         for field in conf.SURFACE_FIELDS:

--- a/src/CSET/loaders/transects.py
+++ b/src/CSET/loaders/transects.py
@@ -82,10 +82,8 @@ def load(conf: Config):
             models, AGGREGATION_TYPES, conf.PRESSURE_LEVEL_FIELDS
         ):
             index = AGGREGATION_TYPES.index(atype)
-            if (
-                len(conf.PLEVEL_TRANSECT_AGGREGATION) > index
-                and conf.PLEVEL_TRANSECT_AGGREGATION[index]
-            ):
+            aggregations = conf.PLEVEL_TRANSECT_AGGREGATION
+            if len(aggregations) > index and aggregations[index]:
                 yield RawRecipe(
                     recipe=f"transect_case_aggregation_{atype}.yaml",
                     variables={
@@ -110,10 +108,8 @@ def load(conf: Config):
             models[1:], AGGREGATION_TYPES, conf.PRESSURE_LEVEL_FIELDS
         ):
             index = AGGREGATION_TYPES.index(atype)
-            if (
-                len(conf.PLEVEL_TRANSECT_AGGREGATION_DIFFERENCE) > index
-                and conf.PLEVEL_TRANSECT_AGGREGATION_DIFFERENCE[index]
-            ):
+            aggregations = conf.PLEVEL_TRANSECT_AGGREGATION_DIFFERENCE
+            if len(aggregations) > index and aggregations[index]:
                 base_model = models[0]
                 yield RawRecipe(
                     recipe=f"transect_case_aggregation_difference_{atype}.yaml",

--- a/src/CSET/loaders/transects.py
+++ b/src/CSET/loaders/transects.py
@@ -81,7 +81,11 @@ def load(conf: Config):
         for model, atype, field in itertools.product(
             models, AGGREGATION_TYPES, conf.PRESSURE_LEVEL_FIELDS
         ):
-            if conf.PLEVEL_TRANSECT_AGGREGATION[AGGREGATION_TYPES.index(atype)]:
+            index = AGGREGATION_TYPES.index(atype)
+            if (
+                len(conf.PLEVEL_TRANSECT_AGGREGATION) > index
+                and conf.PLEVEL_TRANSECT_AGGREGATION[index]
+            ):
                 yield RawRecipe(
                     recipe=f"transect_case_aggregation_{atype}.yaml",
                     variables={
@@ -105,9 +109,11 @@ def load(conf: Config):
         for model, atype, field in itertools.product(
             models[1:], AGGREGATION_TYPES, conf.PRESSURE_LEVEL_FIELDS
         ):
-            if conf.PLEVEL_TRANSECT_AGGREGATION_DIFFERENCE[
-                AGGREGATION_TYPES.index(atype)
-            ]:
+            index = AGGREGATION_TYPES.index(atype)
+            if (
+                len(conf.PLEVEL_TRANSECT_AGGREGATION_DIFFERENCE) > index
+                and conf.PLEVEL_TRANSECT_AGGREGATION_DIFFERENCE[index]
+            ):
                 base_model = models[0]
                 yield RawRecipe(
                     recipe=f"transect_case_aggregation_difference_{atype}.yaml",


### PR DESCRIPTION
<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

fixes #1498; also fixes IndexError exceptions when an aggregation switch is absent in Config. (Config handles missing switch with its getattr() but if the switch is missing - e.g. in the case of no aggregation ordered - trying to access the switch list item raises IndexError)

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [ ] Ensured the pull request title is descriptive.
- [ ] Ensure `rose-suite.conf.example` has been updated if new diagnostic added.
- [ ] Conda lock files have been updated if dependencies have changed.
- [x] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
