### PR TITLE
Add support for CubeLists in subtraction and common_points operators

### DIFF
--- a/src/CSET/operators/misc.py
+++ b/src/CSET/operators/misc.py
@@ -17,6 +17,7 @@
 import itertools
 import logging
 from collections.abc import Iterable
+from functools import reduce
 
 import iris
 import iris.analysis.calculus
@@ -154,19 +155,21 @@ def addition(addend_1, addend_2):
     return addend_1 + addend_2
 
 
-def subtraction(minuend, subtrahend):
+def subtraction(
+    minuend: Cube | CubeList, subtrahend: Cube | CubeList
+) -> Cube | CubeList:
     """Subtraction of two fields.
 
     Parameters
     ----------
-    minuend: Cube
-        Any field to have another field subtracted from it.
-    subtrahend: Cube
-        Any field to be subtracted from to another field.
+    minuend: Cube | CubeList
+        Any field(s) to have another field subtracted from it.
+    subtrahend: Cube | CubeList
+        Any field(s) to be subtracted from to another field.
 
     Returns
     -------
-    Cube
+    Cube | CubeList
 
     Raises
     ------
@@ -180,12 +183,45 @@ def subtraction(minuend, subtrahend):
     differences to allow for comparisons between the same field in different
     models or model configurations.
 
+    If called with 2 Cubes as input, will return a difference cube.
+    If called with 2 CubeLists as input, with return a CubeList of differences.
+    If called with CubeList as minuend and Cube as subtrahend, will return CubeList of differences subtracting Cube from each element of input CubeList.
+
     Examples
     --------
     >>> model_diff = misc.subtraction(temperature_model_A, temperature_model_B)
 
     """
-    return minuend - subtrahend
+
+    def subtract_preserve_attributes(a, b):
+        result = a - b
+        result.attributes.update(a.attributes)
+        return result
+
+    # Case where both inputs are single cubes
+    if isinstance(minuend, iris.cube.Cube) and isinstance(subtrahend, iris.cube.Cube):
+        return subtract_preserve_attributes(minuend, subtrahend)
+
+    # Check if minuend is iterable
+    cubes_a = iter_maybe(minuend)
+
+    # Case: subtrahend also iterable
+    if isinstance(subtrahend, iris.cube.CubeList):
+        cubes_b = iter_maybe(subtrahend)
+        result = iris.cube.CubeList(
+            [
+                subtract_preserve_attributes(a, b)
+                for a, b in zip(cubes_a, cubes_b, strict=True)
+            ]
+        )
+    else:
+        # Case: subtract single cube from each minuend
+        result = iris.cube.CubeList(
+            [subtract_preserve_attributes(a, subtrahend) for a in cubes_a]
+        )
+
+    # Return single cube if only one result, else return CubeList
+    return result[0] if len(result) == 1 else result
 
 
 def division(numerator, denominator):
@@ -457,7 +493,11 @@ def _extract_common_time_points(base: Cube, other: Cube) -> tuple[Cube, Cube]:
         shared_times = set.intersection(set(base_times), set(other_times))
     logging.debug("Shared times: %s", shared_times)
     time_constraint = iris.Constraint(
-        coord_values={time_coord: lambda cell: cell.point in shared_times}
+        coord_values={
+            time_coord: lambda cell, shared_times=shared_times: (
+                cell.point in shared_times
+            )
+        }
     )
     # Extract points matching the shared times.
     base = base.extract(time_constraint)
@@ -573,49 +613,47 @@ def _slice_cube_on_levels(cube: iris.cube.Cube, coord_name: str, levels: list):
 
 def extract_common_points(cubes: iris.cube.CubeList, coordinate: str):
     """
-    Extract common points for a given coordinate between two cubes.
+    Extract common points for a given coordinate between cubes in a CubeList.
 
     Parameters
     ----------
     cubes: iris.cube.CubeList
-        CubeList containing exactly two cubes.
+        CubeList containing cubes for which to extract common points.
 
     coordinate: str
-        The coordinate name to be checked for common levels.
+        The coordinate name to be checked for common points.
 
     Returns
     -------
     iris.cube.CubeList
-        CubeList containing the two cubes sliced to common levels
+        CubeList containing the two cubes sliced to common points
         for the given coordinate.
     """
     # Check type of input
     if type(cubes) is not iris.cube.CubeList:
         raise TypeError(f"Not a CubeList, got type {type(cubes)}")
 
-    # Check that only two cubes are passed into function.
-    if len(cubes) != 2:
-        raise ValueError(f"Maximum of two cubes allowed, received {len(cubes)}")
-
     # Extract coordinate
     try:
-        p1 = cubes[0].coord(coordinate)
-        p2 = cubes[1].coord(coordinate)
+        points_list = []
+        for cube in cubes:
+            points_list.append(cube.coord(coordinate).points)
     except iris.exceptions.CoordinateNotFoundError as err:
         raise ValueError(f"Both cubes must have an {coordinate} coordinate") from err
 
     # Find common points
-    common_points = np.intersect1d(p1.points, p2.points)
+    common_points = reduce(np.intersect1d, points_list)
 
     # Check that common points is more than zero.
     if common_points.size == 0:
         raise ValueError("No common levels found")
 
     # Extract common points
-    cube0_common = _slice_cube_on_levels(cubes[0], coordinate, common_points)
-    cube1_common = _slice_cube_on_levels(cubes[1], coordinate, common_points)
+    common_cubes = iris.cube.CubeList()
+    for cube in cubes:
+        common_cubes.append(_slice_cube_on_levels(cube, coordinate, common_points))
 
