### PR TITLE
Fix bug in plot_line_series to allow plotting of spectra for multiple models

### DIFF
--- a/src/CSET/operators/plot.py
+++ b/src/CSET/operators/plot.py
@@ -2197,7 +2197,6 @@ def plot_line_series(
         If the cube isn't a Cube or CubeList.
     """
     # Ensure we have a name for the plot file.
-
     recipe_title = get_recipe_metadata().get("title", iter_maybe(cube)[0].name())
 
     num_models = get_num_models(cube)

--- a/src/CSET/operators/plot.py
+++ b/src/CSET/operators/plot.py
@@ -2197,6 +2197,7 @@ def plot_line_series(
         If the cube isn't a Cube or CubeList.
     """
     # Ensure we have a name for the plot file.
+
     recipe_title = get_recipe_metadata().get("title", iter_maybe(cube)[0].name())
 
     num_models = get_num_models(cube)
@@ -2258,6 +2259,7 @@ def plot_line_series(
                     # Plot postage stamps
                     plotting_func = _plot_and_save_postage_stamp_power_spectrum_series
             cube_iterables = cubes[0].slices_over(sequence_coordinate)
+            nplot = np.size(cubes[0].coord(sequence_coordinate).points)
         else:
             all_points = sorted(
                 set(
@@ -2282,8 +2284,7 @@ def plot_line_series(
                 )
                 for point in all_points
             ]
-
-        nplot = np.size(cube.coord(sequence_coordinate).points)
+            nplot = len(all_points)
 
         # Create a plot for each value of the sequence coordinate. Allowing for
         # multiple cubes in a CubeList to be plotted in the same plot for similar


### PR DESCRIPTION
Fixes Issue #2348 

The plotting of spectra failed with multiple models when calculating the number of plots to plot.

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
