### PR TITLE
Create the update PR without using the GitHub App

### DIFF
--- a/.github/workflows/scheduled-updates.yml
+++ b/.github/workflows/scheduled-updates.yml
@@ -38,18 +38,11 @@ jobs:
       - name: Update CSET developer lock files and pre-commit hooks
         run: make update-dev-deps
 
-      - name: Generate GitHub App Token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
-        id: app-token
-        with:
-          app-id: ${{ secrets.AUTH_APP_ID }}
-          private-key: ${{ secrets.AUTH_APP_PRIVATE_KEY }}
-
       - name: Commit changes and create pull requests
         env:
           source_ref: ${{ github.ref }}
           source_ref_type: ${{ github.ref_type }}
-          gh_token: ${{ steps.app-token.outputs.token }}
+          gh_token: ${{ github.token }}
           repository: ${{ github.repository }}
         run: |
           original_commit="$(git rev-parse --verify HEAD)"


### PR DESCRIPTION
This is now possible, where before Actions workflows could not start without using a GitHub App or PAT.
https://github.blog/changelog/2026-06-11-bot-created-pull-requests-can-run-workflows-if-approved/

Once merged we can remove the secret for the app and ask that it be deleted, as we have no other need for it. This enhances our repo security.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Ensure `rose-suite.conf.example` has been updated if new diagnostic added.
- [ ] Conda lock files have been updated if dependencies have changed.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
