### PR TITLE
Save and close figure via function call and protect for sphinx-documentation

### DIFF
--- a/src/CSET/operators/plot.py
+++ b/src/CSET/operators/plot.py
@@ -132,11 +132,7 @@ def _make_plot_html_page(plots: list):
         fp.write(html)
 
 
-def _save_close_figure(
-    figure,
-    plot_type: str,
-    filename: str,
-):
+def _save_close_figure(figure, plot_type: str, filename: str):
     """Save generated plot figure file and close figure.
 
     If running documentation gallery generation, avoid saving to file.

--- a/src/CSET/operators/plot.py
+++ b/src/CSET/operators/plot.py
@@ -21,6 +21,7 @@ import json
 import logging
 import math
 import os
+import sys
 from typing import Literal
 
 import cartopy.crs as ccrs
@@ -76,6 +77,11 @@ mpl.use("agg")
 ############################
 
 
+def in_sphinx_gallery():
+    """Test if running plot code in sphinx-gallery context."""
+    return "sphinx_gallery" in sys.modules
+
+
 def _append_to_plot_index(plot_index: list) -> list:
     """Add plots into the plot index, returning the complete plot index."""
     with open("meta.json", "r+t", encoding="UTF-8") as fp:
@@ -124,6 +130,30 @@ def _make_plot_html_page(plots: list):
     # Save completed HTML.
     with open("index.html", "wt", encoding="UTF-8") as fp:
         fp.write(html)
+
+
+def _save_close_figure(
+    figure,
+    plot_type: str,
+    filename: str,
+):
+    """Save generated plot figure file and close figure.
+
+    If running documentation gallery generation, avoid saving to file.
+
+    Parameters
+    ----------
+    figure:
+        Matplotlib Figure object holding all plot elements.
+    plot_type: str
+        String identifier for plot type for logging information.
+    filename: str
+        Filename for saved figure.
+    """
+    if not in_sphinx_gallery():
+        figure.savefig(filename, bbox_inches="tight", dpi=_get_plot_resolution())
+        logger.info("Saved %s plot to %s", plot_type, filename)
+        plt.close(figure)
 
 
 def _setup_spatial_map(
@@ -780,9 +810,7 @@ def _plot_and_save_spatial_plot(
         logger.debug("Set colorbar ticks and labels.")
 
     # Save plot.
-    fig.savefig(filename, bbox_inches="tight", dpi=_get_plot_resolution())
-    logger.info("Saved spatial plot to %s", filename)
-    plt.close(fig)
+    _save_close_figure(fig, "spatial", filename)
 
 
 def _plot_and_save_postage_stamp_spatial_plot(
@@ -906,9 +934,8 @@ def _plot_and_save_postage_stamp_spatial_plot(
     # Overall figure title.
     fig.suptitle(title, fontsize=16)
 
-    fig.savefig(filename, bbox_inches="tight", dpi=_get_plot_resolution())
-    logger.info("Saved contour postage stamp plot to %s", filename)
-    plt.close(fig)
+    # Save plot.
+    _save_close_figure(fig, "contour postate stamp", filename)
 
 
 def _plot_and_save_line_series(
@@ -1025,9 +1052,7 @@ def _plot_and_save_line_series(
     ax.legend(handles=handles, loc="best", ncol=1, frameon=True, fontsize=16)
 
     # Save plot.
-    fig.savefig(filename, bbox_inches="tight", dpi=_get_plot_resolution())
-    logger.info("Saved line plot to %s", filename)
-    plt.close(fig)
+    _save_close_figure(fig, "line", filename)
 
 
 def _plot_and_save_line_power_spectrum_series(
@@ -1150,9 +1175,7 @@ def _plot_and_save_line_power_spectrum_series(
     ax.legend(handles=handles, loc="best", ncol=1, frameon=True, fontsize=16)
 
     # Save plot.
-    fig.savefig(filename, bbox_inches="tight", dpi=_get_plot_resolution())
-    logger.info("Saved line plot to %s", filename)
-    plt.close(fig)
+    _save_close_figure(fig, "line power spectrum", filename)
 
 
 def _plot_and_save_vertical_line_series(
@@ -1292,9 +1315,7 @@ def _plot_and_save_vertical_line_series(
     ax.legend(handles=handles, loc="best", ncol=1, frameon=True, fontsize=16)
 
     # Save plot.
-    fig.savefig(filename, bbox_inches="tight", dpi=_get_plot_resolution())
-    logger.info("Saved line plot to %s", filename)
-    plt.close(fig)
+    _save_close_figure(fig, "vertical line", filename)
 
 
 def _plot_and_save_scatter_plot(
@@ -1366,9 +1387,7 @@ def _plot_and_save_scatter_plot(
     ax.autoscale()
 
     # Save plot.
-    fig.savefig(filename, bbox_inches="tight", dpi=_get_plot_resolution())
-    logger.info("Saved scatter plot to %s", filename)
-    plt.close(fig)
+    _save_close_figure(fig, "scatter", filename)
 
 
 def _plot_and_save_vector_plot(
@@ -1479,9 +1498,7 @@ def _plot_and_save_vector_plot(
     iplt.quiver(cube_u[::step, ::step], cube_v[::step, ::step], pivot="middle")
 
     # Save plot.
-    fig.savefig(filename, bbox_inches="tight", dpi=_get_plot_resolution())
-    logger.info("Saved vector plot to %s", filename)
-    plt.close(fig)
+    _save_close_figure(fig, "vector", filename)
 
 
 def _plot_and_save_histogram_series(
@@ -1601,9 +1618,7 @@ def _plot_and_save_histogram_series(
         ax.legend(loc="best", ncol=1, frameon=True, fontsize=16)
 
     # Save plot.
-    fig.savefig(filename, bbox_inches="tight", dpi=_get_plot_resolution())
-    logger.info("Saved histogram plot to %s", filename)
-    plt.close(fig)
+    _save_close_figure(fig, "histogram", filename)
 
 
 def _plot_and_save_postage_stamp_histogram_series(
@@ -1661,9 +1676,8 @@ def _plot_and_save_postage_stamp_histogram_series(
     # Overall figure title.
     fig.suptitle(title, fontsize=16)
 
-    fig.savefig(filename, bbox_inches="tight", dpi=_get_plot_resolution())
-    logger.info("Saved histogram postage stamp plot to %s", filename)
-    plt.close(fig)
+    # Save plot.
+    _save_close_figure(fig, "histogram postage stamp", filename)
 
 
 def _plot_and_save_postage_stamps_in_single_plot_histogram_series(
@@ -1696,12 +1710,8 @@ def _plot_and_save_postage_stamps_in_single_plot_histogram_series(
     # Add a legend
     ax.legend(fontsize=16)
 
-    # Save the figure to a file
-    plt.savefig(filename, bbox_inches="tight", dpi=_get_plot_resolution())
-    logger.info("Saved histogram postage stamp plot to %s", filename)
-
-    # Close the figure
-    plt.close(fig)
+    # Save plot.
+    _save_close_figure(fig, "histogram postage stamp", filename)
 
 
 def _plot_and_save_scatter_series(
@@ -1840,9 +1850,7 @@ def _plot_and_save_scatter_series(
         cb.set_label("Number of data points", size=12)
 
     # Save plot.
-    fig.savefig(filename, bbox_inches="tight", dpi=_get_plot_resolution())
-    logger.info("Saved scatter plot to %s", filename)
-    plt.close(fig)
+    _save_close_figure(fig, "scatter", filename)
 
 
 def _spatial_plot(
@@ -3404,9 +3412,8 @@ def _plot_and_save_postage_stamp_power_spectrum_series(
         ax = plt.gca()
         ax.set_title(f"Member #{member.coord(stamp_coordinate).points[0]}")
 
-    fig.savefig(filename, bbox_inches="tight", dpi=_get_plot_resolution())
-    logger.info("Saved histogram postage stamp plot to %s", filename)
-    plt.close(fig)
+    # Save plot.
+    _save_close_figure(fig, "histogram postage stamp", filename)
 
 
 def _plot_and_save_postage_stamps_in_single_plot_power_spectrum_series(
@@ -3534,8 +3541,5 @@ def _plot_and_save_postage_stamps_in_single_plot_power_spectrum_series(
     # Figure title.
     ax.set_title(title, fontsize=16)
 
-    # Save the figure to a file
-    plt.savefig(filename, bbox_inches="tight", dpi=_get_plot_resolution())
-
-    # Close the figure
-    plt.close(fig)
+    # Save plot.
+    _save_close_figure(fig, "power spectra postage stamp", filename)

--- a/tests/operators/test_plot.py
+++ b/tests/operators/test_plot.py
@@ -1125,6 +1125,7 @@ def test_save_close_figure(tmp_working_dir, caplog):
             if message == "Saved my test plot to test_filename.png":
                 message_match = True
         assert message_match
+    assert (tmp_working_dir / "test_filename.png").is_file()
 
 
 def test_get_plot_resolution(tmp_working_dir):

--- a/tests/operators/test_plot.py
+++ b/tests/operators/test_plot.py
@@ -1115,6 +1115,18 @@ def test_scatter_plot_too_many_y_dimensions(
         plot.scatter_plot(cube_x, cube_y)
 
 
+def test_save_close_figure(tmp_working_dir, caplog):
+    """Test saving and closing figure file."""
+    fig = mpl.pyplot.figure()
+    message_match = False
+    with caplog.at_level(logging.INFO):
+        plot._save_close_figure(fig, "my test", "test_filename.png")
+        for _, _, message in caplog.record_tuples:
+            if message == "Saved my test plot to test_filename.png":
+                message_match = True
+        assert message_match
+
+
 def test_get_plot_resolution(tmp_working_dir):
     """Test getting the plot resolution."""
     with open("meta.json", "wt", encoding="UTF-8") as fp:

--- a/tests/operators/test_plot.py
+++ b/tests/operators/test_plot.py
@@ -1128,6 +1128,15 @@ def test_save_close_figure(tmp_working_dir, caplog):
     assert (tmp_working_dir / "test_filename.png").is_file()
 
 
+def test_save_close_figure_in_gallery(tmp_working_dir, monkeypatch):
+    """Figure is not saved when running under sphinx_gallery."""
+    fig = mpl.pyplot.figure()
+    with monkeypatch.context() as mp:
+        mp.setattr("sys.modules", {"sphinx_gallery": None})
+        plot._save_close_figure(fig, "my test", "test_filename.png")
+    assert not (tmp_working_dir / "test_filename.png").exists()
+
+
 def test_get_plot_resolution(tmp_working_dir):
     """Test getting the plot resolution."""
     with open("meta.json", "wt", encoding="UTF-8") as fp:


### PR DESCRIPTION

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

Fixes #2355 

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [X] Documentation has been updated to reflect change.
- [X] New code has tests, and affected old tests have been updated.
- [X] All tests and CI checks pass.
- [X] Ensured the pull request title is descriptive.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [X] Marked the PR as ready to review.


Supports auto-generation of sphinx-gallery by only saving figure files when not running as part of sphinx gallery.
New test added to directly ensure function works as required.
Note note been able to mimic running with sphinx-gallery active case.