### PR TITLE
Update GitHub docs links to avoid unneeded redirects

### DIFF
--- a/docs/source/contributing/dependencies.rst
+++ b/docs/source/contributing/dependencies.rst
@@ -97,6 +97,6 @@ it, and soon after your updated package will be published on conda-forge.
 .. _github.com/conda-forge/cset-feedstock: https://github.com/conda-forge/cset-feedstock
 .. _recipe/recipe.yaml: https://github.com/conda-forge/cset-feedstock/blob/main/recipe/recipe.yaml
 .. _Lines 27 to 37 in commit 805148a: https://github.com/conda-forge/cset-feedstock/blob/805148a2191e1256667fb74f8e5b051f6339af56/recipe/recipe.yaml#L27-L37
-.. _fork of the repository: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo
+.. _fork of the repository: https://docs.github.com/en/pull-requests/how-tos/work-with-forks/fork-a-repo
 .. _build number: https://github.com/conda-forge/cset-feedstock/blob/805148a2191e1256667fb74f8e5b051f6339af56/recipe/recipe.yaml#L14
 .. _feedstock maintainer: https://github.com/conda-forge/cset-feedstock?tab=readme-ov-file#feedstock-maintainers

--- a/docs/source/contributing/getting-started.rst
+++ b/docs/source/contributing/getting-started.rst
@@ -21,7 +21,7 @@ PR title.
 
 .. _issue tracker on GitHub: https://github.com/MetOffice/CSET/issues
 .. _working practices: https://metoffice.github.io/CSET/contributing/
-.. _draft pull request functionality of GitHub: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests
+.. _draft pull request functionality of GitHub: https://docs.github.com/en/pull-requests/reference/pull-requests#draft-pull-requests
 
 Before you get to coding, there are a few steps you need to do to setup the
 development environment.

--- a/docs/source/contributing/git.rst
+++ b/docs/source/contributing/git.rst
@@ -16,7 +16,7 @@ started with git on the command line, you may find this `git cheat sheet`_
 helpful.
 
 .. _Met Office git and GitHub tutorial: https://metoffice.github.io/git-novice/
-.. _GitHub flow: https://docs.github.com/en/get-started/quickstart/github-flow
+.. _GitHub flow: https://docs.github.com/en/get-started/using-github/github-flow
 .. _good commit messages: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
 .. _git cheat sheet: https://education.github.com/git-cheat-sheet-education.pdf
 
@@ -86,7 +86,7 @@ To avoid having to use a username and password you can switch to SSH:
 
     git remote set-url origin git@github.com:MetOffice/CSET.git
 
-.. _Git Credential Manager: https://github.com/git-ecosystem/git-credential-manager/blob/main/README.md
+.. _Git Credential Manager: https://github.com/git-ecosystem/git-credential-manager
 .. _GitHub CLI to authenticate: https://cli.github.com/manual/gh_auth_login
 .. _configure git to use it: https://cli.github.com/manual/gh_auth_setup-git
 .. _GitHub's documentation on SSH: https://docs.github.com/en/authentication/connecting-to-github-with-ssh


### PR DESCRIPTION
GitHub has moved these bits of documentation, so this directly points to the new functionality. The Git Credential manager link is moved to the landing page of the repository to be more standard.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [x] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
