### PR TITLE
Fix bug in the checks within plot_line_series to consider what type of dimension realization is.

### DIFF
--- a/src/CSET/operators/plot.py
+++ b/src/CSET/operators/plot.py
@@ -2226,8 +2226,20 @@ def plot_line_series(
             raise ValueError(
                 f"Cube must have a {series_coordinate} coordinate."
             ) from err
-        if model_cube.coords("realization") and model_cube.ndim > 2:
-            raise ValueError("Cube must be 1D or 2D with a realization coordinate.")
+        # Count dimensions excluding realization
+        ndim = model_cube.ndim
+
+        if model_cube.coords("realization"):
+            realization_dims = model_cube.coord_dims("realization")
+
+            # Only subtract if realization is a dimension coordinate
+            if realization_dims:
+                ndim -= len(realization_dims)
+
+        if ndim > 2:
+            raise ValueError(
+                "Cube must be 1D or 2D (excluding any realization dimension)."
+            )
 
     plot_index = []
 

--- a/tests/operators/test_plot.py
+++ b/tests/operators/test_plot.py
@@ -572,8 +572,6 @@ def test_plot_line_series_extra_dimension_failure(tmp_working_dir):
         3,
     )
 
-    print("CUBE ", cube, cube.ndim)
-
     with pytest.raises(
         ValueError,
         match="Cube must be 1D or 2D",

--- a/tests/operators/test_plot.py
+++ b/tests/operators/test_plot.py
@@ -530,6 +530,57 @@ def test_plot_power_spectrum_no_sequence_coordinate(
         plot.plot_line_series(power_spectrum_cube, series_coordinate="frequency")
 
 
+def test_plot_line_series_extra_dimension_failure(tmp_working_dir):
+    """Error with three non-realization dimensions."""
+    data = np.random.rand(2, 3, 4, 10)
+
+    cube = iris.cube.Cube(
+        data,
+        long_name="power_spectral_density",
+    )
+
+    # Add a realization coord plus 3 other coordinates
+    cube.add_dim_coord(
+        iris.coords.DimCoord(
+            np.arange(2),
+            standard_name="realization",
+        ),
+        0,
+    )
+
+    cube.add_dim_coord(
+        iris.coords.DimCoord(
+            np.arange(3),
+            long_name="forecast_reference_time",
+        ),
+        1,
+    )
+
+    cube.add_dim_coord(
+        iris.coords.DimCoord(
+            np.arange(4),
+            standard_name="time",
+        ),
+        2,
+    )
+
+    cube.add_dim_coord(
+        iris.coords.DimCoord(
+            np.arange(10),
+            long_name="physical_wavenumber",
+        ),
+        3,
+    )
+
+    print("CUBE ", cube, cube.ndim)
+
+    with pytest.raises(
+        ValueError,
+        match="Cube must be 1D or 2D",
+    ):
+        plot.plot_line_series(cube, filename="test_extra_dim", series_coordinate="time")
+
+
 def test_select_series_coord_frequency_fallback(power_spectrum_cube):
     """Select a valid fallback when frequency is missing."""
     freq = power_spectrum_cube.coord("frequency")


### PR DESCRIPTION
There is a "raise ValueError" in plot_line_series that counts the number of dimensions for the cube and fails if n_dim is > 2.  However, the check fails in ensembles, where the number of realizations is larger than 1. This PR alters the code so that it doesn't include realization when counting dimensions so that it will work whatever the number and type of realization coordinate.

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [x] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [x] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
