### PR TITLE
Reduce matplotlib logging verbosity

### DIFF
--- a/src/CSET/__init__.py
+++ b/src/CSET/__init__.py
@@ -203,12 +203,8 @@ def setup_logging(verbosity: int):
     # Set logging level.
     logger.setLevel(loglevel)
 
-    # Hide matplotlib's many font messages.
-    class NoFontMessageFilter(logging.Filter):
-        def filter(self, record):
-            return not record.getMessage().startswith("findfont:")
-
-    logging.getLogger("matplotlib.font_manager").addFilter(NoFontMessageFilter())
+    # Suppress matplotlib's verbose debug output.
+    logging.getLogger("matplotlib").setLevel(logging.WARNING)
 
     stderr_log = logging.StreamHandler(stream=sys.stdout)
     stderr_log.setFormatter(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -125,13 +125,14 @@ def test_setup_logging():
 
 
 def test_setup_logging_mpl_font_logs_filtered(caplog):
-    """Test matplotlib log messages about fonts are filtered out."""
+    """Test matplotlib DEBUG/INFO log messages are filtered out."""
     CSET.setup_logging(2)
     logger = logging.getLogger("matplotlib.font_manager")
     logger.debug("findfont: message")
     logger.debug("other message")
+    logger.warning("Important!")
     assert len(caplog.records) == 1
-    assert caplog.records[0].getMessage() == "other message"
+    assert caplog.records[0].getMessage() == "Important!"
 
 
 def test_main_no_subparser(capsys):


### PR DESCRIPTION
Matplotlib produces loads of output at DEBUG log levels that we are not interested in. This obscures the output we care about, making it harder to spot problems. This change filters out anything below WARNING from matplotlib's ticker module.

Factored out of #1872.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [ ] All tests and CI checks pass.
- [ ] Ensured the pull request title is descriptive.
- [ ] Ensure `rose-suite.conf.example` has been updated if new diagnostic added.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [ ] Marked the PR as ready to review.
