### PR TITLE
Use micromamba for GitHub Actions conda environment creation

### DIFF
--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -31,31 +31,26 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Cache conda environment
-        id: conda-env-cache
+      - name: Setup conda environment
+        uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476
+        with:
+          environment-name: cset-dev
+          environment-file: requirements/locks/${{ matrix.py-ver }}-lock-linux-64.txt
+          cache-environment: true
+          init-shell: "none"
+
+      - name: Cache downloaded cartopy shapefiles
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
-          key: conda|${{runner.os}}-${{runner.arch}}|${{ hashFiles(format('requirements/locks/{0}-lock-linux-64.txt', matrix.py-ver)) }}
-          path: |
-            ~/conda-env
-            ~/.local/share/cartopy
-
-      - name: Create conda environment
-        if: steps.conda-env-cache.outputs.cache-hit != 'true'
-        env:
-          py_ver: ${{ matrix.py-ver }}
-        run: |
-          # Check cache hasn't pulled a partial key match.
-          test ! -e "${HOME}/conda-env"
-          conda create --prefix="${HOME}/conda-env" --file=requirements/locks/${py_ver}-lock-linux-64.txt
-
-      - name: Add conda environment to PATH
-        run: echo "${HOME}/conda-env/bin" >> $GITHUB_PATH
+          key: cartopy-shapefiles
+          path: ~/.local/share/cartopy
 
       - name: Install local package
+        shell: micromamba-shell {0}
         run: pip install --no-deps .
 
       - name: Run fast tests
+        shell: micromamba-shell {0}
         env:
           PY_COLORS: "1"
           py_ver: ${{ matrix.py-ver }}
@@ -171,30 +166,21 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Cache conda environment
-        id: conda-env-cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
+      - name: Setup conda environment
+        uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476
         with:
-          key: conda|${{runner.os}}-${{runner.arch}}|${{hashFiles('requirements/locks/latest')}}
-          path: |
-            ~/conda-env
-            ~/.local/share/cartopy
+          environment-name: cset-dev
+          environment-file: requirements/locks/latest
+          cache-environment: true
+          init-shell: "none"
 
-      - name: Create conda environment
-        if: steps.conda-env-cache.outputs.cache-hit != 'true'
-        run: |
-          # Check cache hasn't pulled a partial key match.
-          test ! -e "${HOME}/conda-env"
-          conda create --prefix="${HOME}/conda-env" --file=requirements/locks/latest
-
-      - name: Add conda environment to PATH
-        run: echo "${HOME}/conda-env/bin" >> $GITHUB_PATH
-
-      - name: Install package so it can be imported during docs generation
+      - name: Install local package
+        shell: micromamba-shell {0}
         run: pip install --no-deps .
 
       - name: Build documentation with Sphinx
-        run: sphinx-build -b html --color "docs/source" "docs/build/html"
+        shell: micromamba-shell {0}
+        run: make docs
 
       - name: Upload documentation artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9

--- a/.github/workflows/weekly-checks.yml
+++ b/.github/workflows/weekly-checks.yml
@@ -22,32 +22,24 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Cache conda environment
-        id: conda-env-cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
+      - name: Setup conda environment
+        uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476
         with:
-          key: conda|${{runner.os}}-${{runner.arch}}|${{hashFiles('requirements/locks/latest')}}
-          path: |
-            ~/conda-env
-            ~/.local/share/cartopy
+          environment-name: cset-dev
+          environment-file: requirements/locks/latest
+          cache-environment: true
+          init-shell: "none"
 
-      - name: Create conda environment
-        if: steps.conda-env-cache.outputs.cache-hit != 'true'
-        run: |
-          # Check cache hasn't pulled a partial key match.
-          test ! -e "${HOME}/conda-env"
-          conda create --prefix="${HOME}/conda-env" --file=requirements/locks/latest
-
-      - name: Add conda environment to PATH
-        run: echo "${HOME}/conda-env/bin" >> $GITHUB_PATH
-
-      - name: Install package so it can be imported during docs generation
+      - name: Install local package
+        shell: micromamba-shell {0}
         run: pip install --no-deps .
 
       - name: Build documentation with Sphinx
+        shell: micromamba-shell {0}
         run: sphinx-build -b html --color "docs/source" "docs/build/html"
 
       - name: Check for broken hyperlinks
+        shell: micromamba-shell {0}
         run: sphinx-build -b linkcheck --color -W --keep-going "docs/source" "docs/build/linkcheck"
 
   full-tests:
@@ -65,31 +57,26 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Cache conda environment
-        id: conda-env-cache
+      - name: Setup conda environment
+        uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476
+        with:
+          environment-name: cset-dev
+          environment-file: requirements/locks/${{ matrix.py-ver }}-lock-linux-64.txt
+          cache-environment: true
+          init-shell: "none"
+
+      - name: Cache downloaded cartopy shapefiles
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
-          key: conda|${{runner.os}}-${{runner.arch}}|${{ hashFiles(format('requirements/locks/{0}-lock-linux-64.txt', matrix.py-ver)) }}
-          path: |
-            ~/conda-env
-            ~/.local/share/cartopy
-
-      - name: Create conda environment
-        if: steps.conda-env-cache.outputs.cache-hit != 'true'
-        env:
-          py_ver: ${{ matrix.py-ver }}
-        run: |
-          # Check cache hasn't pulled a partial key match.
-          test ! -e "${HOME}/conda-env"
-          conda create --prefix="${HOME}/conda-env" --file=requirements/locks/${py_ver}-lock-linux-64.txt
-
-      - name: Add conda environment to PATH
-        run: echo "${HOME}/conda-env/bin" >> $GITHUB_PATH
+          key: cartopy-shapefiles
+          path: ~/.local/share/cartopy
 
       - name: Install local package
+        shell: micromamba-shell {0}
         run: pip install --no-deps .
 
       - name: Run full test suite
+        shell: micromamba-shell {0}
         env:
           PY_COLORS: "1"
         run: make test-full


### PR DESCRIPTION
<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

The default miniconda installation is going away with the ubuntu-26.04
Actions runner image. Therefore we move to using micromamba for
environment creation.

Micromamba has a nice Action which removes the need to do our own
caching and provides the micromamba-shell custom shell to run our
commands in.

I've still kept the caching of the cartopy shapefiles in for
reliability, though they are now only downloaded by the jobs that need
them. Given they should very rarely change I've gone for a fixed cache
key to keep things simple and allow them to be shared across all
branches.

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Ensure `rose-suite.conf.example` has been updated if new diagnostic added.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
