### PR TITLE
Adjust interpolate to point cube and extract common times and refactor

### DIFF
--- a/src/CSET/operators/_time_utils.py
+++ b/src/CSET/operators/_time_utils.py
@@ -47,37 +47,18 @@ def _extract_common_time_points_multiple_cubes_with_frt(cubes: CubeList) -> Cube
             )
 
     # Start from the first cube's forecast periods.
-    shared_periods = set(cubes[0].coord("forecast_period").points)
+    time_constraint = _make_shared_period_constraint(cubes[0], cubes[1:])
 
-    # Find intersection across all cubes.
-    for cube in cubes[1:]:
-        shared_periods &= set(cube.coord("forecast_period").points)
-
-    if not shared_periods:
-        raise ValueError("No common forecast periods found.")
-
-    logger.debug(
-        "Common forecast periods: %s",
-        sorted(shared_periods),
-    )
-
-    constraint = iris.Constraint(
-        forecast_period=lambda cell, shared_periods=shared_periods: (
-            cell.point in shared_periods
-        )
-    )
-
-    output = CubeList()
-
+    common_time_cubelist = CubeList()
     for cube in cubes:
-        extracted = cube.extract(constraint)
+        extracted = cube.extract(time_constraint)
 
         if extracted is None:
             raise ValueError(f"No common forecast periods remain for {cube.name()}")
 
-        output.append(extracted)
+        common_time_cubelist.append(extracted)
 
-    return output
+    return common_time_cubelist
 
 
 def _extract_common_time_points_multiple_cubes_no_frt(cubes: CubeList) -> CubeList:
