### PR TITLE
Adds a bug fix to scores_RMSE implementation

### DIFF
--- a/src/CSET/operators/scoreswrappers.py
+++ b/src/CSET/operators/scoreswrappers.py
@@ -117,7 +117,8 @@ def _sort_cubes_for_verification(cubes: CubeList):
     base_lat_direction = is_increasing(base.coord(base_lat_name).points)
     other_lat_direction = is_increasing(other.coord(other_lat_name).points)
     if base_lat_direction != other_lat_direction:
-        reverse(other, other_lat_name)
+        # Regrid the data onto the same grid (this should only flip the array and not alter the data).
+        other = other.regrid(base, iris.analysis.Linear())
 
     # Extract just common time points.
     base, other = _extract_common_time_points(base, other)

--- a/src/CSET/operators/scoreswrappers.py
+++ b/src/CSET/operators/scoreswrappers.py
@@ -18,6 +18,7 @@ import logging
 
 import iris
 import iris.exceptions
+import numpy as np
 import scores
 import scores.continuous
 import xarray as xr
@@ -76,6 +77,9 @@ def _sort_cubes_for_verification(cubes: CubeList):
         except iris.exceptions.CoordinateNotFoundError:
             pass
 
+    # Extract just common time points.
+    base, other = _extract_common_time_points(base, other)
+
     # Get spatial coord names.
     base_lat_name, base_lon_name = get_cube_yxcoordname(base)
     other_lat_name, other_lon_name = get_cube_yxcoordname(other)
@@ -117,11 +121,17 @@ def _sort_cubes_for_verification(cubes: CubeList):
     base_lat_direction = is_increasing(base.coord(base_lat_name).points)
     other_lat_direction = is_increasing(other.coord(other_lat_name).points)
     if base_lat_direction != other_lat_direction:
-        # Regrid the data onto the same grid (this should only flip the array and not alter the data).
-        other = other.regrid(base, iris.analysis.Linear())
-
-    # Extract just common time points.
-    base, other = _extract_common_time_points(base, other)
+        # Copy base cube for correct coordinate information.
+        other_tmp = base.copy()
+        # Flip the data and place in the copied cube.
+        other_tmp.data = np.flip(
+            other.data, other.coord(other_lat_name).cube_dims(other)
+        )
+        # Use original name and units from the other cube.
+        other_tmp.rename(other.name())
+        other_tmp.units = other.units
+        # Replace the cube.
+        other = other_tmp
 
     # Equalise attributes so we can merge.
     fully_equalise_attributes(CubeList([base, other]))


### PR DESCRIPTION
When running CSET with scores_RMSE with two regional models (UM and LFRic) preserved dimensions were not being preserved instead those coordinates were having dimensions of zero.

After investigation it appeared to be potentially linked to xarray conversions from iris. However, deeper investigation showed that the arrays were not flipping as expected as the latitude arrays were the reverse of each other. Using the reverse utility in iris was expected to flip both the data and the coordinates, however (and this may just have been the original implementation of it) this did not appear to be the case.

The solution was to regrid the cube onto the same grid, so that flipping occurred. This allows us to preserve dimensions and keep the same overall functionality.

Fixes #2187

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [x] Documentation has been updated to reflect change.
- [x] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Ensure `rose-suite.conf.example` has been updated if new diagnostic added.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
