### PR TITLE
Update description for rmse scores 

### DIFF
--- a/src/CSET/cset_workflow/meta/verification/rose-meta.conf
+++ b/src/CSET/cset_workflow/meta/verification/rose-meta.conf
@@ -63,6 +63,7 @@ title=Scores
 ns=Verification/Scores
 description=Create spatially mapped RMSE plots for the specified surface fields.
             The analysis method(s) set in SPATIAL_SURFACE_FIELD_METHOD will be used.
+	    NOTE currently only available for model-model intercomparisons
 type=python_boolean
 compulsory=true
 sort-key=scores1
@@ -70,6 +71,7 @@ sort-key=scores1
 [template variables=SCORES_RMSE_TIMESERIES]
 ns=Verification/Scores
 description=Create a timeseries of the RMSE for the specified surface fields.
+	    NOTE currently only available for model-model intercomparisons
 type=python_boolean
 compulsory=true
 sort-key=scores2

--- a/src/CSET/cset_workflow/meta/verification/rose-meta.conf
+++ b/src/CSET/cset_workflow/meta/verification/rose-meta.conf
@@ -63,7 +63,7 @@ title=Scores
 ns=Verification/Scores
 description=Create spatially mapped RMSE plots for the specified surface fields.
             The analysis method(s) set in SPATIAL_SURFACE_FIELD_METHOD will be used.
-	    NOTE currently only available for model-model intercomparisons
+            NOTE currently only available for model-model intercomparisons
 type=python_boolean
 compulsory=true
 sort-key=scores1
@@ -71,7 +71,7 @@ sort-key=scores1
 [template variables=SCORES_RMSE_TIMESERIES]
 ns=Verification/Scores
 description=Create a timeseries of the RMSE for the specified surface fields.
-	    NOTE currently only available for model-model intercomparisons
+            NOTE currently only available for model-model intercomparisons
 type=python_boolean
 compulsory=true
 sort-key=scores2


### PR DESCRIPTION
Related to Issue #2218

Update the description of the RMSE scores in the GUI to reflect that they are currently only available for model-model intercomparisons.

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [ ] All tests and CI checks pass.
- [ ] Ensured the pull request title is descriptive.
- [ ] Ensure `rose-suite.conf.example` has been updated if new diagnostic added.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [ ] Marked the PR as ready to review.