-    return iris.cube.CubeList([cube0_common, cube1_common])
+    return common_cubes
 
 
 def differentiate(

--- a/src/CSET/operators/misc.py
+++ b/src/CSET/operators/misc.py
@@ -186,6 +186,7 @@ def subtraction(
     If called with 2 Cubes as input, will return a difference cube.
     If called with 2 CubeLists as input, with return a CubeList of differences.
     If called with CubeList as minuend and Cube as subtrahend, will return CubeList of differences subtracting Cube from each element of input CubeList.
+    If called with Cube as minuend and CubeList as subtrahend, will return CubeList of differences subtracting each element on CubeList from input Cube.
 
     Examples
     --------
@@ -193,9 +194,9 @@ def subtraction(
 
     """
 
-    def subtract_preserve_attributes(a, b):
-        result = a - b
-        result.attributes.update(a.attributes)
+    def subtract_preserve_attributes(cube_a: Cube, cube_b: Cube) -> Cube:
+        result = cube_a - cube_b
+        result.attributes.update(cube_a.attributes)
         return result
 
     # Case where both inputs are single cubes
@@ -208,16 +209,23 @@ def subtraction(
     # Case: subtrahend also iterable
     if isinstance(subtrahend, iris.cube.CubeList):
         cubes_b = iter_maybe(subtrahend)
-        result = iris.cube.CubeList(
-            [
-                subtract_preserve_attributes(a, b)
-                for a, b in zip(cubes_a, cubes_b, strict=True)
-            ]
-        )
+        if isinstance(minuend, iris.cube.CubeList):
+            # Case: subtract cubelist from cubelist - assume both same sizes
+            result = iris.cube.CubeList(
+                [
+                    subtract_preserve_attributes(cube_a, cube_b)
+                    for cube_a, cube_b in zip(cubes_a, cubes_b, strict=True)
+                ]
+            )
+        else:
+            # Case: subtract each element of subtrahend from single cube
+            result = iris.cube.CubeList(
+                [subtract_preserve_attributes(minuend, cube_b) for cube_b in cubes_b]
+            )
     else:
         # Case: subtract single cube from each minuend
         result = iris.cube.CubeList(
-            [subtract_preserve_attributes(a, subtrahend) for a in cubes_a]
+            [subtract_preserve_attributes(cube_a, subtrahend) for cube_a in cubes_a]
         )
 
     # Return single cube if only one result, else return CubeList

--- a/tests/operators/test_misc.py
+++ b/tests/operators/test_misc.py
@@ -78,6 +78,32 @@ def test_subtraction_failure(cube):
         misc.subtraction(cube, a)
 
 
+def test_subtraction_cubelist(cube):
+    """Subtracts one cubelist from another."""
+    a = iris.cube.CubeList([cube, cube])
+    b = misc.subtraction(a, a)
+    assert isinstance(b, iris.cube.CubeList)
+    assert np.allclose(b[0].data, 0.0, atol=1e-5, equal_nan=True)
+    assert np.allclose(b[1].data, 0.0, atol=1e-5, equal_nan=True)
+
+
+def test_subtraction_cubelist_cube(cube):
+    """Subtracts a cube from a cubelist."""
+    a = iris.cube.CubeList([cube, cube])
+    b = misc.subtraction(a, cube)
+    assert isinstance(b, iris.cube.CubeList)
+    assert np.allclose(b[0].data, 0.0, atol=1e-5, equal_nan=True)
+    assert np.allclose(b[1].data, 0.0, atol=1e-5, equal_nan=True)
+
+
+def test_subtraction_single_cubelist_cube(cube):
+    """Subtracts a cube from a cubelist with single entry."""
+    a = iris.cube.CubeList([cube])
+    b = misc.subtraction(a, cube)
+    assert isinstance(b, iris.cube.Cube)
+    assert np.allclose(b.data, 0.0, atol=1e-5, equal_nan=True)
+
+
 def test_division(cube):
     """Divides one object by another."""
     a = cube / cube
@@ -472,17 +498,6 @@ def test_slice_cube_on_common_levels(vertical_profile_cube):
     assert np.allclose(
         output.coord("pressure").points, [700, 950], rtol=1e-6, atol=1e-2
     )
-
-
-def test_extract_common_points_toomanycubes(vertical_profile_cube):
-    """Test handling of too many cubes."""
-    with pytest.raises(ValueError, match="Maximum of two cubes allowed, received 3"):
-        misc.extract_common_points(
-            cubes=iris.cube.CubeList(
-                [vertical_profile_cube, vertical_profile_cube, vertical_profile_cube]
-            ),
-            coordinate="pressure",
-        )
 
 
 def test_extract_common_points_cubelist(vertical_profile_cube):

--- a/tests/operators/test_misc.py
+++ b/tests/operators/test_misc.py
@@ -104,6 +104,15 @@ def test_subtraction_single_cubelist_cube(cube):
     assert np.allclose(b.data, 0.0, atol=1e-5, equal_nan=True)
 
 
+def test_subtraction_cubelist_from_cube(cube):
+    """Subtracts a cubelist from a cube."""
+    a = iris.cube.CubeList([cube, cube])
+    b = misc.subtraction(cube, a)
+    assert isinstance(b, iris.cube.CubeList)
+    assert np.allclose(b[0].data, 0.0, atol=1e-5, equal_nan=True)
+    assert np.allclose(b[1].data, 0.0, atol=1e-5, equal_nan=True)
+
+
 def test_division(cube):
     """Divides one object by another."""
     a = cube / cube


### PR DESCRIPTION
<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

Fixes required scope of #2283 for supporting observation and multiple model input use-case.

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [X] Documentation has been updated to reflect change.
- [X] New code has tests, and affected old tests have been updated.
- [X] All tests and CI checks pass.
- [X] Ensured the pull request title is descriptive.
- [X] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [X] Marked the PR as ready to review.

MS CoPilot used for guidance on some unit test design.

Marking as ready for review.