### PR TITLE
Move references into central bibliography to avoid duplicate reference warning

### DIFF
--- a/docs/source/reference/bibliography.rst
+++ b/docs/source/reference/bibliography.rst
@@ -1,0 +1,140 @@
+Bibliography
+============
+
+.. [scoresa] Leeuwenburg, T., Loveday, N., Ebert, E. E., Cook, H.,
+    Khanarmuei, M., Taggart, R. J., Ramanathan, N., Carroll, M., Chong, S.,
+    Griffiths, A., & Sharples, J. (2024) "scores: A Python package for
+    verifying and evaluating models and predictions with xarray". Journal
+    of Open Source Software, vol. 9, 6889. doi: 10.21105/joss.06889
+
+.. [scoresb] Leeuwenburg, T., Loveday, N., Ramanathan, N., Chong, S.,
+    Taggart, R. J., Shrestha, D., Khanarmuei, M., Cook, H., Bluett, L., Ebert,
+    E. E., Carroll, M., Trotta, B., Bishop, S., Squire, D. T., Griffiths, A.,
+    Pagano, T. C., Fisher, A. J., Mandelbaum, T., Jinghan, F., … Smallwood, J.
+    (2026) "scores: Metrics for the verification, evaluation and optimisation of
+    forecasts, predictions or models (2.5.0)". Zenodo. doi: 10.5281/zenodo.18638494
+
+.. [CRPS] Hersbach, H., 2000: Decomposition of the Continuous Ranked
+    Probability Score for Ensemble Prediction Systems. Wea.
+    Forecasting, 15, 559–570, https://doi.org/10.1175/1520-0434(2000)015<0559:DOTCRP>2.0.CO;2.
+
+.. [Daviesetal24] Davies, P.A., Fowler, H.J, Villalobos-Herrera, R.,
+    Slingo, J., Flack, D.L.A., and Taszarek, M (2024)
+    "A New Conceptual Model for Understanding and Predicting Life-Threatening
+    Rainfall Extremes." Weather and Climate Extremes, vol. 45, 100696,
+    doi: 10.1016/j.wace.2024.100696
+
+.. [Daviesetal26] Davies, P. A., Flack, D. L. A., Pirret, J., Fowler, H. J.
+    (2026) "Application of the Davies Four-Stage Conceptual Model for
+    Life-Threatening Rainfall Extremes on the April 2024 United Arab Emirates
+    and Oman Floods." Weather and Climate Extremes, vol. 51, 100846.
+    doi:10.1016/j.wace.2025.100846
+
+.. [Bolton80] Bolton. D. (1980) "The computation of equivalent potential
+    temperature". Monthly Weather Review, vol. 108, 1046-1053,
+    doi: 10.1175/1520-0493(1980)108<1046:TCOEPT>2.0.CO;2
+
+.. [Flack24] Flack, D.L.A. (2024) "Stratification of the vertical spread-skill
+    relation by radiosonde drift in a convective-scale ensemble."
+    Atmospheric Science Letters, vol. 25, e1194, doi: 10.1002/asl.1194
+
+.. [Stull11] Stull, R. (2011) "Wet-Bulb Temperature from Relative Humidity
+    and air temperature." Journal of Applied Meteorology and Climatology, vol. 50,
+    2267-2269, doi: 10.1175/JAMC-D-11-0143.1
+
+.. [Paluch79] Paluch, I.R., (1979) "The entrainment mechanism in Colorado
+    Cumuli" Journal of the Atmospheric Sciences, vol. 36, 2467-2478,
+    doi: 10.1175/1520-0469(1979)036<2467:TEMICC>2.0.CO;2
+
+.. [Emanuel94] Emanuel, K.A. (1994) "Atmospheric Convection" Oxford University
+    Press, 580 pp.
+
+.. [DaviesJones08] Davies-Jones, R. (2008) "An Efficient and Accurate
+    Method for Computing the Wet-Bulb Temperature along Pseudoadiabats"
+    Monthly Weather Review, vol. 136, 2764-2785, doi: 10.1175/2007MWR2224.1
+
+.. [Stull2000] Stull, R.B., (2000) "Meteorology for Scientists and Engineers",
+    2nd Edition, Brooks/Cole, California, USA, 502 pp.
+
+.. [Raymondetal2009] Raymond, D.J., Sessions, S.L., Sobel, A.H., Fuchs, Z.
+    (2009) "The Mechanics of Gross Moist Stability" Journal of Advances in
+    Modelling Earth Systems, vol. 1, 20 pp. doi: 10.3894/JAMES.2009.1.9
+
+.. [Raymondetal09] Raymond, D.J., Sessions, S.L., Sobel, A.H., Fuchs, Z.
+    (2009) "The Mechanics of Gross Moist Stability" Journal of Advances in
+    Modelling Earth Systems, vol. 1, 20 pp. doi: 10.3894/JAMES.2009.1.9
+
+.. [Zengetal05] Zeng, X., Tao, W-K, and Simpson, J. (2005) "An Equation for Moist
+    Entropy in a Precipitating and Icy Atmosphere" Journal of the Atmospheric Sciences,
+    vol. 2, 4293-4309, doi: 10.1175/JAS3570.1
+
+.. [Clarketal2012] Clark, A. J., Kain J. S., Marsh P. T., Correia J., Xue
+    M., and Kong F., (2012) "Forecasting tornado pathlengths using a
+    three-dimensional object identification algorithm applied to
+    convection-allowing forecasts." Weather and Forecasting, vol. 27,
+    1090-1113, doi: 10.1175/WAF-D-11-00147.1
+
+.. [FlackCAPE2023] Flack, D.L.A., Lehnert, M., Lean, H.W., and Willington,
+    S. (2023) "Characteristics of Diagnostics for Identifying Elevated
+    Convection over the British Isles in a Convection-Allowing Model."
+    Weather and Forecasting, vol. 30, 1079-1094, doi: 10.1175/WAF-D-22-0219.1
+
+.. [Thompsonetal2007] Thompson, R. L. Mead, C. M., and Edwards, R., (2007)
+    "Effective Storm-Relative Helicity and Bulk Shear in Supercell
+    Thunderstorm Environments." Weather and Forecasting, vol. 22, 102-115,
+    doi: 10.1175/WAF969.1
+
+.. [Flackinf2023] Flack, D.L.A., Lehnert, M., Lean, H.W., and Willington, S.
+    (2023) "Characteristics of Diagnostics for Identifying Elevated
+    Convection over the British Isles in a Convection-Allowing Model."
+    Weather and Forecasting, vol. 30, 1079-1094, doi: 10.1175/WAF-D-22-0219.1
+
+.. [Warneretal2023] Warner, J.L., Petch, J., Short, C., Bain, C., 2023.
+    Assessing the impact of an NWP warm-start system on model spin-up over
+    tropical Africa. QJ, 149(751), pp.621-636. doi:10.1002/qj.4429
+
+.. [Warneretal2024] Diagnosing lateral boundary spin-up in regional models
+    using an age of air diagnostic. James L. Warner, Charmaine N. Franklin,
+    Belinda Roux, Shaun Cooper, Susan Rennie, Vinod Kumar. Submitted for
+    Quarterly Journal of the Royal Meteorological Society.
+
+.. [Flacketal2016] Flack, D.L.A., Plant, R.S., Gray, S.L., Lean, H.W.,
+    Keil, C. and Craig, G.C. (2016) "Characterisation of Convective
+    Regimes over the British Isles." Quarterly Journal of the Royal
+    Meteorological Society, vol. 142, 1541-1553. doi:10.1002/qj.2758
+
+.. [Wangetal2004] Wang, Z., Bovik, A.C., Sheikh, H.R., Simoncelli, E.P. (2004)
+    "Image Quality Assessment: From Error Visibility to Structural Similarity."
+    IEEE Transactions on Image Processing, vol. 13, 600-612,
+    doi: 10.1109/TIP.2003.819861
+
+.. [Wangetal2004a] Wang, Z., Bovik, A.C., Sheikh, H.R., Simoncelli, E.P. (2004)
+    "Image Quality Assessment: From Error Visibility to Structural Similarity."
+    IEEE Transactions on Image Processing, vol. 13, 600-612,
+    doi: 10.1109/TIP.2003.819861
+
+.. [Denis_etal_2002] Bertrand Denis, Jean Cote and Rene Laprise (2002)
+    "Spectral Decomposition of Two-Dimensional Atmospheric Fields on
+    Limited-Area Domains Using the Discrete Cosine Transform (DCT)"
+    Monthly Weather Review, vol. 130, 1812-1828,
+    doi: 10.1175/1520-0493(2002)130<1812:SDOTDA>2.0.CO;2
+
+.. [Wilks2011] Wilks, D.S., (2011) "Statistical Methods in the Atmospheric
+    Sciences" Third Edition, vol. 100, Academic Press, Oxford, UK, 676 pp.
+
+.. [Buck81] Buck, A.L. (1981) "New Equations for Computing Vapor Pressure
+    and Enhancement Factor". J. App. Meteor. Clim. 20: 1527-1532.
+
+.. [Holton13] Holton, J.R. and Hakim G.J. (2013) "An Introduction to Dynamic
+    Meteorology." 5th Edition, Burlington, MA, Elsevier Academic Press, 532 pp.
+
+.. [Beer96] Beer, T. (1996) Environmental Oceanography, CRC Marince Science,
+    vol. 11, 2nd Edition, CRC Press, 402 pp.
+
+.. [Berryetal45] Berry, F. A., Jr., E. Bollay, and N. R. Beers, (1945)
+    Handbook of Meteorology. McGraw Hill, 1068 pp.
+
+.. [Zhangetal2002] Zhang, F., Snyder, C., and Rotunno, R., (2002)
+    "Mesoscale Predictability of the 'Surprise' Snowstorm of 24-25 January
+    2000." Monthly Weather Review, vol. 130, 1617-1632,
+    doi: 10.1175/1520-0493(2002)130<1617:MPOTSS>2.0.CO;2

