### PR TITLE
Make finish_website app self-contained

### DIFF
--- a/src/CSET/cset_workflow/app/finish_website/bin/finish_website.py
+++ b/src/CSET/cset_workflow/app/finish_website/bin/finish_website.py
@@ -21,16 +21,17 @@ index, and updates the workflow status on the front page of the
 web interface.
 """
 
+import argparse
 import json
 import logging
 import os
+import re
 import shutil
 import sys
 import time
+from collections.abc import Iterable
 from importlib.metadata import version
 from pathlib import Path
-
-from CSET._common import sort_dict
 
 logging.basicConfig(
     level=os.getenv("LOGLEVEL", "INFO"),
@@ -40,41 +41,66 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 
-def install_website_skeleton(www_root_link: Path, www_content: Path):
-    """Copy static website files and create symlink from web document root."""
-    # Remove existing link to output ahead of creating new symlink.
-    logger.info("Removing any existing output link at %s.", www_root_link)
-    www_root_link.unlink(missing_ok=True)
+def human_sorted(iterable: Iterable, reverse: bool = False) -> list:
+    """Sort such numbers within strings are sorted correctly."""
+    # Adapted from https://nedbatchelder.com/blog/200712/human_sorting.html
 
+    def alphanum_key(s):
+        """Turn a string into a list of string and number chunks.
+
+        >>> alphanum_key("z23a")
+        ["z", 23, "a"]
+        """
+        try:
+            return [int(c) if c.isdecimal() else c for c in re.split(r"(\d+)", s)]
+        except TypeError:
+            return s
+
+    return sorted(iterable, key=alphanum_key, reverse=reverse)
+
+
+def sort_dict(d: dict) -> dict:
+    """Recursively sort a dictionary."""
+    # Thank you to https://stackoverflow.com/a/47882384
+    return {
+        k: sort_dict(v) if isinstance(v, dict) else v
+        for k, v in human_sorted(d.items())
+    }
+
+
+def install_website_skeleton(
+    www_root_link: Path | None, www_content: Path, skeleton_dir: Path
+):
+    """Copy static website files and create symlink from web document root."""
     logger.info("Installing website files to %s.", www_content)
     # Create directory for web content.
     www_content.mkdir(parents=True, exist_ok=True)
     # Copy static HTML/CSS/JS.
-    html_source = Path.cwd() / "html"
-    shutil.copytree(html_source, www_content, dirs_exist_ok=True)
-    # Create directory for plots.
-    plot_dir = www_content / "plots"
-    plot_dir.mkdir(exist_ok=True)
-
-    logger.info("Linking %s to web content.", www_root_link)
-    # Ensure parent directories of WEB_DIR exist.
-    www_root_link.parent.mkdir(parents=True, exist_ok=True)
-    # Create symbolic link to web directory.
-    # NOTE: While good for space, it means `cylc clean` removes output.
-    www_root_link.symlink_to(www_content)
+    shutil.copytree(skeleton_dir, www_content, dirs_exist_ok=True)
+    # Setup symbolic link from web root.
+    if www_root_link is not None:
+        logger.info("Linking %s to web content.", www_root_link)
+        # Remove existing link to output ahead of creating new symlink.
+        www_root_link.unlink(missing_ok=True)
+        # Ensure parent directories of WEB_DIR exist.
+        www_root_link.parent.mkdir(parents=True, exist_ok=True)
+        # Create symbolic link to web directory.
+        # NOTE: While good for space, it means `cylc clean` removes output.
+        www_root_link.symlink_to(www_content)
 
 
 def construct_index(www_content: Path):
     """Construct the plot index."""
-    plots_dir = www_content / "plots"
-    with open(plots_dir / "index.jsonl", "wt", encoding="UTF-8") as index_fp:
+    with open(www_content / "index.jsonl", "wt", encoding="UTF-8") as index_fp:
         # Loop over all diagnostics and append to index. The glob is sorted to
         # ensure a consistent ordering.
-        for metadata_file in sorted(plots_dir.glob("**/*/meta.json")):
+        for metadata_file in sorted(www_content.glob("**/*/meta.json")):
             try:
                 with open(metadata_file, "rt", encoding="UTF-8") as plot_fp:
                     plot_metadata = json.load(plot_fp)
-                plot_metadata["path"] = str(metadata_file.parent.relative_to(plots_dir))
+                plot_metadata["path"] = str(
+                    metadata_file.parent.relative_to(www_content)
+                )
                 # Remove keys that are not useful for the index.
                 removed_index_keys = [
                     "description",
@@ -89,7 +115,7 @@ def construct_index(www_content: Path):
                 ]
                 for key in removed_index_keys:
                     plot_metadata.pop(key, None)
-                # Sort plot metadata.
+                # Sort plot metadata for consistency.
                 plot_metadata = sort_dict(plot_metadata)
                 # Write metadata into website index.
                 json.dump(plot_metadata, index_fp, separators=(",", ":"))
@@ -105,17 +131,14 @@ def bust_cache(www_content: Path):
     We only need to do this for static resources referenced from the index page,
     as each plot already uses a unique filename based on the recipe.
     """
