### PR TITLE
Add fetch obs task time limit and retries

### DIFF
--- a/src/CSET/cset_workflow/flow.cylc
+++ b/src/CSET/cset_workflow/flow.cylc
@@ -154,6 +154,8 @@ final cycle point = {{CSET_TRIAL_END_DATE}}
     [[fetch_obs]]
     # Fetch observations from the MetDB.
     inherit = FETCH_DATA
+    execution time limit = PT3M
+    submission retry delays = PT30S, PT1M, PT2M, PT5M, PT10M
     script = rose task-run -v --app-key=fetch_obs
         [[[environment]]]
         MODEL_IDENTIFIER = "OBS"

--- a/src/CSET/cset_workflow/flow.cylc
+++ b/src/CSET/cset_workflow/flow.cylc
@@ -154,8 +154,8 @@ final cycle point = {{CSET_TRIAL_END_DATE}}
     [[fetch_obs]]
     # Fetch observations from the MetDB.
     inherit = FETCH_DATA
-    execution time limit = PT3M
-    submission retry delays = PT30S, PT1M, PT2M, PT5M, PT10M
+    execution time limit = PT5M
+    submission retry delays = PT10S, PT20M
     script = rose task-run -v --app-key=fetch_obs
         [[[environment]]]
         MODEL_IDENTIFIER = "OBS"


### PR DESCRIPTION
fixes #2441 

small PR to add a time limit and retires to fetch obs task since fetching observations has been a bit patchy. 

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
