### PR TITLE
Ensure `make setup` doesn't fail outside the Met Office

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,8 @@ help: ## Display this help message.
 prepare-lockfiles:
 	@hostname -f | grep -qF metoffice \
 	  && echo "Running on Met Office system; updating lockfiles to use conda-forge mirror." \
-	  && sed -i "s|conda.anaconda.org|metoffice.jfrog.io/metoffice/api/conda|" requirements/locks/*.txt
+	  && sed -i "s|conda.anaconda.org|metoffice.jfrog.io/metoffice/api/conda|" requirements/locks/*.txt \
+	  || true
 
 conda: prepare-lockfiles
 	conda create -n cset-dev --file requirements/locks/latest --yes


### PR DESCRIPTION
Follow up to #2136.

The command chain was exiting non-zero, which caused make to fail on non-Met Office systems. Tested on JASMIN and works well there.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Ensure `rose-suite.conf.example` has been updated if new diagnostic added.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
