### PR TITLE
Add Makefile target and script to update developer environment lock files

### DIFF
--- a/.github/workflows/scheduled-updates.yml
+++ b/.github/workflows/scheduled-updates.yml
@@ -28,36 +28,14 @@ jobs:
         with:
           python-version: "3.x"
 
-      - name: Install dependencies
-        run: pip install conda-lock pre-commit
-
       - name: Setup git user and branch
         run: |
           git config --local user.name "github-actions[bot]"
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git switch -c "scheduled-updates-$(date +%s)"
 
-      - name: Update CSET developer and workflow lock files
-        run: |
-          py_vers="3.12 3.13 3.14"
-          for py_ver in ${py_vers}
-          do
-            # Developer lock files.
-            cp "requirements/environment.yml" "${RUNNER_TEMP}/${py_ver}_dev_environment.yml"
-            echo -e "\n  - python = $py_ver" >> "${RUNNER_TEMP}/${py_ver}_dev_environment.yml"
-            conda-lock --channel conda-forge --kind explicit --file "${RUNNER_TEMP}/${py_ver}_dev_environment.yml" --platform linux-64 --filename-template "requirements/locks/py$(echo $py_ver | sed 's/\.//')-lock-linux-64.txt"
-          done
-
-          # Sort lock files to make diffs easier to review.
-          for file in requirements/locks/*.txt
-          do
-            # Leave the file header unsorted.
-            cat "$file" | (sed -u 4q; sort) > sorted.txt
-            mv sorted.txt "$file"
-          done
-
-      - name: Update pre-commit config
-        run: pre-commit autoupdate --freeze
+      - name: Update CSET developer lock files and pre-commit hooks
+        run: make update-dev-deps
 
       - name: Generate GitHub App Token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
@@ -77,7 +55,7 @@ jobs:
           git diff --stat
 
           # Commit changed lockfiles.
-          git add requirements/locks/*.txt
+          git add requirements/locks/
           git commit -m "[CI] Update conda lock files" || true
 
           # Commit changed pre-commit config.

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,9 @@ test-full: pre-commit ## Run all tests, including slow or network reliant.
 	playwright install --only-shell chromium
 	pytest -vv --cov --cov-append --cov-config=pyproject.toml --numprocesses logical
 
+update-dev-deps:  ## Update pre-commit hooks and conda lock files for the development environment.
+	scripts/update-developer-dependencies.sh
+
 # Mark targets as 'phony' to indicate they don't actually produce a file with
 # the same name as their target. Basically for actions rather than files.
-.PHONY: help setup docs test test-fast test-full prepare-lockfiles conda
+.PHONY: help setup docs test test-fast test-full prepare-lockfiles conda update-dev-deps

--- a/docs/source/contributing/dependencies.rst
+++ b/docs/source/contributing/dependencies.rst
@@ -33,12 +33,15 @@ Specifically it needs to be added to the ``pyproject.toml`` under the
 "dependencies" key, and ``requirements/environment.yaml`` under the appropriate
 dependencies section.
 
-After updating those two files and making a pull request, you'll need to rerun
-the conda lockfile generation action. In `Actions > Update conda lock files >
-Run workflow`_ select your branch, then run the workflow. A new PR will be
-created to update the lockfiles, which you can merge into your own branch.
+After updating those two files and making a pull request, you'll need to
+regenerate the conda lockfiles.
 
-.. _Actions > Update conda lock files > Run workflow: https://github.com/MetOffice/CSET/actions/workflows/conda-lock.yml
+.. code-block:: bash
+
+    # Regenerate the lock files.
+    make update-dev-deps
+    # Commit them to your branch.
+    git commit -m "Update conda lockfiles" requirements/
 
 Updating the conda-forge package
 --------------------------------

--- a/scripts/update-developer-dependencies.sh
+++ b/scripts/update-developer-dependencies.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Update conda lock files and pre-commit hooks.
+set -euo pipefail
+
+# Create a temporary virtual environment.
+venv_location="$(mktemp -d)"
+echo "Creating temporary virtual environment at ${venv_location}"
+python3 -m venv "${venv_location}"
+# shellcheck disable=SC1091
+source "${venv_location}/bin/activate"
+
+echo "Installing update tools"
+pip install --quiet conda-lock pre-commit
+
+# Create lock files for supported python versions.
+py_vers="3.12 3.13 3.14"
+env_tmp="$(mktemp -d)"
+for py_ver in ${py_vers}
+do
+    # Developer lock files.
+    echo "Updating lock files for python ${py_ver}"
+    cp "requirements/environment.yml" "${env_tmp}/${py_ver}_dev_environment.yml"
+    echo -e "\n  - python = $py_ver" >> "${env_tmp}/${py_ver}_dev_environment.yml"
+    conda-lock --channel conda-forge --kind explicit --file "${env_tmp}/${py_ver}_dev_environment.yml" --platform linux-64 --filename-template "requirements/locks/py${py_ver//.}-lock-linux-64.txt"
+done
+
+# Replace Met Office specific URLs with normal ones.
+sed -i "s|metoffice.jfrog.io/metoffice/api/conda|conda.anaconda.org|" requirements/locks/*.txt
+
+# Sort lock files to make diffs easier to review.
+for file in requirements/locks/*.txt
+do
+    # Leave the file header unsorted.
+    cat "${file}" | (sed -u 4q; sort) > sorted.txt
+    mv sorted.txt "${file}"
+done
+
+# Record the environment.yml used to build the environment.
+sha256sum requirements/environment.yml > requirements/locks/sources
+
+echo "Updating pre-commit hooks"
+pre-commit autoupdate --freeze
+
+echo "Cleaning up temporary files"
+# Clean up temporary environment definitions.
+rm -r "${env_tmp}"
+# Clean up virtual environment.
+deactivate
+rm -r "${venv_location}"


### PR DESCRIPTION
<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

This makes it possible to update these without relying on GitHub Actions. Additionally a marker file is now created indicating when the lock files were last generated, as a prerequisite for #2207.

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [x] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Ensure `rose-suite.conf.example` has been updated if new diagnostic added.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