-    # Search and replace the string "CACHEBUSTER".
-    CACHEBUSTER = str(int(time.time()))
+    # Search and replace the string "CACHEBUSTER" with a time-based cache key.
+    cache_key = str(int(time.time()))
     with open(www_content / "index.html", "r+t") as fp:
         content = fp.read()
-        new_content = content.replace("CACHEBUSTER", CACHEBUSTER)
+        new_content = content.replace("CACHEBUSTER", cache_key)
         fp.seek(0)
         fp.truncate()
         fp.write(new_content)
-
-    # Move plots directory so it has a unique name.
-    os.rename(www_content / "plots", www_content / f"plots-{CACHEBUSTER}")
 
 
 def update_workflow_status(www_content: Path):
@@ -135,23 +158,50 @@ def update_workflow_status(www_content: Path):
 
 def copy_rose_config(www_content: Path):
     """Copy the rose-suite.conf file to add to output web directory."""
-    rose_suite_conf = Path(os.environ["CYLC_WORKFLOW_RUN_DIR"]) / "rose-suite.conf"
-    web_conf_file = www_content / "rose-suite.conf"
-    shutil.copyfile(rose_suite_conf, web_conf_file)
+    cylc_run_dir = os.getenv("CYLC_WORKFLOW_RUN_DIR", None)
+    if cylc_run_dir:
+        rose_suite_conf = Path(cylc_run_dir) / "rose-suite.conf"
+        web_conf_file = www_content / "rose-suite.conf"
+        try:
+            shutil.copyfile(rose_suite_conf, web_conf_file)
+        except FileNotFoundError:
+            logger.warning("No rose-suite.conf file found for cylc workflow.")
 
 
-def run():
+def parse_args(args: list[str] | None = None) -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Create a navigation interface for a set of diagnostic webpages.",
+    )
+    parser.add_argument(
+        "web_content",
+        type=Path,
+        help="Where to save the HTML content and find the diagnostic webpages.",
+    )
+    parser.add_argument(
+        "--web-root-link",
+        type=Path,
+        help="Where to create a symlink to the content, optional.",
+    )
+    parser.add_argument(
+        "--skeleton",
+        type=Path,
+        help="Directory containing static website files. Defaults to $PWD/html",
+        default=Path.cwd() / "html",
+    )
+    return parser.parse_args(args)
+
+
+def run():  # pragma: no cover
     """Do the final steps to finish the website."""
-    # Strip trailing slashes in case they have been added in the config.
-    # Otherwise they break the symlinks.
-    www_root_link = Path(os.environ["WEB_DIR"].rstrip("/"))
-    www_content = Path(os.environ["CYLC_WORKFLOW_SHARE_DIR"] + "/web")
+    args = parse_args()
+    logger.debug("Arguments: %s", args)
 
-    install_website_skeleton(www_root_link, www_content)
-    copy_rose_config(www_content)
-    construct_index(www_content)
-    bust_cache(www_content)
-    update_workflow_status(www_content)
+    install_website_skeleton(args.web_root_link, args.web_content, args.skeleton)
+    copy_rose_config(args.web_content)
+    construct_index(args.web_content)
+    bust_cache(args.web_content)
+    update_workflow_status(args.web_content)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/src/CSET/cset_workflow/app/finish_website/bin/finish_website.py
+++ b/src/CSET/cset_workflow/app/finish_website/bin/finish_website.py
@@ -94,7 +94,7 @@ def construct_index(www_content: Path):
     with open(www_content / "index.jsonl", "wt", encoding="UTF-8") as index_fp:
         # Loop over all diagnostics and append to index. The glob is sorted to
         # ensure a consistent ordering.
