### PR TITLE
Prevent copytree from overwriting permissions on the target directory during `cset install-restricted-files`

### DIFF
--- a/src/CSET/extract_workflow.py
+++ b/src/CSET/extract_workflow.py
@@ -219,6 +219,10 @@ def install_restricted_files(workflow_dir: Path, alternative_url: str | None = N
         # Delete unwanted top-level README.
         (Path(tempdir) / "README.md").unlink(missing_ok=True)
 
+        # HACK: This prevents copystat (as used inside copytree) from
+        # overwriting permission of the target directory.
+        _original_copystat = shutil.copystat
+        shutil.copystat = lambda *args, **kwargs: None
         # Copy remaining files, skipping hidden files.
         shutil.copytree(
             tempdir,
@@ -227,4 +231,8 @@ def install_restricted_files(workflow_dir: Path, alternative_url: str | None = N
             symlinks=True,
             dirs_exist_ok=True,
         )
+        # Put copystat back so we don't break other code.
+        # This is by no means threadsafe.
+        shutil.copystat = _original_copystat
+
         print(f"Installed site-specific restricted files into {workflow_dir}.")

--- a/tests/test_extract_workflow.py
+++ b/tests/test_extract_workflow.py
@@ -240,6 +240,8 @@ def test_clone_ref_no_such_ref(tmp_path: Path, restricted_git_repo: str):
 
 def test_install_restricted_files(tmp_path: Path, restricted_git_repo: str):
     """Install restricted files from a Git repository."""
+    # Give some extra permissions to ensure they are not stripped.
+    tmp_path.chmod(0o755)
     # Make into cylc workflow.
     (tmp_path / "flow.cylc").touch()
 
@@ -254,6 +256,8 @@ def test_install_restricted_files(tmp_path: Path, restricted_git_repo: str):
     assert (tmp_path / "restricted_file.txt").exists()
     # Existing files are untouched.
     assert (tmp_path / "flow.cylc").exists()
+    # Existing directory permissions are unchanged.
+    assert stat.filemode(tmp_path.stat().st_mode) == "drwxr-xr-x"
 
 
 def test_install_restricted_files_version_tag(


### PR DESCRIPTION
This is decidedly a hack, but we need the directory merging of `shutil.copytree`. Unfortunately it does not allow us to control this overwriting of permission in any nicer way.

The root cause of the permission difference is that the temporary directory is created with mode 0o700. While we could try and fix that to match the umask, we ideally want to match the permission of the target directory, not just what the umask is set to. Therefore this solution has been chosen in favour of just calling `os.chmod(tempdir, 0o755)`.

Fixes #2461

<!-- Thanks for contributing! Please add a short description of your change, and link to an issue, e.g. "Fixes #123" -->

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [x] New code has tests, and affected old tests have been updated.
- [x] All tests and CI checks pass.
- [x] Ensured the pull request title is descriptive.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [x] Marked the PR as ready to review.