--- a/docs/source/reference/bibliography.rst
+++ b/docs/source/reference/bibliography.rst
@@ -12,11 +12,13 @@ Bibliography
     E. E., Carroll, M., Trotta, B., Bishop, S., Squire, D. T., Griffiths, A.,
     Pagano, T. C., Fisher, A. J., Mandelbaum, T., Jinghan, F., … Smallwood, J.
     (2026) "scores: Metrics for the verification, evaluation and optimisation of
-    forecasts, predictions or models (2.5.0)". Zenodo. doi: 10.5281/zenodo.18638494
+    forecasts, predictions or models (2.5.0)". Zenodo,
+    doi: 10.5281/zenodo.18638494
 
 .. [CRPS] Hersbach, H., 2000: Decomposition of the Continuous Ranked
     Probability Score for Ensemble Prediction Systems. Wea.
-    Forecasting, 15, 559–570, https://doi.org/10.1175/1520-0434(2000)015<0559:DOTCRP>2.0.CO;2.
+    Forecasting, 15, 559-570,
+    doi: 10.1175/1520-0434(2000)015<0559:DOTCRP>2.0.CO;2
 
 .. [Daviesetal24] Davies, P.A., Fowler, H.J, Villalobos-Herrera, R.,
     Slingo, J., Flack, D.L.A., and Taszarek, M (2024)

