### PR TITLE
Correct indentation of Scores references in docstrings

### DIFF
--- a/src/CSET/operators/scoreswrappers.py
+++ b/src/CSET/operators/scoreswrappers.py
@@ -132,7 +132,7 @@ def scores_rmse(
 ):
     r"""Calculate the Root Mean Square Error (RMSE) using scores.
 
-    Acts as a wrapper around the RMSE calculation from `scores` ([scoresa]_, [scoresb]_).
+    Acts as a wrapper around the RMSE calculation from ``scores`` ([scoresa]_, [scoresb]_).
     It is calculated as
 
     .. math:: RMSE = \sqrt{\frac{1}{N} \Sigma(forecast - observations)^2}
@@ -157,18 +157,17 @@ def scores_rmse(
     References
     ----------
     .. [scoresa] Leeuwenburg, T., Loveday, N., Ebert, E. E., Cook, H.,
-    Khanarmuei, M., Taggart, R. J., Ramanathan, N., Carroll, M., Chong, S.,
-    Griffiths, A., & Sharples, J. (2024) "scores: A Python package for
-    verifying and evaluating models and predictions with xarray". Journal
-    of Open Source Software, vol. 9, 6889. doi: 10.21105/joss.06889
+        Khanarmuei, M., Taggart, R. J., Ramanathan, N., Carroll, M., Chong, S.,
+        Griffiths, A., & Sharples, J. (2024) "scores: A Python package for
+        verifying and evaluating models and predictions with xarray". Journal
+        of Open Source Software, vol. 9, 6889. doi: 10.21105/joss.06889
 
     .. [scoresb] Leeuwenburg, T., Loveday, N., Ramanathan, N., Chong, S.,
-    Taggart, R. J., Shrestha, D., Khanarmuei, M., Cook, H., Bluett, L., Ebert,
-    E. E., Carroll, M., Trotta, B., Bishop, S., Squire, D. T., Griffiths, A.,
-    Pagano, T. C., Fisher, A. J., Mandelbaum, T., Jinghan, F., … Smallwood, J.
-    (2026) "scores: Metrics for the verification, evaluation and optimisation of
-    forecasts, predictions or models (2.5.0)". Zenodo. doi: 10.5281/zenodo.18638494
-
+        Taggart, R. J., Shrestha, D., Khanarmuei, M., Cook, H., Bluett, L., Ebert,
+        E. E., Carroll, M., Trotta, B., Bishop, S., Squire, D. T., Griffiths, A.,
+        Pagano, T. C., Fisher, A. J., Mandelbaum, T., Jinghan, F., … Smallwood, J.
+        (2026) "scores: Metrics for the verification, evaluation and optimisation of
+        forecasts, predictions or models (2.5.0)". Zenodo. doi: 10.5281/zenodo.18638494
     """
     base, other = _sort_cubes_for_verification(cubes)
     # Scores operators on xarray data arrays, so we transform the iris cube into an array,


### PR DESCRIPTION
<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

It was producing a warning when running, as it didn't like the rest of the reference not also being indented. This also caused the references to miss-render in the documentation:

<img width="775" height="289" alt="image" src="https://github.com/user-attachments/assets/5cf649ab-0470-4385-9178-68721748e608" />

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [x] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Ensure `rose-suite.conf.example` has been updated if new diagnostic added.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
