### PR TITLE
Add ensemble capability to scores RMSE vertical profiles

### DIFF
--- a/src/CSET/cset_workflow/meta/verification/rose-meta.conf
+++ b/src/CSET/cset_workflow/meta/verification/rose-meta.conf
@@ -198,6 +198,36 @@ type=python_boolean
 compulsory=true
 sort-key=sc-ts-4
 
+
+# Scores profile plots
+[Verification/ScoresVerticalProfiles]
+ns=Verification/ScoresVerticalProfiles
+sort-key=scoresvertical
+title=Scores vertical profiles
+
+[template variables=SCORES_RMSE_VERTICAL_PROFILES]
+ns=Verification/ScoresVerticalProfiles
+description=Create vertical profile RMSE plots for the specified level fields.
+    A total RMSE profile is calculated from all grid points for all timesteps within a case study at each pressure level.
+    In case of ensembles the ensemble mean is calculated first and the RMSE is then calculated between the ensemble mean and the base model ensemble mean.
+type=python_boolean
+compulsory=true
+sort-key=scoresprofile1
+
+[template variables=SCORES_RMSE_VERTICAL_PROFILES_SEQUENCE]
+ns=Verification/Scores vertical profiles
+description=Create a sequence of RMSE vertical profiles, one per time step, for each case study.
+help=When True, the RMSE is calculated for all grid points and at each level for every
+    time step, collapsing only the spatial (horizontal) dimensions. This produces
+    a sequence of vertical RMSE profile plots, one per time step, in addition to
+    the profile that is aggregated across the whole case study.
+    In case of ensembles the ensemble mean is calculated first and the RMSE is then calculated between the ensemble mean and the base model ensemble mean.
+type=python_boolean
+compulsory=true
+sort-key=scoresprofile2
+
+
+# Scores ensemble diagnostics
 [template variables=SCORES_CRPS_FOR_ENSEMBLE]
 ns=Verification/Scores
 description=Create a timeseries of the CRPS for comparing ensemble members to control.
@@ -226,31 +256,3 @@ help=Usually this should be set to 0, but in some case it may be 1.
 type=integer
 compulsory=true
 sort-key=scores4b
-
-[Verification/Scores vertical profiles]
-ns=Verification/Scores vertical profiles
-sort-key=scoresvertical
-title=Scores vertical profiles
-
-[Verification/Scores vertical profiles]
-[template variables=SCORES_RMSE_VERTICAL_PROFILES]
-ns=Verification/Scores vertical profiles
-description=Create vertical profile RMSE plots for the specified level fields.
-    RMSE profiles are calculated at each grid point for all timesteps within a case study at each pressure level.
-type=python_boolean
-compulsory=true
-sort-key=scoresprofile1
-
-[template variables=SCORES_RMSE_VERTICAL_PROFILES_SEQUENCE]
-ns=Verification/Scores vertical profiles
-description=Also produce one RMSE vertical profile per time step.
-help=When True, the RMSE is calculated at each grid point and level for every
-    time step, collapsing only the spatial (horizontal) dimensions. This produces
-    a sequence of vertical RMSE profile plots, one per time step, in addition to
-    the profile that is aggregated across the whole case study.
-
-    When False (default), only the aggregated vertical RMSE profile is produced.
-type=python_boolean
-compulsory=true
-#trigger=template variables=SCORES_RMSE_VERTICAL_PROFILES: True;
-sort-key=scoresprofile2

--- a/src/CSET/loaders/verification.py
+++ b/src/CSET/loaders/verification.py
@@ -168,7 +168,7 @@ def load(conf: Config):
                     "VARNAME": field,
                     "BASE_MODEL": base_model["name"],
                     "OTHER_MODEL": model["name"],
-                    "PRESERVED_COORDS": ["time", "pressure", "realization"],
+                    "PRESERVED_COORDS": ["time", "pressure"],
                     "AGGREGATION_MODE": "Time-step RMSE",
                     "SUBAREA_TYPE": conf.SUBAREA_TYPE if conf.SELECT_SUBAREA else None,
                     "SUBAREA_EXTENT": conf.SUBAREA_EXTENT

--- a/src/CSET/loaders/verification.py
+++ b/src/CSET/loaders/verification.py
@@ -168,7 +168,7 @@ def load(conf: Config):
                     "VARNAME": field,
                     "BASE_MODEL": base_model["name"],
                     "OTHER_MODEL": model["name"],