--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -14,3 +14,4 @@ components.
     operators
     workflow/index
     internal
+    bibliography

--- a/src/CSET/operators/ageofair.py
+++ b/src/CSET/operators/ageofair.py
@@ -282,15 +282,6 @@ def compute_ageofair(
     the impact of new data assimilation techniques. A further paper is currently in review ([Warneretal2024]_)
     which applies the diagnostic more widely to the Australian ACCESS convection-permitting models.
 
-    References
-    ----------
-    .. [Warneretal2023] Warner, J.L., Petch, J., Short, C., Bain, C., 2023. Assessing the impact of an NWP warm-start
-        system on model spin-up over tropical Africa. QJ, 149( 751), pp.621-636. doi:10.1002/qj.4429
-    .. [Warneretal2024] Diagnosing lateral boundary spin-up in regional models using an age of air diagnostic
-        James L. Warner, Charmaine N. Franklin, Belinda Roux, Shaun Cooper, Susan Rennie, Vinod
-        Kumar.
-        Submitted for Quarterly Journal of the Royal Meteorological Society.
-
     """
     # Set up temporary directory to store intermediate age of air slices.
     tmpdir = tempfile.TemporaryDirectory(dir=os.getenv("CYLC_TASK_WORK_DIR"))

--- a/src/CSET/operators/convection.py
+++ b/src/CSET/operators/convection.py
@@ -87,18 +87,6 @@ def cape_ratio(SBCAPE, MUCAPE, MUCIN, MUCIN_thresh=-75.0):
     has occurred, not before as is the usual interpretation of CAPE related
     diagnostics.
 
-    References
-    ----------
-    .. [Clarketal2012] Clark, A. J., Kain J. S., Marsh P. T., Correia J., Xue
-       M., and Kong F., (2012) "Forecasting tornado pathlengths using a
-       three-dimensional object identification algorithm applied to
-       convection-allowing forecasts." Weather and Forecasting, vol. 27,
-       1090–1113, doi: 10.1175/WAF-D-11-00147.1
-    .. [FlackCAPE2023] Flack, D.L.A., Lehnert, M., Lean, H.W., and Willington,
-       S. (2023) "Characteristics of Diagnostics for Identifying Elevated
-       Convection over the British Isles in a Convection-Allowing Model."
-       Weather and Forecasting, vol. 30, 1079-1094, doi: 10.1175/WAF-D-22-0219.1
-
     Examples
     --------
     >>> CAPE_ratios=convection.cape_ratio(
@@ -203,17 +191,6 @@ def inflow_layer_properties(EIB, BLheight, Orography):
     and ensemble member.`` these warnings are expected when the orography files
     are not 2-dimensional, and do not cause any problems unless ordering is not
     as expected.
-
-    References
-    ----------
-    .. [Thompsonetal2007] Thompson, R. L. Mead, C. M., and Edwards, R., (2007)
-       "Effective Storm-Relative Helicity and Bulk Shear in Supercell
-       Thunderstorm Environments." Weather and Forecasting, vol. 22, 102-115,
-       doi: 10.1175/WAF969.1
-    .. [Flackinf2023] Flack, D.L.A., Lehnert, M., Lean, H.W., and Willington, S.
-       (2023) "Characteristics of Diagnostics for Identifying Elevated
-       Convection over the British Isles in a Convection-Allowing Model."
-       Weather and Forecasting, vol. 30, 1079-1094, doi: 10.1175/WAF-D-22-0219.1
 
     Examples
     --------

--- a/src/CSET/operators/ensembles.py
+++ b/src/CSET/operators/ensembles.py
@@ -69,13 +69,6 @@ def DKE(u: iris.cube.Cube, v: iris.cube.Cube) -> iris.cube.Cube:
     presence of upscale error growth or the dominant scales of error growth. It
     is often plotted on a logarithmic scale.
 
-    References
-    ----------
-    .. [Zhangetal2002] Zhang, F., Snyder, C., and Rotunno, R., (2002)
-       "Mesoscale Predictability of the 'Surprise' Snowstorm of 24-25 January
-       2000." Monthly Weather Review, vol. 130, 1617-1632,
-       doi: 10.1175/1520-0493(2002)130<1617:MPOTSS>2.0.CO;2
-
     Examples
     --------
     >>> DKE = ensembles.DKE(u, v)

--- a/src/CSET/operators/humidity.py
+++ b/src/CSET/operators/humidity.py
@@ -491,21 +491,6 @@ def precipitable_water(
     Examples
     --------
     >>> pwat = humidity.precipitable_water(mixing_ratio)
-
-    References
-    ----------
-    .. [Daviesetal24] Davies, P.A., Fowler, H.J, Villalobos-Herrera, R.,
-       Slingo, J., Flack, D.L.A., and Taszarek, M (2024)
-       "A New Conceptual Model for Understanding and Predicting Life-Threatening
-       Rainfall Extremes." Weather and Climate Extremes, vol. 45, 100696,
-       doi: 10.1016/j.wace.2024.100696
-    .. [Daviesetal26] Davies, P. A., Flack, D. L. A., Pirret, J., Fowler, H. J.
-       (2026) "Application of the Davies Four-Stage Conceptual Model for
-       Life-Threatening Rainfall Extremes on the April 2024 United Arab Emirates
-       and Oman Floods." Weather and Climate Extremes, vol. 51, 100846.
-       doi:10.1016/j.wace.2025.100846
-    .. [Stull2000] Stull, R.B., (2000) "Meteorology for Scientists and Engineers",
-       2nd Edition, Brooks/Cole, California, USA, 502 pp.
     """
     precipitable_water = iris.cube.CubeList([])
     for w in iter_maybe(mixing_ratio):
@@ -586,12 +571,6 @@ def saturation_precipitable_water(
     Examples
     --------
     >>> sat_pwat = humidity.saturated_precipitable_water(mixing_ratio, RH)
-
-    References
-    ----------
-    .. [Raymondetal2009] Raymond, D.J., Sessions, S.L., Sobel, A.H.,  Fuchs, Z.
-       (2009) "The Mechanics of Gross Moist Stability" Journal of Advances in
-       Modelling Earth Systems, vol. 1, 20 pp. doi: 10.3894/JAMES.2009.1.9
     """
     saturation_precipitable_water = iris.cube.CubeList([])
     for w, rh in zip(
@@ -656,7 +635,7 @@ def saturation_fraction(
     is. A value close to one implies that the atmosphere is fully saturated
     throughout the entire column. Smaller values imply the atmosphere is
     drier throughout the column. It is based around ideas of specific entropy
-    ([Zengetal05]_) but can be simplified to an approximation following [Daviesetal2026]_.
+    ([Zengetal05]_) but can be simplified to an approximation following [Daviesetal26]_.
 
     It can be approximated following [Raymondetal09]_ as
 
@@ -664,7 +643,7 @@ def saturation_fraction(
 
     and can be used throughout the globe with the same interpretation.
 
-    For a recent example, [Daviesetal2026]_ have applied the concept to their
+    For a recent example, [Daviesetal26]_ have applied the concept to their
     conceptual model for extreme rainfall. Thus it is a potentially useful diagnostic
     to consider for extreme events, and is thought of as more reliable than
     using precipitable water on its own.
@@ -677,20 +656,6 @@ def saturation_fraction(
     Examples
     --------
     >>> sf = humidity.saturation_fraction(mixing_ratio, relative_humidity)
-
-    References
-    ----------
-    .. [Daviesetal2026] Davies, P. A., Flack, D. L. A., Pirret, J., Fowler, H. J.
-       (2026) "Application of the Davies Four-Stage Conceptual Model for
-       Life-Threatening Rainfall Extremes on the April 2024 United Arab Emirates
-       and Oman Floods." Weather and Climate Extremes, vol. 51, 100846.
-       doi:10.1016/j.wace.2025.100846
-    .. [Raymondetal09] Raymond, D.J., Sessions, S.L., Sobel, A.H.,  Fuchs, Z.
-       (2009) "The Mechanics of Gross Moist Stability" Journal of Advances in
-       Modelling Earth Systems, vol. 1, 20 pp. doi: 10.3894/JAMES.2009.1.9
-    .. [Zengetal05] Zeng, X., Tao, W-K, and Simpson, J. (2005) "An Equation for Moist
-       Entropy in a Precipitating and Icy Atmosphere" Journal of the Atmospheric Sciences,
-       vol. 2, 4293-4309, doi: 10.1175/JAS3570.1
     """
     saturation_fraction = iris.cube.CubeList([])
     for w, rh in zip(

--- a/src/CSET/operators/imageprocessing.py
+++ b/src/CSET/operators/imageprocessing.py
@@ -180,13 +180,6 @@ def spatial_structural_similarity_model_comparisons(
     Further details, including caveats, can be found in Wang et al. (2004)
     [Wangetal2004]_.
 
-    References
-    ----------
-    .. [Wangetal2004] Wang, Z., Bovik, A.C., Sheikh, H.R., Simoncelli, E.P. (2004)
-       "Image Quality Assessment: From Error Visibility to Structural Similarity."
-       IEEE Transactions on Image Processing, vol. 13, 600-612,
-       doi: 10.1109/TIP.2003.819861
-
     Examples
     --------
     >>> SSIM = imageprocessing.spatial_structural_similarity_model_comparisons(
@@ -280,13 +273,6 @@ def mean_structural_similarity_model_comparisons(
 
     Further details, including caveats, can be found in Wang et al. (2004)
     [Wangetal2004a]_.
-
-    References
-    ----------
-    .. [Wangetal2004a] Wang, Z., Bovik, A.C., Sheikh, H.R., Simoncelli, E.P. (2004)
-       "Image Quality Assessment: From Error Visibility to Structural Similarity."
-       IEEE Transactions on Image Processing, vol. 13, 600-612,
-       doi: 10.1109/TIP.2003.819861
 
     Examples
     --------

--- a/src/CSET/operators/mesoscale.py
+++ b/src/CSET/operators/mesoscale.py
@@ -77,13 +77,6 @@ def spatial_perturbation_field(
     Caution should be applied to boundaries, particularly if the domain is of
     variable resolution, as some numerical artifacts could be introduced.
 
-    References
-    ----------
-    .. [Flacketal2016] Flack, D.L.A., Plant, R.S., Gray, S.L., Lean, H.W.,
-       Keil, C. and Craig, G.C. (2016) "Characterisation of Convective
-       Regimes over the British Isles." Quarterly Journal of the Royal
-       Meteorological Society, vol. 142, 1541-1553. doi:10.1002/qj.2758
-
     Examples
     --------
     >>> Temperature_perturbation = meso.spatial_perturbation_fields(Temp,

--- a/src/CSET/operators/plot.py
+++ b/src/CSET/operators/plot.py
@@ -2621,10 +2621,6 @@ def qq_plot(
     closer values/values further apart at the tails imply poor representation of
     the extremes.
 
-    References
-    ----------
-    .. [Wilks2011] Wilks, D.S., (2011) "Statistical Methods in the Atmospheric
-       Sciences" Third Edition, vol. 100, Academic Press, Oxford, UK, 676 pp.
     """
     # Check cubes using same functionality as the difference operator.
     if len(cubes) != 2:

--- a/src/CSET/operators/power_spectrum.py
+++ b/src/CSET/operators/power_spectrum.py
@@ -43,6 +43,10 @@ def calculate_power_spectrum(cubes: iris.cube.Cube | iris.cube.CubeList):
     each cube and calculates an individual power spectrum. In case of a
     single cube (one model) it directly calculates the power spectrum.
 
+    Method for regional domains:
+    Calculate power spectra over limited area domain using Discrete Cosine Transform (DCT)
+    as described in Denis et al 2002 [Denis_etal_2002]_.
+
     Parameters
     ----------
     cubes: Cube | CubeList
@@ -241,18 +245,6 @@ def _DCT_ps(y_3d):
     -------
     ps_array:
         Array of power spectra values calculated for input field (for each time)
-
-    Method for regional domains:
-    Calculate power spectra over limited area domain using Discrete Cosine Transform (DCT)
-    as described in Denis et al 2002 [Denis_etal_2002]_.
-
-    References
-    ----------
-    .. [Denis_etal_2002] Bertrand Denis, Jean Côté and René Laprise (2002)
-        "Spectral Decomposition of Two-Dimensional Atmospheric Fields on
-        Limited-Area Domains Using the Discrete Cosine Transform (DCT)"
-        Monthly Weather Review, Vol. 130, 1812-1828
-        doi: https://doi.org/10.1175/1520-0493(2002)130<1812:SDOTDA>2.0.CO;2
     """
     Nt, Ny, Nx = y_3d.shape
 

--- a/src/CSET/operators/precipitation.py
+++ b/src/CSET/operators/precipitation.py
@@ -82,19 +82,6 @@ def MAUL_properties(
     The MAUL diagnostic is applicable anywhere in the globe and across all scales.
     The properties used here are based upon [Daviesetal24]_ and [Daviesetal26]_.
 
-    References
-    ----------
-    .. [Daviesetal24] Davies, P.A., Fowler, H.J, Villalobos-Herrera, R.,
-       Slingo, J., Flack, D.L.A., and Taszarek, M (2024)
-       "A New Conceptual Model for Understanding and Predicting Life-Threatening
-       Rainfall Extremes." Weather and Climate Extremes, vol. 45, 100696,
-       doi: 10.1016/j.wace.2024.100696
-    .. [Daviesetal26] Davies, P. A., Flack, D. L. A., Pirret, J., Fowler, H. J.
-       (2026) "Application of the Davies Four-Stage Conceptual Model for
-       Life-Threatening Rainfall Extremes on the April 2024 United Arab Emirates
-       and Oman Floods." Weather and Climate Extremes, vol. 51, 100846.
-       doi:10.1016/j.wace.2025.100846
-
     Examples
     --------
     >>> No_MAULs = precipitation.MAUL_properties(maul_mask, u, v, output="number")

--- a/src/CSET/operators/pressure.py
+++ b/src/CSET/operators/pressure.py
@@ -59,11 +59,6 @@ def vapour_pressure(
     will be the saturation vapour pressure. On the other hand, if the dewpoint
     temperature is used the vapour pressure will be calculated.
 
-    References
-    ----------
-    .. [Buck81] Buck, A.L. (1981) "New Equations for Computing Vapor Pressure
-       and Enhancement Factor". J. App. Meteor. Clim. 20: 1527-1532.
-
     Examples
     --------
     >>> vapour_pressure = pressure.vapour_pressure(temperature)
@@ -169,11 +164,6 @@ def exner_pressure(
     A value below one implies the pressure is higher than the reference pressure;
     values above one implies the pressure is lower than the reference pressure; a
     value of one implies the pressure is equal to the reference pressure.
-
-    References
-    ----------
-    .. [Holton13] Holton, J.R. and Hakim G.J. (2013) "An Introduction to Dynamic
-       Meteorology." 5th Edition, Burlington, MA, Elsevier Academic Press, 532 pp.
 
     Examples
     --------

--- a/src/CSET/operators/scoreswrappers.py
+++ b/src/CSET/operators/scoreswrappers.py
@@ -218,21 +218,6 @@ def scores_rmse(cubes: CubeList, preserved_coordinates: list[str] | str | None =
     -------
     scores_cube: iris.cube.Cube
         A cube containing the RMSE between the base and other cube.
-
-    References
-    ----------
-    .. [scoresa] Leeuwenburg, T., Loveday, N., Ebert, E. E., Cook, H.,
-        Khanarmuei, M., Taggart, R. J., Ramanathan, N., Carroll, M., Chong, S.,
-        Griffiths, A., & Sharples, J. (2024) "scores: A Python package for
-        verifying and evaluating models and predictions with xarray". Journal
-        of Open Source Software, vol. 9, 6889. doi: 10.21105/joss.06889
-
-    .. [scoresb] Leeuwenburg, T., Loveday, N., Ramanathan, N., Chong, S.,
-        Taggart, R. J., Shrestha, D., Khanarmuei, M., Cook, H., Bluett, L., Ebert,
-        E. E., Carroll, M., Trotta, B., Bishop, S., Squire, D. T., Griffiths, A.,
-        Pagano, T. C., Fisher, A. J., Mandelbaum, T., Jinghan, F., … Smallwood, J.
-        (2026) "scores: Metrics for the verification, evaluation and optimisation of
-        forecasts, predictions or models (2.5.0)". Zenodo. doi: 10.5281/zenodo.18638494
     """
     base, other = _sort_cubes_for_verification(cubes)
 
@@ -306,21 +291,6 @@ def scores_mae(cubes: CubeList, preserved_coordinates: list[str] | str | None = 
     -------
     scores_cube: iris.cube.Cube
         A cube containing the MAE between the base and other cube.
-
-    References
-    ----------
-    .. [scoresa] Leeuwenburg, T., Loveday, N., Ebert, E. E., Cook, H.,
-        Khanarmuei, M., Taggart, R. J., Ramanathan, N., Carroll, M., Chong, S.,
-        Griffiths, A., & Sharples, J. (2024) "scores: A Python package for
-        verifying and evaluating models and predictions with xarray". Journal
-        of Open Source Software, vol. 9, 6889. doi: 10.21105/joss.06889
-
-    .. [scoresb] Leeuwenburg, T., Loveday, N., Ramanathan, N., Chong, S.,
-        Taggart, R. J., Shrestha, D., Khanarmuei, M., Cook, H., Bluett, L., Ebert,
-        E. E., Carroll, M., Trotta, B., Bishop, S., Squire, D. T., Griffiths, A.,
-        Pagano, T. C., Fisher, A. J., Mandelbaum, T., Jinghan, F., … Smallwood, J.
-        (2026) "scores: Metrics for the verification, evaluation and optimisation of
-        forecasts, predictions or models (2.5.0)". Zenodo. doi: 10.5281/zenodo.18638494
     """
     base, other = _sort_cubes_for_verification(cubes)
 
@@ -394,21 +364,6 @@ def scores_additive_bias(
     -------
     scores_cube: iris.cube.Cube
         A cube containing the ME between the base and other cube.
-
-    References
-    ----------
-    .. [scoresa] Leeuwenburg, T., Loveday, N., Ebert, E. E., Cook, H.,
-        Khanarmuei, M., Taggart, R. J., Ramanathan, N., Carroll, M., Chong, S.,
-        Griffiths, A., & Sharples, J. (2024) "scores: A Python package for
-        verifying and evaluating models and predictions with xarray". Journal
-        of Open Source Software, vol. 9, 6889. doi: 10.21105/joss.06889
-
-    .. [scoresb] Leeuwenburg, T., Loveday, N., Ramanathan, N., Chong, S.,
-        Taggart, R. J., Shrestha, D., Khanarmuei, M., Cook, H., Bluett, L., Ebert,
-        E. E., Carroll, M., Trotta, B., Bishop, S., Squire, D. T., Griffiths, A.,
-        Pagano, T. C., Fisher, A. J., Mandelbaum, T., Jinghan, F., … Smallwood, J.
-        (2026) "scores: Metrics for the verification, evaluation and optimisation of
-        forecasts, predictions or models (2.5.0)". Zenodo. doi: 10.5281/zenodo.18638494
     """
     base, other = _sort_cubes_for_verification(cubes)
 
@@ -481,21 +436,6 @@ def scores_correlation_pearsonr(
     -------
     scores_cube: iris.cube.Cube
         A cube containing the PC between the base and other cube.
-
-    References
-    ----------
-    .. [scoresa] Leeuwenburg, T., Loveday, N., Ebert, E. E., Cook, H.,
-        Khanarmuei, M., Taggart, R. J., Ramanathan, N., Carroll, M., Chong, S.,
-        Griffiths, A., & Sharples, J. (2024) "scores: A Python package for
-        verifying and evaluating models and predictions with xarray". Journal
-        of Open Source Software, vol. 9, 6889. doi: 10.21105/joss.06889
-
-    .. [scoresb] Leeuwenburg, T., Loveday, N., Ramanathan, N., Chong, S.,
-        Taggart, R. J., Shrestha, D., Khanarmuei, M., Cook, H., Bluett, L., Ebert,
-        E. E., Carroll, M., Trotta, B., Bishop, S., Squire, D. T., Griffiths, A.,
-        Pagano, T. C., Fisher, A. J., Mandelbaum, T., Jinghan, F., … Smallwood, J.
-        (2026) "scores: Metrics for the verification, evaluation and optimisation of
-        forecasts, predictions or models (2.5.0)". Zenodo. doi: 10.5281/zenodo.18638494
     """
     base, other = _sort_cubes_for_verification(cubes)
 
@@ -551,7 +491,7 @@ def scores_crps_for_ensemble(
 ) -> iris.Constraint:
     r"""Calculate the CRPS for an ensemble.
 
-    Acts as a wrapper around the crps_for_ensemble from ``scores`` ([scores_a]_, [scores_b]_).
+    Acts as a wrapper around the crps_for_ensemble from ``scores`` ([scoresa]_, [scoresb]_).
 
     Lower CRPS values are better (implies experiment distribution is closer to control distribution/observations),
     larger values are worse (implies distributions are dissimilar).
@@ -559,7 +499,7 @@ def scores_crps_for_ensemble(
     Default method is ecdf.  ecdf is exact value from the empirical distributions,
     whereas fair produces an approximated value based on a random sample of the underlying distribution.
 
-    See [CRPS] for further information.
+    See [CRPS]_ for further information.
 
     Parameters
     ----------
@@ -570,26 +510,6 @@ def scores_crps_for_ensemble(
     -------
     crps: iris.cube.Cube
         A cube containing the crps between the ensemble members and the control
-
-    References
-    ----------
-    .. [scores_a] Leeuwenburg, T., Loveday, N., Ebert, E. E., Cook, H.,
-        Khanarmuei, M., Taggart, R. J., Ramanathan, N., Carroll, M., Chong, S.,
-        Griffiths, A., & Sharples, J. (2024) "scores: A Python package for
-        verifying and evaluating models and predictions with xarray". Journal
-        of Open Source Software, vol. 9, 6889. doi: 10.21105/joss.06889
-
-    .. [scores_b] Leeuwenburg, T., Loveday, N., Ramanathan, N., Chong, S.,
-        Taggart, R. J., Shrestha, D., Khanarmuei, M., Cook, H., Bluett, L., Ebert,
-        E. E., Carroll, M., Trotta, B., Bishop, S., Squire, D. T., Griffiths, A.,
-        Pagano, T. C., Fisher, A. J., Mandelbaum, T., Jinghan, F., … Smallwood, J.
-        (2026) "scores: Metrics for the verification, evaluation and optimisation of
-        forecasts, predictions or models (2.5.0)". Zenodo. doi: 10.5281/zenodo.18638494
-
-    .. [CRPS]
-        Hersbach, H., 2000: Decomposition of the Continuous Ranked
-        Probability Score for Ensemble Prediction Systems. Wea.
-        Forecasting, 15, 559–570, https://doi.org/10.1175/1520-0434(2000)015<0559:DOTCRP>2.0.CO;2.
     """
     if control_member != 0:
         logger.warning("control member is usual 0")

--- a/src/CSET/operators/temperature.py
+++ b/src/CSET/operators/temperature.py
@@ -68,15 +68,6 @@ def dewpoint_temperature(
 
     All cubes must be on the same grid.
 
-    References
-    ----------
-    .. [Bolton80] Bolton. D. (1980) "The computation of equivalent potential
-       temperature". Monthly Weather Review, vol. 108, 1046-1053,
-       doi: 10.1175/1520-0493(1980)108<1046:TCOEPT>2.0.CO;2
-    .. [Flack24] Flack, D.L.A. (2024) "Stratification of the vertical spread-skill
-       relation by radiosonde drift in a convective-scale ensemble."
-       Atmospheric Science Letters, vol. 25, e1194, doi: 10.1002/asl.1194
-
     Examples
     --------
     >>> Td = temperature.dewpoint_temperature(T, RH)
@@ -186,12 +177,6 @@ def wet_bulb_temperature(
     operator.
 
     All cubes should be on the same grid.
-
-    References
-    ----------
-    .. [Stull11] Stull, R. (2011) "Wet-Bulb Temperature from Relative Humidity
-       and air temperature." Journal of Applied Meteorology and Climatology, vol. 50,
-       2267-2269, doi: 10.1175/JAMC-D-11-0143.1
 
     Examples
     --------
@@ -380,14 +365,6 @@ def equivalent_potential_temperature(
 
     All cubes must be on the same grid.
 
-    References
-    ----------
-    .. [Emanuel94] Emanuel, K.A. (1994) "Atmospheric Convection" Oxford University
-       Press, 580 pp.
-    .. [Paluch79] Paluch, I.R., (1979) "The entrainment mechanism in Colorado
-       Cumuli" Journal of the Atmospheric Sciences, vol. 36, 2467-2478,
-       doi: 10.1175/1520-0469(1979)036<2467:TEMICC>2.0.CO;2
-
     Examples
     --------
     >>> Theta_e = temperature.equivalent_potential_temperature(T, RH, P)
@@ -459,12 +436,6 @@ def wet_bulb_potential_temperature(
     this range.
 
     All cubes must be on the same grid.
-
-    References
-    ----------
-    .. [DaviesJones08] Davies-Jones, R. (2008) "An Efficient and Accurate
-       Method for Computing the Wet-Bulb Temperature along Pseudoadiabats"
-       Monthly Weather Review, vol. 136, 2764-2785, doi: 10.1175/2007MWR2224.1
 
     Examples
     --------

--- a/src/CSET/operators/wind.py
+++ b/src/CSET/operators/wind.py
@@ -230,13 +230,6 @@ def convert_to_beaufort_scale(
     can reach above 12 in this diagnostic. However, these are not referred to
     in the table as anything above F12 is labelled as Hurricane force.
 
-    References
-    ----------
-    .. [Beer96] Beer, T. (1996) Environmental Oceanography, CRC Marince Science,
-       Vol. 11, 2nd Edition, CRC Press, 402 pp.
-    .. [Berryetal45] Berry, F. A., Jr., E. Bollay, and N. R. Beers, (1945) Handbook
-       of Meteorology. McGraw Hill, 1068 pp.
-
     Examples
     --------
     >>> Beaufort_Scale=wind.convert_to_Beaufort_scale(winds)


### PR DESCRIPTION
This avoids issues when the same reference is used in multiple operators, as the reference will not be defined multiple times.

Developed with GitHub Copilot Agent mode.

Fixes #2335.

This makes the full weekly check pass: https://github.com/MetOffice/CSET/actions/runs/30378240287

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [x] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [x] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
