### PR TITLE
Remove "Technical" from References title to make it clear it contains all kinds of reference material

### DIFF
--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -1,5 +1,5 @@
-Technical Reference
-===================
+Reference
+=========
 
 This section contains comprehensive descriptions of CSET, and its various
 components.


### PR DESCRIPTION
These references cover a wide range of topics, not just technical details. This change is only visual and URLs are not affected. (URLs were already just "reference" anyway.)

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [x] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
