### PR TITLE
Improve workflow housekeeping with multiple cycles

### DIFF
--- a/src/CSET/cset_workflow/flow.cylc
+++ b/src/CSET/cset_workflow/flow.cylc
@@ -49,6 +49,15 @@ final cycle point = {{CSET_TRIAL_END_DATE}}
     parbake_recipes:skip_baking? | bake_recipes => cycle_complete
     """
 
+    # Make sure all cycles are complete before housekeeping
+    {% if CSET_CYCLING_MODE == "case_study" %}
+        {% for i in range(1, CSET_CASE_DATES | length) %}
+        R1/{{CSET_CASE_DATES[i]}} = """cycle_complete[{{CSET_CASE_DATES[i-1]}}] => cycle_complete"""
+        {% endfor %}
+    {% elif CSET_CYCLING_MODE == "trial" %}
+        {{CSET_TRIAL_CYCLE_PERIOD}} = """cycle_complete[-{{CSET_TRIAL_CYCLE_PERIOD}}] => cycle_complete"""
+    {% endif %}
+
     # Only runs on the final cycle.
     R1/$ = """
     # Run aggregation recipes.

--- a/src/CSET/cset_workflow/includes/metplus_point_stat.cylc
+++ b/src/CSET/cset_workflow/includes/metplus_point_stat.cylc
@@ -7,7 +7,6 @@
         fetch_fcst_m1 => metplus_prep_fcst_m1
         metplus_prep_fcst_m1 => metplus_point_stat
         metplus_ascii2nc => metplus_point_stat => cycle_complete
-        metplus_point_stat => housekeeping
     {% endmacro %}
 
     {% if CSET_CYCLING_MODE == "case_study" %}


### PR DESCRIPTION
<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

Improve housekeeping behaviour with multiple cycles
- Ensure all cycles are complete before running housekeeping
- Don't add a housekeeping on each cycle in the metplus include (it still has the implicit dependency through `cycle_complete`)

Fixes #2150 

New graph with multiple cycles and metplus enabled:
<img width="2753" height="1399" alt="graph" src="https://github.com/user-attachments/assets/0ecba11b-a23f-4af9-b7bf-06a3d99dc9bb" />

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [x] Documentation has been updated to reflect change.
- [x] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [x] Ensure `rose-suite.conf.example` has been updated if new diagnostic added.
- [x] Conda lock files have been updated if dependencies have changed.
- [x] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
