### PR TITLE
Add reformatted coverage report as Actions job summary

### DIFF
--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -107,20 +107,35 @@ jobs:
           repository: ${{ github.repository }}
           head_ref: ${{ github.head_ref }}
         run: |
-          # This links to a hosted version of the HTML report.
+          # Host the HTML report.
           tar -czf coverage-report.tar.gz htmlcov/
           report_url="$(curl -sSf --user "token:${tmpweb_api_key}" --data-binary @coverage-report.tar.gz https://tmpweb.net || true)"
           if [[ -z "${report_url}" ]] ; then
             echo "Could not upload report."
+            report_html=""
           else
-            echo "Report hosted at $report_url"
-            badge_options="$(coverage json --fail-under=0 -qo - | jq -r .totals.percent_covered_display)%25-blue?style=for-the-badge"
-            echo "[![Coverage](https://img.shields.io/badge/coverage-${badge_options})](${report_url})" >> cov-report.md
-            # Edit last comment if it exists, else create new one.
-            if ! gh pr comment --repo "${repository}" --edit-last --create-if-none "${head_ref}" --body-file cov-report.md ; then
-              echo "Failed to post comment. This is likely due to this being a PR from a fork."
-            fi
+            echo "Report hosted at ${report_url}"
+            report_html="(<a href=\"${report_url}\">HTML report</a>)"
           fi
+          percent_coverage="$(coverage json --fail-under=0 -qo - | jq -r .totals.percent_covered_display)"
+          # Write coverage report.
+          cat <<- EOF > cov-report.md
+          <details>
+          <summary>
+            Total coverage: <strong>${percent_coverage}%</strong>
+            ${report_html}
+          </summary>
+          <pre>
+          $(coverage report)
+          </pre>
+          </details>
+          EOF
+          # Edit last comment if it exists, else create new one.
+          if ! gh pr comment --repo "${repository}" --edit-last --create-if-none "${head_ref}" --body-file cov-report.md ; then
+            echo "Failed to post comment. This is likely due to this being a PR from a fork."
+          fi
+          # Add report as job summary.
+          cat cov-report.md > "${GITHUB_STEP_SUMMARY}"
 
       - name: Check 90% minimum coverage
         run: coverage report --fail-under=90


### PR DESCRIPTION
<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

This allows the basic coverage information to also be visible for pull
requests from forks and removes our dependency on the third-party
shields.io service.

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Ensure `rose-suite.conf.example` has been updated if new diagnostic added.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
