### PR TITLE
Exclude public opt and site files from gitignore to avoid warning from Git

### DIFF
--- a/src/CSET/cset_workflow/.gitignore
+++ b/src/CSET/cset_workflow/.gitignore
@@ -5,6 +5,14 @@
 *metdb*
 restricted*
 
+# Public site and opt files.
+!/opt/rose-suite-RAL3LFRIC.conf
+!/opt/rose-suite-nci_ral3lfric.conf
+!/opt/rose-suite-test_validate.conf
+!/site/localhost.cylc
+!/site/monsoon.cylc
+!/site/nci-gadi.cylc
+
 # User workflow configuration.
 /*rose-suite*
 !/rose-suite.conf.example


### PR DESCRIPTION
This stops git warning when they are added and means they show up nicely as changed files in git status/diff.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