-        for metadata_file in sorted(www_content.glob("**/*/meta.json")):
+        for metadata_file in sorted(www_content.glob("**/*.json")):
             try:
                 with open(metadata_file, "rt", encoding="UTF-8") as plot_fp:
                     plot_metadata = json.load(plot_fp)

--- a/src/CSET/cset_workflow/app/finish_website/file/html/index.html
+++ b/src/CSET/cset_workflow/app/finish_website/file/html/index.html
@@ -96,7 +96,6 @@
             </article>
         </div>
     </main>
-    <script>const PLOTS_PATH = "plots-CACHEBUSTER";</script>
     <script src="script.js?v=CACHEBUSTER"></script>
 </body>
 

--- a/src/CSET/cset_workflow/app/finish_website/file/html/script.js
+++ b/src/CSET/cset_workflow/app/finish_website/file/html/script.js
@@ -499,7 +499,7 @@ function create_diagnostic_element(record) {
     // Add a callback updating the iframe when the link is clicked.
     button.addEventListener("click", (event) => {
       event.preventDefault();
-      display_diagnostic(`${PLOTS_PATH}/${path}`, position);
+      display_diagnostic(path, position);
     });
 
     // Add button to chooser.
@@ -592,8 +592,8 @@ function setup_plots_sidebar() {
   if (!document.getElementById("plot-selector")) {
     return;
   }
-  // Loading of plot index file, and adding them to the sidebar.
-  fetch(`${PLOTS_PATH}/index.jsonl`)
+  // Load plot index file, ensuring it is up-to-date.
+  fetch("index.jsonl", { cache: "no-cache" })
     .then((response) => {
       // Display a message and stop if the fetch fails.
       if (!response.ok) {

--- a/src/CSET/cset_workflow/app/finish_website/file/html/script.js
+++ b/src/CSET/cset_workflow/app/finish_website/file/html/script.js
@@ -592,7 +592,7 @@ function setup_plots_sidebar() {
   if (!document.getElementById("plot-selector")) {
     return;
   }
-  // Load plot index file, ensuring it is up-to-date.
+  // Load plot index file, ensuring it is up-to-date via a conditional request.
   fetch("index.jsonl", { cache: "no-cache" })
     .then((response) => {
       // Display a message and stop if the fetch fails.

--- a/src/CSET/cset_workflow/app/finish_website/rose-app.conf
+++ b/src/CSET/cset_workflow/app/finish_website/rose-app.conf
@@ -1,2 +1,2 @@
 [command]
-default=app_env_wrapper finish_website.py
+default=app_env_wrapper finish_website.py --web-root-link "${WEB_DIR}" "${CYLC_WORKFLOW_SHARE_DIR}/web"

--- a/tests/test_web_interface.py
+++ b/tests/test_web_interface.py
@@ -34,15 +34,15 @@ def webserver():
         tmp_path,
         dirs_exist_ok=True,
     )
-    plot_dir = tmp_path / "plots-CACHEBUSTER"
-    plot_dir.mkdir(exist_ok=True)
-    shutil.copy("tests/test_data/index.jsonl", plot_dir)
+    web_dir = tmp_path / "www"
+    web_dir.mkdir(exist_ok=True)
+    shutil.copy("tests/test_data/index.jsonl", web_dir)
 
     class HTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
         """Serve files from the temporary directory."""
 
         def __init__(self, *args, **kwargs):
-            super().__init__(*args, **kwargs, directory=tmp_path)
+            super().__init__(*args, **kwargs, directory=web_dir)
 
     # Try ports until we find one, up to 100 tries.
     port = 8000

--- a/tests/test_web_interface.py
+++ b/tests/test_web_interface.py
@@ -39,7 +39,7 @@ def webserver():
     shutil.copy("tests/test_data/index.jsonl", web_dir)
 
     class HTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
-        """Serve files from the temporary directory."""
+        """Serve files from the web directory."""
 
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs, directory=web_dir)

--- a/tests/workflow_utils/test_finish_website.py
+++ b/tests/workflow_utils/test_finish_website.py
@@ -22,16 +22,15 @@ from pathlib import Path
 from CSET.cset_workflow.app.finish_website.bin import finish_website
 
 
-def test_install_website_skeleton(monkeypatch, tmp_path):
+def test_install_website_skeleton(tmp_path):
     """Check static files are copied correctly."""
     www_content = tmp_path / "web"
     www_root_link = tmp_path / "www/CSET"
-    monkeypatch.chdir("src/CSET/cset_workflow/app/finish_website/file")
-    finish_website.install_website_skeleton(www_root_link, www_content)
+    skeleton_dir = Path("src/CSET/cset_workflow/app/finish_website/file/html")
+    finish_website.install_website_skeleton(www_root_link, www_content, skeleton_dir)
     assert www_content.is_dir()
     assert (www_content / "index.html").is_file()
     assert (www_content / "script.js").is_file()
-    assert (www_content / "plots").is_dir()
     assert www_root_link.is_symlink()
     assert www_root_link.resolve() == www_content.resolve()
 
@@ -53,16 +52,12 @@ def test_bust_cache(tmp_path):
     """Cache busting query string is added where requested."""
     with open(tmp_path / "index.html", "wt") as fp:
         fp.write('<img href="image.jpg?v=CACHEBUSTER" />\n')
-    (tmp_path / "plots").mkdir()
     finish_website.bust_cache(tmp_path)
     # Check cache busting query has been added.
     with open(tmp_path / "index.html", "rt") as fp:
         content = fp.read()
     assert "CACHEBUSTER" not in content
     assert re.search(r"\?v=\d+", content)
-    renamed_plot_dir = list(tmp_path.glob("plots-*"))
-    assert len(renamed_plot_dir) == 1
-    assert renamed_plot_dir[0].is_dir()
 
 
 def test_write_workflow_status(tmp_path):
@@ -81,7 +76,8 @@ def test_write_workflow_status(tmp_path):
 
 def test_construct_index(tmp_path):
     """Test putting the index together."""
-    plots_dir = tmp_path / "web/plots"
+    web_dir = tmp_path / "web"
+    plots_dir = web_dir / "plots"
     plots_dir.mkdir(parents=True)
 
     # Plot directories.
@@ -98,23 +94,24 @@ def test_construct_index(tmp_path):
     static_resource.touch()
 
     # Construct index.
-    finish_website.construct_index(plots_dir.parent)
+    finish_website.construct_index(web_dir)
 
     # Check index.
-    index_file = plots_dir / "index.jsonl"
+    index_file = web_dir / "index.jsonl"
     assert index_file.is_file()
     with open(index_file, "rt", encoding="UTF-8") as fp:
         index = fp.read()
     expected = (
-        '{"case_date":"20250101","category":"Category","path":"p1","title":"P1"}\n'
-        '{"case_date":"20250101","category":"Category","path":"p2","title":"P2"}\n'
+        '{"case_date":"20250101","category":"Category","path":"plots/p1","title":"P1"}\n'
+        '{"case_date":"20250101","category":"Category","path":"plots/p2","title":"P2"}\n'
     )
     assert index == expected
 
 
 def test_construct_index_aggregation_case(tmp_path):
     """Construct the index from a diagnostics without a case date."""
-    plots_dir = tmp_path / "web/plots"
+    web_dir = tmp_path / "web"
+    plots_dir = web_dir / "plots"
     plots_dir.mkdir(parents=True)
 
     # Plot directories.
@@ -123,20 +120,21 @@ def test_construct_index_aggregation_case(tmp_path):
     plot1.write_text('{"category": "Category", "title": "P1"}')
 
     # Construct index.
-    finish_website.construct_index(plots_dir.parent)
+    finish_website.construct_index(web_dir)
 
     # Check index.
-    index_file = plots_dir / "index.jsonl"
+    index_file = web_dir / "index.jsonl"
     assert index_file.is_file()
     with open(index_file, "rt", encoding="UTF-8") as fp:
         index = json.load(fp)
-    expected = {"category": "Category", "path": "p1", "title": "P1"}
+    expected = {"category": "Category", "path": "plots/p1", "title": "P1"}
     assert index == expected
 
 
 def test_construct_index_remove_keys(tmp_path):
     """Unneeded keys are removed from the index."""
-    plots_dir = tmp_path / "web/plots"
+    web_dir = tmp_path / "web"
+    plots_dir = web_dir / "plots"
     plots_dir.mkdir(parents=True)
 
     # Plot directories.
@@ -147,10 +145,10 @@ def test_construct_index_remove_keys(tmp_path):
     )
 
     # Construct index.
-    finish_website.construct_index(plots_dir.parent)
+    finish_website.construct_index(web_dir)
 
     # Check index.
-    index_file = plots_dir / "index.jsonl"
+    index_file = web_dir / "index.jsonl"
     assert index_file.is_file()
     with open(index_file, "rt", encoding="UTF-8") as fp:
         index = json.loads(fp.readline())
@@ -160,7 +158,8 @@ def test_construct_index_remove_keys(tmp_path):
 
 def test_construct_index_invalid(tmp_path, caplog):
     """Test constructing index when metadata is invalid."""
-    plots_dir = tmp_path / "web/plots"
+    web_dir = tmp_path / "web"
+    plots_dir = web_dir / "plots"
     plots_dir.mkdir(parents=True)
 
     # Plot directories.
@@ -169,45 +168,36 @@ def test_construct_index_invalid(tmp_path, caplog):
     plot.write_text('"Not JSON!"')
 
     # Construct index.
-    finish_website.construct_index(plots_dir.parent)
+    finish_website.construct_index(web_dir)
 
     # Check log message.
     _, level, message = caplog.record_tuples[0]
     assert level == logging.ERROR
     assert "p1/meta.json is invalid, skipping." in message
 
-    index_file = plots_dir / "index.jsonl"
+    index_file = web_dir / "index.jsonl"
     assert index_file.is_file()
     assert index_file.stat().st_size == 0
 
 
-def test_entrypoint(monkeypatch):
-    """Test running the finish_website module."""
-    # Count the number of times the other functions are run, to ensure they
-    # are all run.
-    counter = 0
+def test_parse_args():
+    """Check arguments are correctly parsed."""
+    # Check content path is read and default arguments set.
+    args = finish_website.parse_args(["/path/to/content"])
+    assert args.web_content == Path("/path/to/content")
+    assert args.web_root_link is None
+    assert args.skeleton == Path.cwd() / "html"
 
-    def increment_counter(*args, **kwargs):
-        nonlocal counter
-        counter += 1
-
-    def check_single_arg(www_content: Path):
-        assert www_content == Path("/share/web")
-        increment_counter()
-
-    def check_args(www_root_link: Path, www_content: Path):
-        assert www_root_link == Path("/var/www/cset")
-        assert www_content == Path("/share/web")
-        increment_counter()
-
-    monkeypatch.setattr(finish_website, "install_website_skeleton", check_args)
-    monkeypatch.setattr(finish_website, "copy_rose_config", check_single_arg)
-    monkeypatch.setattr(finish_website, "construct_index", check_single_arg)
-    monkeypatch.setattr(finish_website, "bust_cache", check_single_arg)
-    monkeypatch.setattr(finish_website, "update_workflow_status", check_single_arg)
-    monkeypatch.setenv("WEB_DIR", "/var/www/cset")
-    monkeypatch.setenv("CYLC_WORKFLOW_SHARE_DIR", "/share")
-
-    # Check that it runs all the needed subfunctions.
-    finish_website.run()
-    assert counter == 5
+    # Check root and skeleton can be set.
+    args = finish_website.parse_args(
+        [
+            "/path/to/content",
+            "--web-root-link",
+            "/path/to/root/",
+            "--skeleton",
+            "/path/to/skeleton",
+        ]
+    )
+    assert args.web_content == Path("/path/to/content")
+    assert args.web_root_link == Path("/path/to/root")
+    assert args.skeleton == Path("/path/to/skeleton")


### PR DESCRIPTION
Also allows for more general diagnostic layouts, so you don't need a plots directory.

A command line interface is added to allow for use outside of a cylc workflow.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [x] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Ensure `rose-suite.conf.example` has been updated if new diagnostic added.
- [ ] Conda lock files have been updated if dependencies have changed.
- [x] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
