### PR TITLE
Test that `meta.json` is not leaked from any tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,8 @@ dmypy.json
 
 # MacOS temp files
 .DS_Store
+
+# Plot files written by CSET that can sometimes leak from the tests.
+/meta.json
+/*.html
+/*.png

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,15 @@ import pytest
 from CSET.operators import constraints, filters, read
 
 
+# Special function that is run after all the tests finish.
+def pytest_sessionfinish(session, exitstatus):
+    """Check we didn't leak any plotting files during testing."""
+    assert not (Path.cwd() / "meta.json").exists(), (
+        "meta.json in top level directory. This usually indicates a test "
+        "is not using the `tmp_working_dir` fixture when it should."
+    )
+
+
 @pytest.fixture
 def cdl_to_nc_path(tmp_path) -> Callable[[str], Path]:
     """Get a callback that will create a temporary NetCDF file based on a CDL definition."""

--- a/tests/operators/test_colormaps.py
+++ b/tests/operators/test_colormaps.py
@@ -74,7 +74,7 @@ def test_load_colorbar_map_override_file_not_found(tmp_path):
     assert isinstance(colorbar, dict)
 
 
-def test_get_model_colors_map(cube):
+def test_get_model_colors_map(cube, tmp_working_dir):
     """Generate model_colors_map if model name provided."""
     cube.attributes["model_name"] = "model_1"
     model_colors_map = _colormaps.get_model_colors_map(cube)
@@ -83,7 +83,7 @@ def test_get_model_colors_map(cube):
     }
 
 
-def test_get_model_colors_map_noname(cube):
+def test_get_model_colors_map_noname(cube, tmp_working_dir):
     """Empty model_colors_map if no model name provided."""
     model_colors_map = _colormaps.get_model_colors_map(cube)
     assert model_colors_map == {}
@@ -398,7 +398,7 @@ def test_colorbar_map_probabilities(cube, tmp_working_dir):
     assert (norm.boundaries == levels).all()
 
 
-def test_colorbar_map_nimrod_wts(cube):
+def test_colorbar_map_nimrod_wts(cube, tmp_working_dir):
     """Set colorbar for nimrod weights variable."""
     cube.rename("Hourly wts accumulation")
     expected_levels = np.arange(-0.5, 14.5, 1.0)
@@ -456,7 +456,7 @@ def test_colorbar_map_scores_rmse(cube, tmp_working_dir):
     assert norm is None
 
 
-def test_colorbar_map_auto(cube):
+def test_colorbar_map_auto(cube, tmp_working_dir):
     """Set colorbar for variables with auto scaling set."""
     cube.rename("surface_altitude")
     cmap, levels, norm = _colormaps.colorbar_map_levels(cube)


### PR DESCRIPTION
<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

This should prevent issues like #2293 recurring.

This PR implements the check at the end of the testing session. This makes it nice and fast, but it does not tell you which test was the problematic one. I also had an alternative method that runs after each test to check, and that points out problematic tests specifically.

I've erred on the side of going for the faster solution, as hopefully future failures will be nicely scoped to just newly added tests.

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [x] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
