### PR TITLE
Use login bash shell instead of micromamba-shell to ensure tests fail the GitHub Actions checks

### DIFF
--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -15,6 +15,11 @@ concurrency:
 # Minimise default GITHUB_TOKEN permissions.
 permissions: {}
 
+defaults:
+  run:
+    # Use a login shell to pickup conda/micromamba initialisation.
+    shell: bash -leo pipefail {0}
+
 jobs:
   tests:
     runs-on: ubuntu-latest
@@ -37,7 +42,6 @@ jobs:
           environment-name: cset-dev
           environment-file: requirements/locks/${{ matrix.py-ver }}-lock-linux-64.txt
           cache-environment: true
-          init-shell: "none"
 
       - name: Cache downloaded cartopy shapefiles
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
@@ -46,11 +50,9 @@ jobs:
           path: ~/.local/share/cartopy
 
       - name: Install local package
-        shell: micromamba-shell {0}
         run: pip install --no-deps .
 
       - name: Run fast tests
-        shell: micromamba-shell {0}
         env:
           PY_COLORS: "1"
           py_ver: ${{ matrix.py-ver }}
@@ -92,7 +94,6 @@ jobs:
           path: ~/.local/share/cartopy
 
       - name: Install local package
-        shell: micromamba-shell {0}
         run: pip install --no-deps .
 
       - name: Setup rose and cylc
@@ -101,7 +102,6 @@ jobs:
           cylc_rose: true
 
       - name: Run workflow tests
-        shell: micromamba-shell {0}
         env:
           PY_COLORS: "1"
         run: make test-workflow
@@ -227,14 +227,11 @@ jobs:
           environment-name: cset-dev
           environment-file: requirements/locks/latest
           cache-environment: true
-          init-shell: "none"
 
       - name: Install local package
-        shell: micromamba-shell {0}
         run: pip install --no-deps .
 
       - name: Build documentation with Sphinx
-        shell: micromamba-shell {0}
         run: make docs
 
       - name: Upload documentation artifact

--- a/.github/workflows/weekly-checks.yml
+++ b/.github/workflows/weekly-checks.yml
@@ -8,6 +8,11 @@ on:
 # Minimise default GITHUB_TOKEN permissions.
 permissions: {}
 
+defaults:
+  run:
+    # Use a login shell to pickup conda/micromamba initialisation.
+    shell: bash -leo pipefail {0}
+
 jobs:
   check-documentation-hyperlinks:
     if: "github.repository == 'MetOffice/CSET'"  # Skip on forks.
@@ -29,18 +34,14 @@ jobs:
           environment-name: cset-dev
           environment-file: requirements/locks/latest
           cache-environment: true
-          init-shell: "none"
 
       - name: Install local package
-        shell: micromamba-shell {0}
         run: pip install --no-deps .
 
       - name: Build documentation with Sphinx
-        shell: micromamba-shell {0}
         run: sphinx-build -b html --color "docs/source" "docs/build/html"
 
       - name: Check for broken hyperlinks
-        shell: micromamba-shell {0}
         run: sphinx-build -b linkcheck --color -W --keep-going "docs/source" "docs/build/linkcheck"
 
   full-tests:
@@ -65,7 +66,6 @@ jobs:
           environment-name: cset-dev
           environment-file: requirements/locks/${{ matrix.py-ver }}-lock-linux-64.txt
           cache-environment: true
-          init-shell: "none"
 
       - name: Cache downloaded cartopy shapefiles
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
@@ -74,11 +74,9 @@ jobs:
           path: ~/.local/share/cartopy
 
       - name: Install local package
-        shell: micromamba-shell {0}
         run: pip install --no-deps .
 
       - name: Run full test suite
-        shell: micromamba-shell {0}
         env:
           PY_COLORS: "1"
         run: make test-full


### PR DESCRIPTION
This allows us to have fail-on-error behaviour which is essential for catching failing Action runs. Due to the way micromamba-shell works, it doesn't set any shell options and the shell default of ignoring errors is used.

This has been tested to correctly fail the checks in https://github.com/MetOffice/CSET/pull/2280.

Fixes #2281

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [x] New code has tests, and affected old tests have been updated.
- [ ] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
