### PR TITLE
Skip null facet values in CSET website to avoid crash

### DIFF
--- a/src/CSET/cset_workflow/app/finish_website/file/html/script.js
+++ b/src/CSET/cset_workflow/app/finish_website/file/html/script.js
@@ -614,7 +614,12 @@ function setup_plots_sidebar() {
             // Normalise values to strings.
             for (const facet in record) {
               if (typeof record[facet] != "string") {
-                record[facet] = record[facet].toString();
+                try {
+                  record[facet] = record[facet].toString();
+                } catch {
+                  console.log("Facet value could not be cast to string.");
+                  delete record[facet];
+                }
               }
             }
             diagnostic_records.push(record);


### PR DESCRIPTION
These couldn't be cast to strings, and were therefore crashing the website when it tried to get their display value.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