-                    "PRESERVED_COORDS": ["time", "pressure"],
+                    "PRESERVED_COORDS": ["time", "pressure", "realization"],
                     "AGGREGATION_MODE": "Time-step RMSE",
                     "SUBAREA_TYPE": conf.SUBAREA_TYPE if conf.SELECT_SUBAREA else None,
                     "SUBAREA_EXTENT": conf.SUBAREA_EXTENT

--- a/src/CSET/operators/plot.py
+++ b/src/CSET/operators/plot.py
@@ -959,6 +959,10 @@ def _plot_and_save_line_series(
     """
     fig = plt.figure(figsize=(10, 10), facecolor="w", edgecolor="k")
 
+    title_suffix = ""
+    if cubes and cubes[0].attributes.get("cset_ensemble_mean") == "true":
+        title_suffix = " (ensemble mean)"
+
     model_colors_map = get_model_colors_map(cubes)
 
     # Store min/max ranges.
@@ -974,7 +978,8 @@ def _plot_and_save_line_series(
             label = cube.attributes.get("model_name")
             color = model_colors_map.get(label)
         if not cube.coords(ensemble_coord):
-            # No ensemble coordinate — plot the cube directly as a single line.
+            # No ensemble coordinate (e.g. after ensemble-mean collapse): plot
+            # the cube as a single deterministic line.
             iplt.plot(coord, cube, color=color, marker="o", ls="-", lw=3, label=label)
         else:
             for cube_slice in cube.slices_over(ensemble_coord):
@@ -1019,7 +1024,7 @@ def _plot_and_save_line_series(
     else:
         ax.set_xlabel(f"{coords[0].name()} / {coords[0].units}", fontsize=14)
     ax.set_ylabel(f"{cubes[0].name()} / {cubes[0].units}", fontsize=14)
-    ax.set_title(title, fontsize=16)
+    ax.set_title(f"{title}{title_suffix}", fontsize=16)
 
     ax.ticklabel_format(axis="y", useOffset=False)
     ax.tick_params(axis="x", labelrotation=15)
@@ -1209,6 +1214,10 @@ def _plot_and_save_vertical_line_series(
     # plot the vertical pressure axis using log scale
     fig = plt.figure(figsize=(10, 10), facecolor="w", edgecolor="k")
 
+    title_suffix = ""
+    if cubes and cubes[0].attributes.get("cset_ensemble_mean") == "true":
+        title_suffix = " (ensemble mean)"
+
     model_colors_map = get_model_colors_map(cubes)
 
     # Check match-up across sequence coords gives consistent sizes
@@ -1221,32 +1230,37 @@ def _plot_and_save_vertical_line_series(
             label = cube.attributes.get("model_name")
             color = model_colors_map.get(label)
 
-        for cube_slice in cube.slices_over(ensemble_coord):
-            # If ensemble data given plot control member with (control)
-            # unless single forecast.
-            if cube_slice.coord(ensemble_coord).points == [0]:
-                iplt.plot(
-                    cube_slice,
-                    coord,
-                    color=color,
-                    marker="o",
-                    ls="-",
-                    lw=3,
-                    label=f"{label} (control)"
-                    if len(cube.coord(ensemble_coord).points) > 1
-                    else label,
-                )
-            # If ensemble data given plot perturbed members with (perturbed).
-            else:
-                iplt.plot(
-                    cube_slice,
-                    coord,
-                    color=color,
-                    ls="-",
-                    lw=1.5,
-                    alpha=0.75,
-                    label=f"{label} (member)",
-                )
+        if not cube.coords(ensemble_coord):
+            # No ensemble coordinate (e.g. after ensemble-mean RMSE): plot
+            # the cube as a single deterministic line.
+            iplt.plot(cube, coord, color=color, marker="o", ls="-", lw=3, label=label)
+        else:
+            for cube_slice in cube.slices_over(ensemble_coord):
+                # If ensemble data given plot control member with (control)
+                # unless single forecast.
+                if cube_slice.coord(ensemble_coord).points == [0]:
+                    iplt.plot(
+                        cube_slice,
+                        coord,
+                        color=color,
+                        marker="o",
+                        ls="-",
+                        lw=3,
+                        label=f"{label} (control)"
+                        if len(cube.coord(ensemble_coord).points) > 1
+                        else label,
+                    )
+                # If ensemble data given plot perturbed members with (perturbed).
+                else:
+                    iplt.plot(
+                        cube_slice,
+                        coord,
+                        color=color,
+                        ls="-",
+                        lw=1.5,
+                        alpha=0.75,
+                        label=f"{label} (member)",
+                    )
 
     # Get the current axis
     ax = plt.gca()
@@ -1294,7 +1308,7 @@ def _plot_and_save_vertical_line_series(
     ax.set_xlabel(
         f"{iter_maybe(cubes)[0].name()} / {iter_maybe(cubes)[0].units}", fontsize=14
     )
-    ax.set_title(title, fontsize=16)
+    ax.set_title(f"{title}{title_suffix}", fontsize=16)
     ax.ticklabel_format(axis="x")
     ax.tick_params(axis="y")
     ax.tick_params(axis="both", labelsize=12)

--- a/src/CSET/operators/scoreswrappers.py
+++ b/src/CSET/operators/scoreswrappers.py
@@ -194,6 +194,14 @@ def _resolve_preserve_dims(
     return preserve_dims
 
 
+def _collapse_ensemble_mean(data_array: xr.DataArray) -> xr.DataArray:
+    """Collapse a realization dimension to its mean when present."""
+    if "realization" in data_array.dims:
+        return data_array.mean(dim="realization", keep_attrs=True)
+
+    return data_array
+
+
 def scores_rmse(cubes: CubeList, preserved_coordinates: list[str] | str | None = None):
     r"""Calculate the Root Mean Square Error (RMSE) using scores.
 
@@ -213,6 +221,8 @@ def scores_rmse(cubes: CubeList, preserved_coordinates: list[str] | str | None =
         ["time","grid_latitude", "grid_longitude"] or if you want a time series
         you can preserve ["time"], if you want to collapse to a single value
         use `None`. The default is `None`.
+        If an ensemble realization dimension is present, it is collapsed to the
+        ensemble mean before the RMSE is calculated.
 
     Returns
     -------
@@ -236,9 +246,13 @@ def scores_rmse(cubes: CubeList, preserved_coordinates: list[str] | str | None =
     """
     base, other = _sort_cubes_for_verification(cubes)
 
-    # Copy the coordinates of the input cubes.
-    other_xr = xr.DataArray.from_iris(other)
-    base_xr = xr.DataArray.from_iris(base)
+    is_ensemble_mean = (
+        "realization" in xr.DataArray.from_iris(base).dims
+        or "realization" in xr.DataArray.from_iris(other).dims
+    )
+
+    other_xr = _collapse_ensemble_mean(xr.DataArray.from_iris(other))
+    base_xr = _collapse_ensemble_mean(xr.DataArray.from_iris(base))
     preserve_dims = _resolve_preserve_dims(other, other_xr, preserved_coordinates)
 
     # Scores operates on xarray data arrays, so we transform the iris cube into an array,
@@ -278,10 +292,13 @@ def scores_rmse(cubes: CubeList, preserved_coordinates: list[str] | str | None =
             )
     except iris.exceptions.CoordinateNotFoundError:
         pass
-
     scores_cube.rename(f"RMSE_of_{base.name()}")
     # if preserved_coordinates == ["grid_latitude", "grid_longitude"]:
     #   scores_cube.add_aux_coord(time_coord)
+
+    # if ensemble add ensemble attribute
+    if is_ensemble_mean:
+        scores_cube.attributes["cset_ensemble_mean"] = "true"
     return scores_cube
 
 

--- a/src/CSET/operators/scoreswrappers.py
+++ b/src/CSET/operators/scoreswrappers.py
@@ -216,7 +216,7 @@ def scores_rmse(cubes: CubeList, preserved_coordinates: list[str] | str | None =
         A CubeList containing exactly two cubes: a base and an "other" model,
         this can be an analysis and the model.
     preserved_coordinates: list[str] | str | None, default is None.
-        The coordinates (or xarray dimension names) that you wish to preserve in the calculaiton of the
+        The coordinates (or xarray dimension names) that you wish to preserve in the calculation of the
         RMSE. For example if you want a map of each time you can preserve
         ["time","grid_latitude", "grid_longitude"] or if you want a time series
         you can preserve ["time"], if you want to collapse to a single value
@@ -251,6 +251,7 @@ def scores_rmse(cubes: CubeList, preserved_coordinates: list[str] | str | None =
         or "realization" in xr.DataArray.from_iris(other).dims
     )
 
+    # if ensemble data then calculate the ensemble mean first before calculating the RMSE
     other_xr = _collapse_ensemble_mean(xr.DataArray.from_iris(other))
     base_xr = _collapse_ensemble_mean(xr.DataArray.from_iris(base))
     preserve_dims = _resolve_preserve_dims(other, other_xr, preserved_coordinates)
@@ -383,7 +384,6 @@ def scores_mae(cubes: CubeList, preserved_coordinates: list[str] | str | None = 
             )
     except iris.exceptions.CoordinateNotFoundError:
         pass
-
     scores_cube.rename(f"MAE_of_{base.name()}")
     return scores_cube
 

--- a/src/CSET/recipes/verification/generic_level_rmse_scores_profile.yaml
+++ b/src/CSET/recipes/verification/generic_level_rmse_scores_profile.yaml
@@ -13,6 +13,8 @@ description: |
   https://scores.readthedocs.io/en/stable/
   https://scores.readthedocs.io/en/stable/api.html#scores.continuous.rmse
 
+  In case of ensemble data the RMSE is calculated between the ensemble mean
+  of $BASE_MODEL and the ensemble mean of $OTHER_MODEL.
 
   Aggregation mode:
   - Case-study RMSE: Single RMSE profile calculated using all time points in the case study.

--- a/tests/operators/test_scoreswrappers.py
+++ b/tests/operators/test_scoreswrappers.py
@@ -17,6 +17,8 @@
 import datetime
 
 import iris
+import iris.analysis
+import iris.analysis.calculus
 import iris.coords
 import numpy as np
 import pytest
@@ -155,6 +157,20 @@ def test_scores_rmse_no_common_points(cube):
     cubes = CubeList([cube, other_cube])
     with pytest.raises(ValueError, match="No common time points found!"):
         scoreswrappers.scores_rmse(cubes)
+
+
+def test_scores_rmse_ensemble_mean(ensemble_cube):
+    """Test RMSE collapses realization to the ensemble mean."""
+    base_cube = ensemble_cube.copy()
+    base_cube.attributes["cset_comparison_base"] = 1
+
+    mean_cube = ensemble_cube.collapsed("realization", iris.analysis.MEAN)
+    cubes = iris.cube.CubeList([base_cube, mean_cube])
+
+    rmse_cube = scoreswrappers.scores_rmse(cubes)
+
+    assert isinstance(rmse_cube, iris.cube.Cube)
+    assert np.allclose(rmse_cube.data, np.zeros_like(rmse_cube.data), atol=1e-9)
 
 
 def test_scores_rmse_incorrect_number_of_cubes(cube):

--- a/tests/operators/test_scoreswrappers.py
+++ b/tests/operators/test_scoreswrappers.py
@@ -165,6 +165,11 @@ def test_scores_rmse_ensemble_mean(ensemble_cube):
     base_cube.attributes["cset_comparison_base"] = 1
 
     mean_cube = ensemble_cube.collapsed("realization", iris.analysis.MEAN)
+    # remove the cset_comparison_base attribute from the mean_cube to avoid having it
+    # in both the ensemble mean and the ensemble base cube, which would cause an error in the RMSE calculation.
+    # this function  only expects a single cube with cset_comparison_base attribute to be present in the cubes list
+    # to identify the base cube for comparison plots against "other" model.
+    mean_cube.attributes.pop("cset_comparison_base", None)
     cubes = iris.cube.CubeList([base_cube, mean_cube])
 
     rmse_cube = scoreswrappers.scores_rmse(cubes)


### PR DESCRIPTION
expanding on PR #2229 to include ensemble capability for vertical profiles of RMSE.
For the calculation the ensemble mean of the variable is calculated first for all ensembles and then the scores package is used to 

- [x] calculate an RMSE for each timepoint in a case study as a sequence 
- [x] calculate the total RMSE profile for each case study.

As the CRPS is more useful for analysing ensembles we only use the RMSE based on the ensemble mean here at the moment,.

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [x] Documentation has been updated to reflect change.
- [x] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [x] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.


#2230  needs to go on trunk first.
