### PR TITLE
New colormaps test to cover Nimrod wts case

### DIFF
--- a/tests/operators/test_colormaps.py
+++ b/tests/operators/test_colormaps.py
@@ -399,6 +399,34 @@ def test_colorbar_map_probabilities(cube, tmp_working_dir):
     assert (norm.boundaries == levels).all()
 
 
+def test_colorbar_map_nimrod_wts(cube):
+    """Set colorbar for nimrod weights variable."""
+    cube.rename("Hourly wts accumulation")
+    expected_levels = np.arange(-0.5, 14.5, 1.0)
+    expected_colors = [
+        "#d10000",
+        "purple",
+        "#8f00d6",
+        "#ff9700",
+        "pink",
+        "#ffff00",
+        "#00007f",
+        "#6c9ccd",
+        "#aae8ff",
+        "#37a648",
+        "#8edc64",
+        "#c5ffc5",
+        "#dcdcdc",
+        "#ffffff",
+    ]
+    expected_cmap = mpl.colors.ListedColormap(expected_colors)
+    cmap, levels, norm = _colormaps.colorbar_map_levels(cube)
+    assert cmap == expected_cmap
+    assert (levels == expected_levels).all()
+    assert isinstance(norm, mpl.colors.BoundaryNorm)
+    assert (norm.boundaries == levels).all()
+
+
 def test_colorbar_map_aviation_colour_state(cube, tmp_working_dir):
     """Test to ensure color bar is change for aviation colour states."""
     cube.rename("aviation_colour_state")


### PR DESCRIPTION
<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

Improves test coverage of ``src/CSET/operators/_colormaps.py``

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [X] New code has tests, and affected old tests have been updated.
- [X] All tests and CI checks pass.
- [X] Ensured the pull request title is descriptive.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [X] Marked the PR as ready to review.

Additional test added to ``test_colormaps.py`` to increase test coverage for new functionality and use-case.
