### PR TITLE
Run scheduled update on the first of the month instead of weekly

### DIFF
--- a/.github/workflows/scheduled-updates.yml
+++ b/.github/workflows/scheduled-updates.yml
@@ -2,7 +2,7 @@ name: "Update conda lock files and pre-commit config"
 
 on:
   schedule:
-    - cron: "37 5 * * 1"
+    - cron: "37 5 1 * *"
   workflow_dispatch:
 
 # Minimise default GITHUB_TOKEN permissions.


### PR DESCRIPTION
This reduces their frequency compared to the weekly cadence we currently follow, reducing the effort required to review them.

Fixes #2422

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
