### PR TITLE
Install from conda-forge mirror on Met Office systems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,15 +10,23 @@ help: ## Display this help message.
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
 	| sed -n 's/^\(.*:\) \(.*\)##\(.*\)/  \1\3/p'
 
-conda:
-	conda create -n cset-dev --file requirements/locks/latest
-	@echo "Run 'conda activate cset-dev' to use conda environment."
+# Check whether we are in the Met Office and modify lockfile if so.
+prepare-lockfiles:
+	@hostname -f | grep -qF metoffice \
+	  && echo "Running on Met Office system; updating lockfiles to use conda-forge mirror." \
+	  && sed -i "s|conda.anaconda.org|metoffice.jfrog.io/metoffice/api/conda|" requirements/locks/*.txt
+
+conda: prepare-lockfiles
+	conda create -n cset-dev --file requirements/locks/latest --yes
+	git restore requirements/locks  # Reset lockfiles in case we Met Office'd them.
 
 .git/hooks/pre-commit: conda
 	conda run -n cset-dev pre-commit install
 
+# Prevent pip from accessing the network; we have everything in our conda env.
 setup: conda .git/hooks/pre-commit ## Setup development environment.
-	conda run -n cset-dev pip install --no-deps -e .
+	conda run -n cset-dev pip install --no-deps --no-index --no-build-isolation --editable .
+	@echo "Run 'conda activate cset-dev' to use conda environment."
 
 docs: ## Build documentation.
 	make --directory=docs html
@@ -39,4 +47,4 @@ test-full: pre-commit ## Run all tests, including slow or network reliant.
 
 # Mark targets as 'phony' to indicate they don't actually produce a file with
 # the same name as their target. Basically for actions rather than files.
-.PHONY: help setup docs test test-fast test-full
+.PHONY: help setup docs test test-fast test-full prepare-lockfiles

--- a/docs/source/contributing/getting-started.rst
+++ b/docs/source/contributing/getting-started.rst
@@ -51,7 +51,7 @@ This will download a copy of the repository (where the code is stored), and all
 of its history onto your computer. From there we need to setup a few things
 before we can develop.
 
-.. note::
+.. tip::
 
     If you have previously cloned the repository you can update it with the
     latest changes. Ensure all changes are committed, then run ``git pull``.
@@ -72,7 +72,15 @@ environment.
 To use the software environment run ``conda activate cset-dev``. You will have
 to rerun this command for every new terminal.
 
-If you don't have make, you can use the following equivalent commands which,
+.. admonition:: Met Office only
+
+    When run on Met Office computers,
+    ``make setup`` will automatically use the Met Office Artifactory conda-forge mirror.
+    Make sure you have `setup authentication to Artifactory`_ in advance.
+
+    Non-Met Office computers install directly from conda-forge and require no extra setup.
+
+If you don't have ``make``, you can use the following equivalent commands which,
 when run from within the CSET directory, will setup a conda environment for you
 to use.
 
@@ -89,6 +97,7 @@ to use.
 
 .. _conda: https://docs.conda.io/en/latest/
 .. _GNU make: https://www.gnu.org/software/make/
+.. _setup authentication to Artifactory: https://wwwspice/~avd/sci/software_stack/conda_initial_how_to.html
 
 Updating tooling
 ----------------


### PR DESCRIPTION
This change detects if running on a Met Office system via the hostname containing "metoffice", then temporarily changes the lockfile URLs to point to our mirror during install.

First half of #2135

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [x] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Ensure `rose-suite.conf.example` has been updated if new diagnostic added.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
