### PR TITLE
Fix missed custom conda path in `app_env_wrapper`

### DIFF
--- a/src/CSET/cset_workflow/bin/app_env_wrapper
+++ b/src/CSET/cset_workflow/bin/app_env_wrapper
@@ -40,7 +40,7 @@ if [[ -d "${CYLC_WORKFLOW_RUN_DIR}/conda-environment" ]]; then
   echo "Using conda environment from ${CYLC_WORKFLOW_RUN_DIR}/conda-environment"
   # Don't capture output so logs are seen while the program is still running.
   exec "${CONDA_PATH}conda" run --no-capture-output --prefix "${CYLC_WORKFLOW_RUN_DIR}/conda-environment" "$@"
-elif conda info --envs | grep -q '^cset-dev '; then
+elif "${CONDA_PATH}conda" info --envs | grep -q '^cset-dev '; then
   echo "No linked conda environment. Attempting to use 'cset-dev' environment."
   exec "${CONDA_PATH}conda" run --no-capture-output --name cset-dev "$@"
 else


### PR DESCRIPTION
<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

This supports conda not being on-path.

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Ensure `rose-suite.conf.example` has been updated if new diagnostic added.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
