### PR TITLE
Remove `cset_comparison_base` attribute when loading data

### DIFF
--- a/src/CSET/operators/read.py
+++ b/src/CSET/operators/read.py
@@ -50,7 +50,7 @@ class NoDataError(FileNotFoundError):
 
 def read_cube(
     file_paths: list[str] | str,
-    constraint: iris.Constraint = None,
+    constraint: iris.Constraint | None = None,
     model_names: list[str] | str | None = None,
     subarea_type: str | None = None,
     subarea_extent: list[float] | None = None,

--- a/src/CSET/operators/read.py
+++ b/src/CSET/operators/read.py
@@ -405,6 +405,7 @@ def _cutout_cubes(
 def _loading_callback(cube: iris.cube.Cube, field, filename: str) -> iris.cube.Cube:
     """Compose together the needed callbacks into a single function."""
     # Most callbacks operate in-place, but save the cube when returned!
+    _remove_cset_comparison_base_attribute_callback(cube)
     _realization_callback(cube)
     _um_normalise_callback(cube)
     _lfric_normalise_callback(cube)
@@ -425,6 +426,14 @@ def _loading_callback(cube: iris.cube.Cube, field, filename: str) -> iris.cube.C
     cube = _fix_no_time_coords_callback(cube)
     _normalise_longname(cube)
     return cube
+
+
+def _remove_cset_comparison_base_attribute_callback(cube):
+    """Remove ``cset_comparison_base`` attribute if present.
+
+    This allows for reprocessing output previously saved by CSET.
+    """
+    cube.attributes.pop("cset_comparison_base", None)
 
 
 def _realization_callback(cube):

--- a/tests/operators/test_read.py
+++ b/tests/operators/test_read.py
@@ -856,6 +856,13 @@ def test_lfric_forecast_period_convert_units_callback(cube):
     assert cube.coord("forecast_period").units == "hours"
 
 
+def test_remove_cset_comparison_base_attribute_callback():
+    """Ensure ``cset_comparison_base`` attribute is removed."""
+    cube = iris.cube.Cube(shape=(1,), attributes={"cset_comparison_base": 1})
+    read._remove_cset_comparison_base_attribute_callback(cube)
+    assert "cset_comparison_base" not in cube.attributes
+
+
 def test_read_cubes_extract_cells():
     """Read cube and ensure appropriate number of cells are trimmed from domain edges."""
     cube = read.read_cubes(


### PR DESCRIPTION
This allows for loading data that has previously been saved with CSET.

Fixes #2436

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [x] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
