### PR TITLE
Fix CRPS citation in scoreswrappers.py

### DIFF
--- a/src/CSET/operators/scoreswrappers.py
+++ b/src/CSET/operators/scoreswrappers.py
@@ -558,7 +558,7 @@ def scores_crps_for_ensemble(
     Default method is ecdf.  ecdf is exact value from the empirical distributions,
     whereas fair produces an approximated value based on a random sample of the underlying distribution.
 
-    See [CRPS] for further information.
+    See [CRPS]_ for further information.
 
     Parameters
     ----------
@@ -588,7 +588,7 @@ def scores_crps_for_ensemble(
     .. [CRPS]
         Hersbach, H., 2000: Decomposition of the Continuous Ranked
         Probability Score for Ensemble Prediction Systems. Wea.
-        Forecasting, 15, 559–570, https://doi.org/10.1175/1520-0434(2000)015<0559:DOTCRP>2.0.CO;2.
+        Forecasting, 15, 559–570, https://doi.org/10.1175/1520-0434(2000)015%3C0559:DOTCRP%3E2.0.CO;2
     """
     if control_member != 0:
         logging.warning("control member is usual 0")


### PR DESCRIPTION
The citation wasn't referenced due to a syntax error. Also the special characters in the DOI caused it to not link properly, so the DOI has been URL encoded.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [x] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
