### PR TITLE
Remove unneeded cycle complete graphing and improve inline documentation for sequential tasks

### DIFF
--- a/src/CSET/cset_workflow/flow.cylc
+++ b/src/CSET/cset_workflow/flow.cylc
@@ -23,8 +23,10 @@ final cycle point = {{CSET_TRIAL_END_DATE}}
 {% endif %}
 
     [[special tasks]]
-    # cycle_complete depends on its previous instance. We then don't need to
-    # know the offset between the cycles.
+    # Sequential tasks depends on their previous instance.
+    # This ensures:
+    #  * All fetches are complete before baking aggregation recipes.
+    #  * All cycles are complete before housekeeping.
     sequential = fetch_complete, cycle_complete
 
     [[graph]]

--- a/src/CSET/cset_workflow/flow.cylc
+++ b/src/CSET/cset_workflow/flow.cylc
@@ -51,15 +51,6 @@ final cycle point = {{CSET_TRIAL_END_DATE}}
     parbake_recipes:skip_baking? | bake_recipes => cycle_complete
     """
 
-    # Make sure all cycles are complete before housekeeping
-    {% if CSET_CYCLING_MODE == "case_study" %}
-        {% for i in range(1, CSET_CASE_DATES | length) %}
-        R1/{{CSET_CASE_DATES[i]}} = """cycle_complete[{{CSET_CASE_DATES[i-1]}}] => cycle_complete"""
-        {% endfor %}
-    {% elif CSET_CYCLING_MODE == "trial" %}
-        {{CSET_TRIAL_CYCLE_PERIOD}} = """cycle_complete[-{{CSET_TRIAL_CYCLE_PERIOD}}] => cycle_complete"""
-    {% endif %}
-
     # Only runs on the final cycle.
     R1/$ = """
     # Run aggregation recipes.


### PR DESCRIPTION
<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

The sequential tasks already cause the `cycle_complete` tasks to wait for the previous cycle's one. This does unfortunately cause inter-cycle dependency, however that is mitigated by using a very large run ahead limit (`runahead limit = P100`) to allow all the tasks to run at once anyway, so it is just the noop `cycle_complete` task that needs to run on each cycle. (And the `fetch_complete` noop task for similar reasons.) Once cylc adds specific start and end tasks that wait for everything else, we can remove this workaround.

<img width="810" height="814" alt="Graph view of the running workflow." src="https://github.com/user-attachments/assets/4b1c95fc-b045-46b8-80c6-4600d56ccc93" />


In issue #2150 the extra housekeeping call was the problematic bit, as it added a housekeeping task to every cycle, however that task cleans up beyond its own cycle.

Please let me know if I've missed something, and this doesn't fix the cycling for you.

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Ensure `rose-suite.conf.example` has been updated if new diagnostic added.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
