### PR TITLE
Use micromamba if available in `make setup`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@
 # To make a command appear in the help, provide a line of documentation after
 # the target/prerequisites with ##.
 
+# Use micromamba if available, else fall back to conda.
+CONDA_EXE := $(shell command -v micromamba >/dev/null && echo "micromamba" || echo "conda")
+
 help: ## Display this help message.
 	@echo "Please provide a target from:"
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
@@ -18,15 +21,15 @@ prepare-lockfiles:
 	  || true
 
 conda: prepare-lockfiles
-	conda create -n cset-dev --file requirements/locks/latest --yes
+	${CONDA_EXE} create -n cset-dev --file requirements/locks/latest --yes
 	git restore requirements/locks  # Reset lockfiles in case we Met Office'd them.
 
 .git/hooks/pre-commit: conda
-	conda run -n cset-dev pre-commit install
+	${CONDA_EXE} run -n cset-dev pre-commit install
 
 # Prevent pip from accessing the network; we have everything in our conda env.
 setup: conda .git/hooks/pre-commit ## Setup development environment.
-	conda run -n cset-dev pip install --no-deps --no-index --no-build-isolation --editable .
+	${CONDA_EXE} run -n cset-dev pip install --no-deps --no-index --no-build-isolation --editable .
 	@echo "Run 'conda activate cset-dev' to use conda environment."
 
 docs: ## Build documentation.
@@ -48,4 +51,4 @@ test-full: pre-commit ## Run all tests, including slow or network reliant.
 
 # Mark targets as 'phony' to indicate they don't actually produce a file with
 # the same name as their target. Basically for actions rather than files.
-.PHONY: help setup docs test test-fast test-full prepare-lockfiles
+.PHONY: help setup docs test test-fast test-full prepare-lockfiles conda

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ conda: prepare-lockfiles
 # Prevent pip from accessing the network; we have everything in our conda env.
 setup: conda .git/hooks/pre-commit ## Setup development environment.
 	${CONDA_EXE} run -n cset-dev pip install --no-deps --no-index --no-build-isolation --editable .
-	@echo "Run 'conda activate cset-dev' to use conda environment."
+	@echo "Run '${CONDA_EXE} activate cset-dev' to use conda environment."
 
 docs: ## Build documentation.
 	make --directory=docs html

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 # the target/prerequisites with ##.
 
 # Use micromamba if available, else fall back to conda.
-CONDA_EXE := $(shell command -v micromamba >/dev/null && echo "micromamba" || echo "conda")
+CONDA_EXE := $(shell command -v micromamba || echo "conda")
 
 help: ## Display this help message.
 	@echo "Please provide a target from:"


### PR DESCRIPTION
<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

Micromamba is significantly faster, and is a much smaller initial install. We are likely going to move to it in CI, given that the ubuntu-26.04 runner images don't have conda pre-installed.

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Ensure `rose-suite.conf.example` has been updated if new diagnostic added.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
