### PR TITLE
Ignore wwwspice links from linkchecking

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -58,4 +58,6 @@ linkcheck_ignore = [
     r"https://stackoverflow.com/.+",
     # Sourceforge blocks requests.
     r"https://.+\.sourceforge\.io/.+",
+    # Met Office internal webserver.
+    r"https://wwwspice/.+",
 ]


### PR DESCRIPTION
These links are internal to the Met Office, and thus linkcheck can't resolve them. Ignoring them prevents the [weekly check](https://github.com/MetOffice/CSET/actions/runs/26385369473) failing.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Ensure `rose-suite.conf.example` has been updated if new diagnostic added.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