@@ -177,10 +158,10 @@ def _extract_common_time_points_with_frt(base: Cube, other: Cube) -> tuple[Cube,
     if not np.array_equal(reference_frts, cube_frts):
         raise ValueError("Cubes do not share the same forecast_reference_time values.")
 
-    constraint = _make_shared_period_constraint(base, other)
+    time_constraint = _make_shared_period_constraint(base, other)
 
-    base = base.extract(constraint)
-    other = other.extract(constraint)
+    base = base.extract(time_constraint)
+    other = other.extract(time_constraint)
 
     return base, other
 
@@ -190,19 +171,38 @@ def _make_shared_period_constraint(base, other) -> iris.Constraint:
     shared_periods = set(base.coord("forecast_period").points)
 
     # Find intersection across all cubes.
+    if isinstance(other, Cube):
+        shared_periods &= set(other.coord("forecast_period").points)
 
-    shared_periods &= set(other.coord("forecast_period").points)
+        if not shared_periods:
+            raise ValueError("No common forecast periods found.")
 
-    if not shared_periods:
-        raise ValueError("No common forecast periods found.")
-
-    logger.debug(
-        "Common forecast periods: %s",
-        sorted(shared_periods),
-    )
-
-    return iris.Constraint(
-        forecast_period=lambda cell, shared_periods=shared_periods: (
-            cell.point in shared_periods
+        logger.debug(
+            "Common forecast periods: %s",
+            sorted(shared_periods),
         )
-    )
+
+        return iris.Constraint(
+            forecast_period=lambda cell, shared_periods=shared_periods: (
+                cell.point in shared_periods
+            )
+        )
+
+    elif isinstance(other, CubeList):
+        # Find intersection across all cubes.
+        for cube in other:
+            shared_periods &= set(cube.coord("forecast_period").points)
+
+        if not shared_periods:
+            raise ValueError("No common forecast periods found.")
+
+        logger.debug(
+            "Common forecast periods: %s",
+            sorted(shared_periods),
+        )
+
+        return iris.Constraint(
+            forecast_period=lambda cell, shared_periods=shared_periods: (
+                cell.point in shared_periods
+            )
+        )

--- a/src/CSET/operators/_time_utils.py
+++ b/src/CSET/operators/_time_utils.py
@@ -1,0 +1,208 @@
+import logging
+
+import iris
+import iris.analysis.calculus
+import numpy as np
+from iris.cube import Cube, CubeList
+
+logger = logging.getLogger(__name__)
+
+
+def _extract_common_time_points_multiple_cubes(
+    cubes: CubeList | Cube,
+) -> CubeList | Cube:
+    """Equalise time points across all cubes."""
+    if isinstance(cubes, Cube) or len(cubes) < 2:
+        return cubes
+    if cubes[0].coords("forecast_reference_time"):
+        return _extract_common_time_points_multiple_cubes_with_frt(cubes)
+    else:
+        return _extract_common_time_points_multiple_cubes_no_frt(cubes)
+
+
+def _extract_common_time_points(base: Cube, other: Cube) -> tuple[Cube, Cube]:
+    """Extract common time points from cubes to allow comparison."""
+    # Get the name of the first non-scalar time coordinate.
+
+    if (
+        base.coords("forecast_reference_time")
+        and np.size(base.coords("forecast_reference_time")) > 1
+    ):
+        return _extract_common_time_points_with_frt(base, other)
+    else:
+        return _extract_common_time_points_no_frt(base, other)
+
+
+def _extract_common_time_points_multiple_cubes_with_frt(cubes: CubeList) -> CubeList:
+
+    # Check all cubes have identical FRTs.
+    reference_frts = cubes[0].coord("forecast_reference_time").points
+
+    for cube in cubes[1:]:
+        cube_frts = cube.coord("forecast_reference_time").points
+
+        if not np.array_equal(reference_frts, cube_frts):
+            raise ValueError(
+                "Cubes do not share the same forecast_reference_time values."
+            )
+
+    # Start from the first cube's forecast periods.
+    shared_periods = set(cubes[0].coord("forecast_period").points)
+
+    # Find intersection across all cubes.
+    for cube in cubes[1:]:
+        shared_periods &= set(cube.coord("forecast_period").points)
+
+    if not shared_periods:
+        raise ValueError("No common forecast periods found.")
+
+    logger.debug(
+        "Common forecast periods: %s",
+        sorted(shared_periods),
+    )
+
+    constraint = iris.Constraint(
+        forecast_period=lambda cell, shared_periods=shared_periods: (
+            cell.point in shared_periods
+        )
+    )
+
+    output = CubeList()
+
+    for cube in cubes:
+        extracted = cube.extract(constraint)
+
+        if extracted is None:
+            raise ValueError(f"No common forecast periods remain for {cube.name()}")
+
+        output.append(extracted)
+
+    return output
+
+
+def _extract_common_time_points_multiple_cubes_no_frt(cubes: CubeList) -> CubeList:
+    base = cubes[0]
+    time_coord = next(
+        (
+            coord.name()
+            for coord in base.coords()
+            if coord.shape > (1,) and coord.name() in ("time", "hour")
+        ),
+        None,
+    )
+    if not time_coord:
+        logger.debug("No time coord, skipping equalisation.")
+        return cubes
+
+    base_time_coord = base.coord(time_coord)
+    shared_times = set(_get_time_points(base_time_coord))
+    logger.debug("Shared times: %s", shared_times)
+
+    for other in cubes[1:]:
+        other_time_coord = other.coord(time_coord)
+        logger.debug("Base: %s\nOther: %s", base_time_coord, other_time_coord)
+        shared_times &= set(_get_time_points(other_time_coord))
+        logger.debug("Shared times: %s", shared_times)
+
+    if not shared_times:
+        raise ValueError("No common time points found!")
+
+    time_constraint = iris.Constraint(
+        coord_values={
+            time_coord: lambda cell, shared_times=shared_times: (
+                cell.point in shared_times
+            )
+        }
+    )
+    return cubes.extract(time_constraint)
+
+
+def _extract_common_time_points_no_frt(base: Cube, other: Cube) -> tuple[Cube, Cube]:
+    time_coord = next(
+        (
+            coord.name()
+            for coord in filter(
+                lambda coord: coord.shape > (1,) and coord.name() in ["time", "hour"],
+                base.coords(),
+            )
+        ),
+        None,
+    )
+    if not time_coord:
+        logger.debug("No time coord, skipping equalisation.")
+        return base, other
+    base_time_coord = base.coord(time_coord)
+    other_time_coord = other.coord(time_coord)
+    logger.debug("Base: %s\nOther: %s", base_time_coord, other_time_coord)
+
+    base_times = _get_time_points(base_time_coord)
+    other_times = _get_time_points(other_time_coord)
+
+    shared_times = set.intersection(set(base_times), set(other_times))
+
+    logger.debug("Shared times: %s", shared_times)
+    time_constraint = iris.Constraint(
+        coord_values={
+            time_coord: lambda cell, shared_times=shared_times: (
+                cell.point in shared_times
+            )
+        }
+    )
+
+    # Extract points matching the shared times.
+    base = base.extract(time_constraint)
+    other = other.extract(time_constraint)
+    if base is None or other is None:
+        raise ValueError("No common time points found!")
+    return base, other
+
+
+def _get_time_points(coord):
+    """Get comparable time points for a coord.
+
+    'Hour' uses raw points since it has non-absolute units; iris auto-converts other time coords to
+    datetimes for comparison, so match that here.
+    """
+    if coord.name() == "hour":
+        return coord.points
+    return coord.units.num2date(coord.points)
+
+
+def _extract_common_time_points_with_frt(base: Cube, other: Cube) -> tuple[Cube, Cube]:
+    """Equalise time points across all cubes."""
+    # Check all cubes have identical FRTs.
+    reference_frts = base.coord("forecast_reference_time").points
+    cube_frts = other.coord("forecast_reference_time").points
+
+    if not np.array_equal(reference_frts, cube_frts):
+        raise ValueError("Cubes do not share the same forecast_reference_time values.")
+
+    constraint = _make_shared_period_constraint(base, other)
+
+    base = base.extract(constraint)
+    other = other.extract(constraint)
+
+    return base, other
+
+
+def _make_shared_period_constraint(base, other) -> iris.Constraint:
+    # Start from the first cube's forecast periods.
+    shared_periods = set(base.coord("forecast_period").points)
+
+    # Find intersection across all cubes.
+
+    shared_periods &= set(other.coord("forecast_period").points)
+
+    if not shared_periods:
+        raise ValueError("No common forecast periods found.")
+
+    logger.debug(
+        "Common forecast periods: %s",
+        sorted(shared_periods),
+    )
+
+    return iris.Constraint(
+        forecast_period=lambda cell, shared_periods=shared_periods: (
+            cell.point in shared_periods
+        )
+    )

--- a/src/CSET/operators/imageprocessing.py
+++ b/src/CSET/operators/imageprocessing.py
@@ -22,8 +22,8 @@ import numpy as np
 from skimage.metrics import structural_similarity
 
 from CSET._common import is_increasing
+from CSET.operators._time_utils import _extract_common_time_points
 from CSET.operators._utils import fully_equalise_attributes, get_cube_yxcoordname
-from CSET.operators.misc import _extract_common_time_points
 from CSET.operators.regrid import regrid_onto_cube
 
 logger = logging.getLogger(__name__)

--- a/src/CSET/operators/misc.py
+++ b/src/CSET/operators/misc.py
@@ -25,6 +25,7 @@ import numpy as np
 from iris.cube import Cube, CubeList
 
 from CSET._common import is_increasing, iter_maybe
+from CSET.operators._time_utils import _extract_common_time_points
 from CSET.operators._utils import fully_equalise_attributes, get_cube_yxcoordname
 from CSET.operators.regrid import regrid_onto_cube
 
@@ -466,54 +467,6 @@ def difference(cubes: CubeList):
 
     difference.data = other.data - base.data
     return difference
-
-
-def _extract_common_time_points(base: Cube, other: Cube) -> tuple[Cube, Cube]:
-    """Extract common time points from cubes to allow comparison."""
-    # Get the name of the first non-scalar time coordinate.
-    time_coord = next(
-        (
-            coord.name()
-            for coord in filter(
-                lambda coord: coord.shape > (1,) and coord.name() in ["time", "hour"],
-                base.coords(),
-            )
-        ),
-        None,
-    )
-    if not time_coord:
-        logger.debug("No time coord, skipping equalisation.")
-        return (base, other)
-    base_time_coord = base.coord(time_coord)
-    other_time_coord = other.coord(time_coord)
-    logger.debug("Base: %s\nOther: %s", base_time_coord, other_time_coord)
-    if time_coord == "hour":
-        # We directly compare points when comparing coordinates with
-        # non-absolute units, such as hour. We can't just check the units are
-        # equal as iris automatically converts to datetime objects in the
-        # comparison for certain coordinate names.
-        base_times = base_time_coord.points
-        other_times = other_time_coord.points
-        shared_times = set.intersection(set(base_times), set(other_times))
-    else:
-        # Units don't match, so converting to datetimes for comparison.
-        base_times = base_time_coord.units.num2date(base_time_coord.points)
-        other_times = other_time_coord.units.num2date(other_time_coord.points)
-        shared_times = set.intersection(set(base_times), set(other_times))
-    logger.debug("Shared times: %s", shared_times)
-    time_constraint = iris.Constraint(
-        coord_values={
-            time_coord: lambda cell, shared_times=shared_times: (
-                cell.point in shared_times
-            )
-        }
-    )
-    # Extract points matching the shared times.
-    base = base.extract(time_constraint)
-    other = other.extract(time_constraint)
-    if base is None or other is None:
-        raise ValueError("No common time points found!")
-    return (base, other)
 
 
 def convert_units(cubes: iris.cube.Cube | iris.cube.CubeList, units: str):

--- a/src/CSET/operators/plot.py
+++ b/src/CSET/operators/plot.py
@@ -50,6 +50,7 @@ from CSET.operators._colormaps import (
     colorbar_map_levels,
     get_model_colors_map,
 )
+from CSET.operators._time_utils import _extract_common_time_points
 from CSET.operators._utils import (
     calc_array_stats,
     check_sequence_coordinate,
@@ -64,7 +65,6 @@ from CSET.operators._utils import (
     validate_cubes_coords,
 )
 from CSET.operators.collapse import collapse
-from CSET.operators.misc import _extract_common_time_points
 from CSET.operators.regrid import regrid_onto_cube
 
 logger = logging.getLogger(__name__)

--- a/src/CSET/operators/regrid.py
+++ b/src/CSET/operators/regrid.py
@@ -24,6 +24,10 @@ import numpy as np
 from iris.analysis.cartography import rotate_pole
 
 from CSET._common import iter_maybe
+from CSET.operators._time_utils import (
+    _extract_common_time_points,
+    _extract_common_time_points_multiple_cubes,
+)
 from CSET.operators._utils import get_cube_yxcoordname
 
 logger = logging.getLogger(__name__)
@@ -407,7 +411,9 @@ def transform_lat_long_points(lon, lat, cube):
 
 
 def interpolate_to_point_cube(
-    fld: iris.cube.Cube | iris.cube.CubeList, point_cube: iris.cube.Cube, **kwargs
+    fld: iris.cube.Cube | iris.cube.CubeList,
+    point_cube: iris.cube.Cube | iris.cube.CubeList,
+    **kwargs,
 ) -> iris.cube.Cube | iris.cube.CubeList:
     """Interpolate a 2D field in cube or CubeList to a set of points.
 
@@ -432,34 +438,17 @@ def interpolate_to_point_cube(
     # Empty CubeList To store regridded cubes.
     regridded_cubes = iris.cube.CubeList()
 
+    # Generate array of point cube lat and lon points.
+    point_lat_name, point_lon_name = get_cube_yxcoordname(point_cube)
+    point_lats = point_cube.coord(point_lat_name).points
+    point_lons = point_cube.coord(point_lon_name).points
+
+    # extract common time points between fld cubes
+    fld = _extract_common_time_points_multiple_cubes(fld)
     # Iterate over all cubes and regrid.
     for cube in iter_maybe(fld):
-        # Ensure matching times in fld cube and point_cube
-        base_time_coord = point_cube.coord("time")
-        other_time_coord = cube.coord("time")
-        base_times = base_time_coord.units.num2date(base_time_coord.points)
-        other_times = other_time_coord.units.num2date(other_time_coord.points)
-        shared_times = set.intersection(set(base_times), set(other_times))
-        logger.debug("Shared times: %s", shared_times)
-        time_constraint = iris.Constraint(
-            coord_values={
-                "time": lambda cell, shared_times=shared_times: (
-                    cell.point in shared_times
-                )
-            }
-        )
-
-        # Extract points matching the shared times.
-        cube = cube.extract(time_constraint)
-        point_cube = point_cube.extract(time_constraint)
-        if cube is None or point_cube is None:
-            raise ValueError("No common time points found!")
-
-        # Generate array of point cube lat and lon points.
-        point_lat_name, point_lon_name = get_cube_yxcoordname(point_cube)
-        point_lats = point_cube.coord(point_lat_name).points
-        point_lons = point_cube.coord(point_lon_name).points
-
+        base, cube = _extract_common_time_points(point_cube, cube)
+        # Get forecast field cube spatial names.
         y_coord, x_coord = get_cube_yxcoordname(cube)
 
         # Rotate point_cube coords if required to match model coord rotation.
@@ -488,52 +477,119 @@ def interpolate_to_point_cube(
             ]
 
         # Interpolate fld cube to required sample points
+
         fld_point_cube = cube.interpolate(
             sample_points, iris.analysis.Linear(extrapolation_mode="mask")
         )
 
-        # Retain only diagonal elements of 2D interpolated cube to vector points
-        od_index = point_cube.coord_dims("station")[0]
+        diag_data = np.diagonal(
+            fld_point_cube.data,
+            axis1=-2,
+            axis2=-1,
+        )
+
         fv_cube = iris.cube.Cube(
-            fld_point_cube.data.diagonal(axis1=od_index, axis2=od_index + 1),
+            diag_data,
             standard_name=cube.standard_name,
             long_name=cube.long_name,
             units=cube.units,
         )
-        # Copy all non-lat/lon coordinates and cube attributes
-        if "time" in [coord.name() for coord in fld_point_cube.coords(dim_coords=True)]:
-            fv_cube.add_dim_coord(
-                point_cube.coord("time"), point_cube.coord_dims("time")[0]
-            )
-        for coord in cube.coords():
-            if coord.name() not in [
-                "time",
+
+        #
+        # Add all non-horizontal dimension coordinates
+        # from the forecast cube.
+        #
+        out_dim = 0
+        for coord in cube.coords(dim_coords=True):
+            if coord.name() in (
                 "latitude",
                 "longitude",
                 "grid_latitude",
                 "grid_longitude",
-            ] and coord.name() not in [coord.name() for coord in fv_cube.coords()]:
-                fv_cube.add_aux_coord(coord.copy(), cube.coord_dims(coord))
+            ):
+                continue
+
+            fv_cube.add_dim_coord(
+                coord.copy(),
+                out_dim,
+            )
+
+            out_dim += 1
+
+        #
+        # Station dimension is always last.
+        #
+        station_dim = out_dim
+
+        fv_cube.add_dim_coord(
+            point_cube.coord("station").copy(),
+            station_dim,
+        )
+
+        #
+        # Copy forecast auxiliary coordinates.
+        #
+        for coord in cube.coords():
+            if coord.name() in (
+                "latitude",
+                "longitude",
+                "grid_latitude",
+                "grid_longitude",
+            ):
+                continue
+
+            if coord.name() in [c.name() for c in fv_cube.coords()]:
+                continue
+
+            dims = cube.coord_dims(coord)
+
+            if dims:
+                fv_cube.add_aux_coord(
+                    coord.copy(),
+                    dims,
+                )
+            else:
+                fv_cube.add_aux_coord(
+                    coord.copy(),
+                )
+
+        #
+        # Copy observation auxiliary coordinates.
+        #
         for coord in point_cube.coords():
-            if coord.name() not in [
-                "time",
+            if coord.name() in (
+                "station",
                 "forecast_period",
                 "forecast_reference_time",
-                "realization",
-                "station",
-            ] and coord.name() not in [coord.name() for coord in fv_cube.coords()]:
-                fv_cube.add_aux_coord(coord.copy(), point_cube.coord_dims(coord))
-        fv_cube.add_dim_coord(point_cube.coord("station"), od_index)
+            ):
+                continue
+
+            if coord.name() in [c.name() for c in fv_cube.coords()]:
+                continue
+
+            dims = point_cube.coord_dims(coord)
+
+            if dims:
+                fv_cube.add_aux_coord(
+                    coord.copy(),
+                    dims,
+                )
+            else:
+                fv_cube.add_aux_coord(
+                    coord.copy(),
+                )
+
         fv_cube.attributes = cube.attributes.copy()
         fv_cube.cell_methods = cube.cell_methods
         fv_cube.units = cube.units
+
         regridded_cubes.append(fv_cube)
 
-    # Preserve returning a cube if only a cube has been supplied to regrid.
+    # Preserve returning a cube if only a cube supplied.
     if len(regridded_cubes) == 1:
         return regridded_cubes[0]
-    else:
-        return regridded_cubes
+
+    return regridded_cubes
 
 
 def vertical_interpolation(

--- a/src/CSET/operators/scoreswrappers.py
+++ b/src/CSET/operators/scoreswrappers.py
@@ -30,12 +30,12 @@ from iris.cube import Cube, CubeList
 from iris.util import reverse
 
 from CSET._common import is_increasing
+from CSET.operators._time_utils import _extract_common_time_points
 from CSET.operators._utils import fully_equalise_attributes, get_cube_yxcoordname
 from CSET.operators.constraints import (
     generate_realization_constraint,
     generate_remove_single_ensemble_member_constraint,
 )
-from CSET.operators.misc import _extract_common_time_points
 from CSET.operators.read import _realization_callback
 from CSET.operators.regrid import regrid_onto_cube
 


### PR DESCRIPTION
fixes #2447 

Added new time utils for handling multiple cubes with multiple forecast reference times.

### Contribution checklist

Aim to have all relevant checks ticked off before merging. See the [developer's guide](https://metoffice.github.io/CSET/contributing/) for more detail.

- [ ] Documentation has been updated to reflect change.
- [ ] New code has tests, and affected old tests have been updated.
- [ ] All tests and CI checks pass.
- [ ] Ensured the pull request title is descriptive.
- [ ] Attributed any Generative AI, such as GitHub Copilot, used in this PR.
- [ ] Marked the PR as ready to review.
