### PR TITLE
Correct extract time in test to account for removed bounds

### DIFF
--- a/tests/operators/test_scoreswrappers.py
+++ b/tests/operators/test_scoreswrappers.py
@@ -78,7 +78,7 @@ def test_scores_rmse_nonzero(cube: iris.cube.Cube):
 
 def test_scores_rmse_no_time_coord(cube):
     """RMSE of cubes with no time coordinate."""
-    c1 = cube.extract(iris.Constraint(time=datetime.datetime(2022, 9, 21, 3, 30)))
+    c1 = cube.extract(iris.Constraint(time=datetime.datetime(2022, 9, 21, 3, 0)))
     c1.remove_coord("time")
     c2 = c1.copy()
     del c2.attributes["cset_comparison_base"]


### PR DESCRIPTION
Follow up to #2111, which stopped guessing the bounds here.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [x] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Ensure `rose-suite.conf.example` has been updated if new diagnostic added.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
